### PR TITLE
DO NOT MERGE: sample TypeScript client

### DIFF
--- a/showcase-v1alpha2/.clang-format
+++ b/showcase-v1alpha2/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     80

--- a/showcase-v1alpha2/README.md
+++ b/showcase-v1alpha2/README.md
@@ -1,0 +1,31 @@
+# Node.js Client for GAPIC Showcase API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-node#versioning))
+
+[GAPIC Showcase API][Product Documentation]:
+GAPIC Showcase API.
+- [Client Library Documentation][]
+- [Product Documentation][]
+
+## Quick Start
+In order to use this library, you first need to go through the following
+steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+3. [Enable the GAPIC Showcase API.](https://console.cloud.google.com/apis/library/showcase.googleapis.com)
+4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication)
+
+### Installation
+```
+$ npm install --save showcase
+```
+
+### Next Steps
+- Read the [Client Library Documentation][] for GAPIC Showcase API
+  to see other available methods on the client.
+- Read the [GAPIC Showcase API Product documentation][Product Documentation]
+  to learn more about the product and see How-to Guides.
+- View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-node/blob/master/README.md)
+  to see the full list of Cloud APIs that we cover.
+
+[Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/showcase
+[Product Documentation]: https://cloud.google.com/showcase

--- a/showcase-v1alpha2/package.json
+++ b/showcase-v1alpha2/package.json
@@ -1,0 +1,55 @@
+{
+  "repository": "googleapis/nodejs-showcase",
+  "name": "showcase",
+  "version": "0.1.0",
+  "author": "Google LLC",
+  "description": "GAPIC Showcase API client for Node.js",
+  "main": "build/src/index.js",
+  "files": [
+    "protos",
+    "src",
+    "AUTHORS",
+    "COPYING"
+  ],
+  "keywords": [
+    "google apis client",
+    "google api client",
+    "google apis",
+    "google api",
+    "google",
+    "google cloud platform",
+    "google cloud",
+    "cloud",
+    "google showcase",
+    "showcase",
+    "GAPIC Showcase API"
+  ],
+  "dependencies": {
+    "google-gax": "googleapis/gax-nodejs#typescript-microgenerator",
+    "lodash.merge": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/duplexify": "^3.5.0",
+    "@types/lodash.merge": "^4.6.4",
+    "gts": "^0.8.0",
+    "mocha": "^5.2.0",
+    "through2": "^2.0.3",
+    "typescript": "~2.8.0"
+  },
+  "scripts": {
+    "publish-module": "node ../../scripts/publish.js showcase",
+    "smoke-test": "mocha smoke-test/*.js --timeout 5000",
+    "test": "mocha test/*.js",
+    "check": "gts check",
+    "clean": "gts clean",
+    "compile": "tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=6.0.0"
+  }
+}

--- a/showcase-v1alpha2/protos/google/showcase/v1alpha2/echo.proto
+++ b/showcase-v1alpha2/protos/google/showcase/v1alpha2/echo.proto
@@ -1,0 +1,177 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/longrunning/operations.proto";
+import "google/protobuf/duration.proto";
+import "google/rpc/status.proto";
+
+package google.showcase.v1alpha2;
+
+option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
+option java_package = "com.google.showcase.v1alpha2";
+option java_multiple_files = true;
+
+option (google.api.metadata) = {
+  product_uri: "https://github.com/googleapis/gapic-showcase"
+};
+
+// This service is used showcase the four main types of rpcs - unary, server
+// side streaming, client side streaming, and bidirectional streaming. This
+// service also exposes methods that explicitly implement server delay, and
+// paginated calls.
+service Echo {
+  // This service is meant to only run locally on the port 7469 (keypad digits
+  // for "show").
+  option (google.api.default_host) = "localhost:7469";
+
+  // This method simply echos the request. This method is showcases unary rpcs.
+  rpc Echo(EchoRequest) returns (EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/echo:echo"
+      body: "*"
+    };
+  }
+
+  // This method split the given content into words and will pass each word back
+  // through the stream. This method showcases server-side streaming rpcs.
+  rpc Expand(ExpandRequest) returns (stream EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/echo:expand"
+      body: "*"
+    };
+    // TODO(landrito): change this to be `fields: ["content", "error"]` once
+    // github.com/dcodeIO/protobuf.js/issues/1094 has been resolved.
+    option (google.api.method_signature) = {
+      fields: "content"
+      fields: "error"
+    };
+  }
+
+  // This method will collect the words given to it. When the stream is closed
+  // by the client, this method will return the a concatenation of the strings
+  // passed to it. This method showcases client-side streaming rpcs.
+  rpc Collect(stream EchoRequest) returns (EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/echo:collect"
+      body: "*"
+    };
+  }
+
+  // This method, upon receiving a request on the stream, the same content will
+  // be passed  back on the stream. This method showcases bidirectional
+  // streaming rpcs.
+  rpc Chat(stream EchoRequest) returns (stream EchoResponse);
+
+  // This method will wait the requested amount of and then return.
+  // This method showcases how a client handles a request timing out.
+  rpc Wait(WaitRequest) returns (WaitResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/echo:wait"
+      body: "*"
+    };
+  }
+
+  // This method returns a page containing numbers specified in the request.
+  // If the last number in the page is below the specified maximum, then the
+  // response will include a page token indicating the next page.
+  rpc Pagination(PaginationRequest) returns (PaginationResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/echo:pagination"
+      body: "*"
+    };
+    // TODO(landrito): change this to be `fields: ["max_response"]` once
+    // github.com/dcodeIO/protobuf.js/issues/1094 has been resolved.
+    option (google.api.method_signature) = {
+      fields: "max_response"
+    };
+  }
+}
+
+// The request message used for the Echo, Collect and Chat methods. If content
+// is set in this message then the request will succeed. If a status is
+message EchoRequest {
+  oneof response {
+    // The content to be echoed by the server.
+    string content = 1;
+
+    // The error to be thrown by the server.
+    google.rpc.Status error = 2;
+  }
+}
+
+// The response message for the Echo methods.
+message EchoResponse {
+  // The content specified in the request.
+  string content = 1;
+}
+
+// The request message for the Expand method.
+message ExpandRequest {
+  // The content that will be split into words and returned on the stream.
+  string content = 1;
+
+  // The error that is thrown after all words are sent on the stream.
+  google.rpc.Status error = 2;
+}
+
+// The request for Wait method.
+message WaitRequest {
+  // The amount of time to wait before returning a response.
+  google.protobuf.Duration response_delay = 1 [(google.api.required) = true];
+
+  oneof response {
+    // The error that will be returned by the server. If this code is specified
+    // to be the OK rpc code, an empty response will be returned.
+    google.rpc.Status error = 2;
+
+    // The response to be returned that will signify successful method call.
+    WaitResponse success = 3;
+  }
+}
+
+// The response for Wait method.
+message WaitResponse {
+  // This content can contain anything, the server will not depend on a value
+  // here.
+  string content = 1;
+}
+
+// The request for the Pagination methods.
+message PaginationRequest {
+  // The maximum number that will be returned in the response.
+  int32 max_response = 1 [(google.api.required) = true];
+
+  // The amount of numbers to returned in the response.
+  int32 page_size = 2;
+
+  // The position of the page to be returned. This will be a stringified int
+  // that will signifiy where to start the page from. Anything other than
+  // a stringified integer within the range of 0 and the max_response will
+  // cause an error to be thrown. This value is a string as opposed to a int32
+  // to follow general google api practices.
+  string page_token = 3;
+}
+
+// The response for the Pagination method.
+message PaginationResponse {
+  // An increasing list of responses starting at the value specified by the
+  // page token. If the page token is empty, then this list will start at 0.
+  repeated int32 responses = 1;
+
+  // The next integer stringified.
+  string next_page_token = 2;
+}

--- a/showcase-v1alpha2/protos/google/showcase/v1alpha2/testing.proto
+++ b/showcase-v1alpha2/protos/google/showcase/v1alpha2/testing.proto
@@ -1,0 +1,239 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/protobuf/empty.proto";
+
+package google.showcase.v1alpha2;
+
+option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
+option java_package = "com.google.showcase.v1alpha2";
+option java_multiple_files = true;
+
+// A service to facilitate running discrete sets of tests
+// against Showcase.
+service Testing {
+  option (google.api.default_host) = "localhost:7469";
+
+  // Report on the status of a session.
+  // This generates a report detailing which tests have been completed,
+  // and an overall rollup.
+  rpc ReportSession(ReportSessionRequest) returns (ReportSessionResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha2/{name=sessions/*}:report"
+    };
+  }
+
+  // Explicitly decline to implement a test.
+  //
+  // This removes the test from subsequent `ListTests` calls, and
+  // attempting to do the test will error.
+  //
+  // This method will error if attempting to delete a required test.
+  rpc DeleteTest(DeleteTestRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1alpha2/{name=sessions/*/tests/*}"
+    };
+  }
+
+  // Register a response to a test.
+  //
+  // In cases where a test involves registering a final answer at the
+  // end of the test, this method provides the means to do so.
+  rpc RegisterTest(RegisterTestRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1alpha2/{name=sessions/*/tests/*}:register"
+    };
+  }
+}
+
+// Request message for reporting on a session.
+message ReportSessionRequest {
+  // The session to be reported on.
+  string name = 1 [(google.api.resource_type) = "Session"];
+}
+
+// Response message for reporting on a session.
+message ReportSessionResponse {
+  // The topline state of the report.
+  enum State {
+    STATE_UNSPECIFIED = 0;
+
+    // The session is complete, and everything passed.
+    PASSED = 1;
+
+    // The session had an explicit failure.
+    FAILED = 2;
+
+    // The session is incomplete.
+    // This is a failure response.
+    INCOMPLETE = 3;
+  }
+
+  // The state of the report.
+  State state = 1;
+
+  // An issue highlighted in the report.
+  message Issue {
+    // The test that is the root of the issue.
+    string test = 1;
+
+    // The different potential types of issues.
+    enum Type {
+      TYPE_UNSPECIFIED = 0;
+
+      // The test was never instrumented.
+      SKIPPED = 1;
+
+      // The test was instrumented, but Showcase got an unexpected
+      // value when the generator tried to confirm success.
+      INCORRECT_CONFIRMATION = 2;
+    }
+
+    // The type of the issue.
+    Type type = 2;
+
+    // Severity levels.
+    enum Severity {
+      SEVERITY_UNSPECIFIED = 0;
+
+      // Errors.
+      ERROR = 1;
+
+      // Warnings.
+      WARNING = 2;
+    }
+
+    // The severity of the issue.
+    Severity severity = 3;
+
+    // A description of the issue.
+    string description = 4;
+  }
+
+  // Issues found which constitute errors.
+  // A non-zero list here requires a failure state for the report overall.
+  repeated Issue errors = 2;
+
+  // Issues found which do not constitute errors.
+  repeated Issue warnings = 3;
+
+  // A message describing the completion level for tests.
+  message Completion {
+    // The ratio of required and recommended tests completed.
+    //
+    // The behavior of the denominator for recommended and optional tests
+    // matches the description in their individual ratios below.
+    float total = 1;
+
+    // The ratio of required tests completed.
+    float required = 2;
+
+    // The ratio of recommended tests completed.
+    // Deleting a recommended test *does not* remove it from the denominator.
+    float recommended = 3;
+
+    // The ratio of optional tests completed.
+    // Deleting an optional test *does* remove it from the denominator.
+    float optional = 4;
+  }
+
+  // The overall completion in the report.
+  Completion completion = 4;
+}
+
+// Request message for deleting a test.
+message DeleteTestRequest {
+  // The test to be deleted.
+  string name = 1 [(google.api.resource_type) = "Test"];
+}
+
+// Register an answer from a test.
+message RegisterTestRequest {
+  // The test to have an answer registered to it.
+  string name = 1 [(google.api.resource_type) = "Test"];
+
+  // The answer from the test.
+  repeated string answers = 2;
+}
+
+// A session is a suite of tests, generally being made in the context
+// of testing code generation.
+//
+// A session defines tests it may expect, based on which version of the
+// code generation spec is in use.
+message Session {
+  // The name of the session. The ID must conform to ^[a-z]+$
+  // If this is not provided, Showcase chooses one at random.
+  string name = 1 [(google.api.resource).path = "sessions/*"];
+
+  // The specification versions understood by Showcase.
+  enum Version {
+    VERSION_UNSPECIFIED = 0;
+
+    // The latest v1. Currently, this is v1.0.
+    V1_LATEST = 1;
+
+    // v1.0. (Until the spec is "GA", this will be a moving target.)
+    V1_0 = 2;
+  }
+
+  // Required. The version this session is using.
+  Version version = 2;
+}
+
+
+// A test is a single test expected by Showcase.
+// The exact way that each test is exercised may vary from test to test.
+message Test {
+  // The name of the test.
+  // The tests/* portion of the names are hard-coded, and do not change
+  // from session to session.
+  string name = 1 [(google.api.resource).path = "sessions/*/tests/*"];
+
+  // Whether or not a test is required, recommended, or optional.
+  enum ExpectationLevel {
+    EXPECTATION_LEVEL_UNSPECIFIED = 0;
+
+    // This test is strictly required.
+    REQUIRED = 1;
+
+    // This test is recommended.
+    //
+    // If a generator explicitly ignores a recommended test (see `DeleteTest`),
+    // then the report may still pass, but with a warning.
+    //
+    // If a generator skips a recommended test and does not explicitly
+    // express that intention, the report will fail.
+    RECOMMENDED = 2;
+
+    // This test is optional.
+    //
+    // If a generator explicitly ignores an optional test (see `DeleteTest`),
+    // then the report may still pass, and no warning will be issued.
+    //
+    // If a generator skips an optional test and does not explicitly
+    // express that intention, the report may still pass, but with a
+    // warning.
+    OPTIONAL = 3;
+  }
+
+  // The expectation level for this test.
+  ExpectationLevel expectation_level = 2;
+
+  // A description of the test.
+  string description = 3;
+}

--- a/showcase-v1alpha2/src/index.ts
+++ b/showcase-v1alpha2/src/index.ts
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @namespace google
+ */
+/**
+ * @namespace google.cloud
+ */
+/**
+ * @namespace google.cloud.showcase
+ */
+/**
+ * @namespace google.cloud.showcase.v1alpha2
+ */
+
+'use strict';
+
+// Import the clients for each version supported by this package.
+import {EchoClient} from './v1alpha2';
+
+export {EchoClient as EchoClientV1alpha2} from './v1alpha2/';
+export {EchoClient} from './v1alpha2';
+
+/**
+ * The `showcase` package has the following named exports:
+ *
+ * - `EchoClient` - Reference to
+ *   {@link v1alpha2.EchoClient}
+ * - `v1alpha2` - This is used for selecting or pinning a
+ *   particular backend service version. It exports:
+ *     - `EchoClient` - Reference to
+ *       {@link v1alpha2.EchoClient}
+ *
+ * @module {object} showcase
+ * @alias nodejs-showcase
+ *
+ * @example <caption>Install the client library with <a
+ * href="https://www.npmjs.com/">npm</a>:</caption> npm install --save showcase
+ *
+ * @example <caption>Import the client library:</caption>
+ * const showcase = require('showcase');
+ *
+ * @example <caption>Create a client that uses <a
+ * href="https://goo.gl/64dyYX">Application Default Credentials
+ * (ADC)</a>:</caption> const client = new showcase.EchoClient();
+ *
+ * @example <caption>Create a client with <a
+ * href="https://goo.gl/RXp6VL">explicit credentials</a>:</caption> const client
+ * = new showcase.EchoClient({ projectId: 'your-project-id', keyFilename:
+ * '/path/to/keyfile.json',
+ * });
+ */

--- a/showcase-v1alpha2/src/v1alpha2/echo_client.ts
+++ b/showcase-v1alpha2/src/v1alpha2/echo_client.ts
@@ -1,0 +1,688 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// TODO: streaming methods return untyped EventEmitter.
+// We cannot make stream.on() stronly typed because we return different types on
+// different events (e.g. stream.on('data') vs stream.on('metadata')). It may be
+// possible to list all valid types for on().
+
+import * as gax from 'google-gax';
+const gapicConfig = require('./echo_client_config') as gax.ClientConfig;
+import merge = require('lodash.merge');
+import * as path from 'path';
+
+const VERSION = require('../../package.json').version;
+
+export interface GapicClientOptions extends gax.GrpcClientOptions,
+                                            gax.GoogleAuthOptions,
+                                            gax.ClientStubOptions {
+  libName?: string;
+  libVersion?: string;
+  clientConfig?: gax.ClientConfig;
+}
+
+export interface Descriptors {
+  page: {[name: string]: gax.PageDescriptor};
+  stream: {[name: string]: gax.StreamDescriptor};
+}
+
+export interface GapicCallback<ResponseObject> {
+  (err?: Error|null, value?: ResponseObject|null): void;
+}
+
+export interface GapicPaginationCallback<
+    RequestObject, ResponseObject, ResponseType> {
+  (err?: Error|null, values?: ResponseType[], nextPageRequest?: RequestObject,
+   rawResponse?: ResponseObject): void;
+}
+
+export interface GapicPaginationResponse<
+    RequestObject, ResponseObject, ResponseType> {
+  values?: ResponseType[];
+  nextPageRequest?: RequestObject;
+  rawResponse?: ResponseObject;
+}
+
+// Interfaces for the service
+export interface Protos extends gax.GrpcObject {
+  google: Google;
+}
+
+export interface Google extends gax.GrpcObject {
+  showcase: GoogleShowcase;
+}
+
+export interface GoogleShowcase extends gax.GrpcObject {
+  v1alpha2: GoogleShowcaseV1alpha2;
+}
+
+export interface GoogleShowcaseV1alpha2 extends gax.GrpcObject {
+  Echo: typeof gax.ClientStub;
+}
+
+export interface EchoRequest {
+  content?: string;
+  error?: object;  // TODO: google.rpc.Status
+}
+
+export interface EchoResponse {
+  content?: string;
+}
+
+export interface ExpandRequest {
+  content?: string;
+  error?: object;  // TODO: google.rpc.Status
+}
+
+export interface WaitRequest {
+  response_delay: object;  // TODO: google.protobuf.Duration
+  error?: object;          // TODO: google.rpc.Status
+  success?: WaitResponse;
+}
+
+export interface WaitResponse {
+  content?: string;
+}
+
+export interface PaginationRequest {
+  max_response: number;
+  page_size?: number;
+  page_token?: string;
+}
+
+export interface PaginationResponse {
+  responses?: number[];
+  next_page_token?: string;
+}
+// End of interfaces
+
+export class EchoClient {
+  _descriptors: Descriptors = {page: {}, stream: {}};
+  _innerApiCalls: {[name: string]: Function};
+  auth: gax.GoogleAuth;
+
+  /**
+   * Construct an instance of EchoClient.
+   *
+   * @param {object} [options] - The configuration object. See the subsequent
+   *   parameters for more details.
+   * @param {object} [options.credentials] - Credentials object.
+   * @param {string} [options.credentials.client_email]
+   * @param {string} [options.credentials.private_key]
+   * @param {string} [options.email] - Account email address. Required when
+   *     using a .pem or .p12 keyFilename.
+   * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+   *     .p12 key downloaded from the Google Developers Console. If you provide
+   *     a path to a JSON file, the projectId option below is not necessary.
+   *     NOTE: .pem and .p12 require you to specify options.email as well.
+   * @param {number} [options.port] - The port on which to connect to
+   *     the remote host.
+   * @param {string} [options.projectId] - The project ID from the Google
+   *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+   *     the environment variable GCLOUD_PROJECT for your project ID. If your
+   *     app is running in an environment which supports
+   *     {@link
+   * https://developers.google.com/identity/protocols/application-default-credentials
+   * Application Default Credentials}, your project ID will be detected
+   * automatically.
+   * @param {function} [options.promise] - Custom promise module to use instead
+   *     of native Promises.
+   * @param {string} [options.servicePath] - The domain name of the
+   *     API remote host.
+   */
+  constructor(opts: GapicClientOptions) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign(
+        {
+          clientConfig: {},
+          port: (this.constructor as typeof EchoClient).port,
+          servicePath: (this.constructor as typeof EchoClient).servicePath,
+        },
+        opts);
+
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    opts.scopes = (this.constructor as typeof EchoClient).scopes;
+    const gaxGrpc = new gax.GrpcClient(opts);
+
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    const clientHeader = [
+      `gl-node/${process.version}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${VERSION}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+    // Load the applicable protos.
+    const protos = merge(
+                       {},
+                       gaxGrpc.loadProto(
+                           path.join(__dirname, '..', '..', 'protos'),
+                           'google/showcase/v1alpha2/echo.proto')) as Protos;
+
+    // Some of the methods on this service return "paged" results,
+    // (e.g. 50 results at a time, with tokens to get subsequent
+    // pages). Denote the keys used for pagination and results.
+    this._descriptors.page = {
+      pagination:
+          new gax.PageDescriptor('pageToken', 'nextPageToken', 'responses'),
+    };
+
+    // Some of the methods on this service provide streaming responses.
+    // Provide descriptors for these.
+    this._descriptors.stream = {
+      expand: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+      collect: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+      chat: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
+    };
+
+    // Put together the default options sent with requests.
+    const defaults = gaxGrpc.constructSettings(
+        'google.showcase.v1alpha2.Echo', gapicConfig, opts.clientConfig || {},
+        {'x-goog-api-client': clientHeader.join(' ')});
+
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.showcase.v1alpha2.Echo.
+    const echoStub =
+        gaxGrpc.createStub(protos.google.showcase.v1alpha2.Echo, opts);
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    const echoStubMethods = [
+      'echo',
+      'expand',
+      'collect',
+      'chat',
+      'wait',
+      'pagination',
+    ];
+    for (const methodName of echoStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+          echoStub.then(stub => () => {
+            const args = Array.prototype.slice.call(arguments, 0);
+            return stub[methodName].apply(stub, args);
+          }),
+          defaults[methodName],
+          this._descriptors.page[methodName] ||
+              this._descriptors.stream[methodName]);
+    }
+  }
+
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'localhost';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 7469;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ];
+  }
+
+  /**
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
+   */
+  getProjectId(): Promise<string>;
+  getProjectId(callback: GapicCallback<string>): void;
+  getProjectId(callback?: GapicCallback<string>): Promise<string>|void {
+    if (!callback) {
+      return this.auth.getProjectId();
+    }
+    this.auth.getProjectId(callback);
+  }
+
+  // -------------------
+  // -- Service calls --
+  // -------------------
+
+  /**
+   * This method simply echos the request. This method is showcases unary rpcs.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.content]
+   *   The content to be echoed by the server.
+   * @param {Object} [request.error]
+   *   The error to be thrown by the server.
+   *
+   *   This object should have the same structure as [Status]{@link
+   * google.rpc.Status}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing
+   * [EchoResponse]{@link google.showcase.v1alpha2.EchoResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing
+   * [EchoResponse]{@link google.showcase.v1alpha2.EchoResponse}. The promise
+   * has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.echo({})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  echo(request: EchoRequest, options?: gax.CallOptions): Promise<EchoResponse>;
+  echo(
+      request: EchoRequest, options: gax.CallOptions,
+      callback: GapicCallback<EchoResponse>): void;
+  echo(
+      request: EchoRequest, options?: gax.CallOptions,
+      callback?: GapicCallback<EchoResponse>): Promise<EchoResponse>|void {
+    options = options || {};
+    return this._innerApiCalls.echo(request, options, callback);
+  }
+
+  /**
+   * This method split the given content into words and will pass each word back
+   * through the stream. This method showcases server-side streaming rpcs.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.content]
+   *   The content that will be split into words and returned on the stream.
+   * @param {Object} [request.error]
+   *   The error that is thrown after all words are sent on the stream.
+   *
+   *   This object should have the same structure as [Status]{@link
+   * google.rpc.Status}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @returns {Stream}
+   *   An object stream which emits [EchoResponse]{@link
+   * google.showcase.v1alpha2.EchoResponse} on 'data' event.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.expand({}).on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   */
+  expand(request: ExpandRequest, options?: gax.CallOptions):
+      NodeJS.ReadableStream {
+    options = options || {};
+    return this._innerApiCalls.expand(request, options);
+  }
+
+  /**
+   * This method will collect the words given to it. When the stream is closed
+   * by the client, this method will return the a concatenation of the strings
+   * passed to it. This method showcases client-side streaming rpcs.
+   *
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing
+   * [EchoResponse]{@link google.showcase.v1alpha2.EchoResponse}.
+   * @returns {Stream} - A writable stream which accepts objects representing
+   *   [EchoRequest]{@link google.showcase.v1alpha2.EchoRequest} for write()
+   * method.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const stream = client.collect((err, response) => {
+   *   if (err) {
+   *     console.error(err);
+   *     return;
+   *   }
+   *   // doThingsWith(response)
+   * });
+   * const request = {};
+   * // Write request objects.
+   * stream.write(request);
+   */
+  collect(options?: gax.CallOptions, callback?: GapicCallback<EchoResponse>):
+      NodeJS.WritableStream {
+    options = options || {};
+    return this._innerApiCalls.collect(null, options, callback);
+  }
+
+  /**
+   * This method, upon receiving a request on the stream, the same content will
+   * be passed  back on the stream. This method showcases bidirectional
+   * streaming rpcs.
+   *
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [EchoRequest]{@link google.showcase.v1alpha2.EchoRequest}
+   * for write() method, and will emit objects representing [EchoResponse]{@link
+   * google.showcase.v1alpha2.EchoResponse} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const stream = client.chat().on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   * const request = {};
+   * // Write request objects.
+   * stream.write(request);
+   */
+  chat(options?: gax.CallOptions): NodeJS.ReadWriteStream {
+    options = options || {};
+    return this._innerApiCalls.chat(options);
+  }
+
+  /**
+   * This method will wait the requested amount of and then return.
+   * This method showcases how a client handles a request timing out.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.responseDelay
+   *   The amount of time to wait before returning a response.
+   *
+   *   This object should have the same structure as [Duration]{@link
+   * google.protobuf.Duration}
+   * @param {Object} [request.error]
+   *   The error that will be returned by the server. If this code is specified
+   *   to be the OK rpc code, an empty response will be returned.
+   *
+   *   This object should have the same structure as [Status]{@link
+   * google.rpc.Status}
+   * @param {Object} [request.success]
+   *   The response to be returned that will signify successful method call.
+   *
+   *   This object should have the same structure as [WaitResponse]{@link
+   * google.showcase.v1alpha2.WaitResponse}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing
+   * [WaitResponse]{@link google.showcase.v1alpha2.WaitResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing
+   * [WaitResponse]{@link google.showcase.v1alpha2.WaitResponse}. The promise
+   * has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const responseDelay = {};
+   * client.wait({responseDelay: responseDelay})
+   *   .then(responses => {
+   *     const response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  wait(request: WaitRequest, options?: gax.CallOptions): Promise<WaitResponse>;
+  wait(
+      request: WaitRequest, options: gax.CallOptions,
+      callback: GapicCallback<WaitResponse>): void;
+  wait(
+      request: WaitRequest, options?: gax.CallOptions,
+      callback?: GapicCallback<WaitResponse>): Promise<WaitResponse>|void {
+    options = options || {};
+    return this._innerApiCalls.wait(request, options, callback);
+  }
+
+  /**
+   * This method returns a page containing numbers specified in the request.
+   * If the last number in the page is below the specified maximum, then the
+   * response will include a page token indicating the next page.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {number} request.maxResponse
+   *   The maximum number that will be returned in the response.
+   * @param {number} [request.pageSize]
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of number.
+   *
+   *   When autoPaginate: false is specified through options, it contains the
+   * result in a single response. If the response indicates the next page
+   * exists, the third parameter is set to be used for the next request object.
+   * The fourth parameter keeps the raw response object of an object
+   * representing [PaginationResponse]{@link
+   * google.showcase.v1alpha2.PaginationResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of number.
+   *
+   *   When autoPaginate: false is specified through options, the array has
+   * three elements. The first element is Array of number in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [PaginationResponse]{@link
+   * google.showcase.v1alpha2.PaginationResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API
+   * call.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * const maxResponse = 0;
+   *
+   * client.pagination({maxResponse: maxResponse})
+   *   .then(responses => {
+   *     const resources = responses[0];
+   *     for (let i = 0; i < resources.length; i += 1) {
+   *       // doThingsWith(resources[i])
+   *     }
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   *
+   * // Or obtain the paged response.
+   * const maxResponse = 0;
+   *
+   *
+   * const options = {autoPaginate: false};
+   * const callback = responses => {
+   *   // The actual resources in a response.
+   *   const resources = responses[0];
+   *   // The next request if the response shows that there are more responses.
+   *   const nextRequest = responses[1];
+   *   // The actual response object, if necessary.
+   *   // const rawResponse = responses[2];
+   *   for (let i = 0; i < resources.length; i += 1) {
+   *     // doThingsWith(resources[i]);
+   *   }
+   *   if (nextRequest) {
+   *     // Fetch the next page.
+   *     return client.pagination(nextRequest, options).then(callback);
+   *   }
+   * }
+   * client.pagination({maxResponse: maxResponse}, options)
+   *   .then(callback)
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  pagination(
+      request: PaginationRequest, options?: gax.CallOptions,
+      callback?: GapicPaginationCallback<
+          PaginationRequest, PaginationResponse, number>):
+      Promise<GapicPaginationResponse<
+          PaginationRequest, PaginationResponse, number>> {
+    options = options || {};
+    // Here we receive an untyped array from gax and convert it to typed object.
+    return new Promise((resolve, reject) => {
+      this._innerApiCalls.pagination(request, options, callback)
+          .then((resultArray: Array<{}>) => {
+            const result: GapicPaginationResponse<
+                PaginationRequest, PaginationResponse, number> = {
+              values: resultArray[0] as number[],
+              nextPageRequest: resultArray[1] as PaginationRequest,
+              rawResponse: resultArray[2] as PaginationResponse
+            };
+            resolve(result);
+          })
+          .catch(reject);
+    });
+  }
+
+  /**
+   * Equivalent to {@link pagination}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link pagination} continuously
+   * and invokes the callback registered for 'data' event for each element in
+   * the responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {number} request.maxResponse
+   *   The maximum number that will be returned in the response.
+   * @param {number} [request.pageSize]
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call,
+   * e.g, timeout, retries, paginations, etc. See [gax.CallOptions]{@link
+   * https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the
+   * details.
+   * @returns {Stream}
+   *   An object stream which emits a number on 'data' event.
+   *
+   * @example
+   *
+   * const showcase = require('showcase.v1alpha2');
+   *
+   * const client = new showcase.v1alpha2.EchoClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * const maxResponse = 0;
+   * client.paginationStream({maxResponse: maxResponse})
+   *   .on('data', element => {
+   *     // doThingsWith(element)
+   *   }).on('error', err => {
+   *     console.log(err);
+   *   });
+   */
+  paginationStream(request: PaginationRequest, options?: gax.CallOptions):
+      NodeJS.ReadableStream {
+    options = options || {};
+    return this._descriptors.page.pagination.createStream(
+        this._innerApiCalls.pagination, request, options);
+  }
+}

--- a/showcase-v1alpha2/src/v1alpha2/echo_client_config.json
+++ b/showcase-v1alpha2/src/v1alpha2/echo_client_config.json
@@ -1,0 +1,56 @@
+{
+  "interfaces": {
+    "google.showcase.v1alpha2.Echo": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 20000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 20000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "Echo": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Expand": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Collect": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "Chat": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Wait": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "Pagination": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/showcase-v1alpha2/src/v1alpha2/index.ts
+++ b/showcase-v1alpha2/src/v1alpha2/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+export {EchoClient} from './echo_client';

--- a/showcase-v1alpha2/tsconfig.json
+++ b/showcase-v1alpha2/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/*.ts",
+    "src/**/*.ts",
+    "test/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/showcase-v1alpha2/tslint.json
+++ b/showcase-v1alpha2/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "gts/tslint.json"
+}


### PR DESCRIPTION
This PR shows **manually** typed Showcase library. I'd like to have it reviewed before I copy all this stuff to templates.

Some TODOs and notes:

1. I'm using my special branch of google-gax ([PR](https://github.com/googleapis/gax-nodejs/pull/326)) that adds some exports needed by GAPIC code.

1. Streams are untyped. I can't easily make `EventEmitter` typed because its `on()` method accepts different types on different events (e.g. `on("data")` vs `on("metadata")`). I can list all possible types but it will take some time and probably will require changes in GAX and/or gRPC typings.

1. Order of method parameters is now fixed. You cannot swap `options` and `callback`. After all, we are in the stronly typed world now. That's a breaking change compared to the existing JavaScript code.

1. Pagination promise returns an object, not an array. You cannot make an array with elements of three different types in TypeScript.

1. Rather than try to make `protobufjs` generate message type annotations for me, I will generate them manually from proto files.

1. Some proto types such as `google.rpc.Status` and `google.protobuf.Duration` are now listed as `object`. This is TODO to add proper typings for them.

1. No LRO yet.

1. JsDoc comments are left untouched, I don't know yet if we are going to leave them, remove them, or change to something else.

1. No unit tests yet.