### PR TITLE
chore(deps): use google-gax v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "c8": "^5.0.1",
     "codecov": "^3.0.4",
     "espower-typescript": "^9.0.0",
-    "google-gax": "^1.5.0",
+    "google-gax": "^1.6.0",
     "gts": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
     "mocha": "^6.0.0",

--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -11,7 +11,7 @@
     "!build/src/**/*.map"
   ],
   "dependencies": {
-    "google-gax": "^1.5.0"
+    "google-gax": "^1.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
We need this to bring the new `compileProtos` script.