### PR TITLE
fix: clientConfig can be omitted

### DIFF
--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -6,11 +6,10 @@
   "description": "{{ api.naming.productName }} client for Node.js",
   "main": "build/src/index.js",
   "dependencies": {
-    "google-gax": "^1.7.0"
+    "google-gax": "^1.7.2"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",
-    "@types/through2": "^2.0.34",
     "gts": "^0.9.0",
     "mocha": "^6.0.0",
     "typescript": "~3.5.3"

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -13,7 +13,7 @@ export interface ClientOptions extends gax.GrpcClientOptions,
                                        gax.ClientStubOptions {
   libName?: string;
   libVersion?: string;
-  clientConfig: gax.ClientConfig;
+  clientConfig?: gax.ClientConfig;
   fallback?: boolean;
   apiEndpoint?: string;
 }

--- a/typescript/test/test_application_ts/src/index.ts
+++ b/typescript/test/test_application_ts/src/index.ts
@@ -15,7 +15,6 @@ const clientOptions = {
   port: 7469,
 };
 
-  // @ts-ignore TODO: client options types are incompatible
   const client = new showcase.EchoClient(clientOptions);
   await testEcho(client);
   await testExpand(client);

--- a/typescript/test/testdata/echo_client_baseline.ts.txt
+++ b/typescript/test/testdata/echo_client_baseline.ts.txt
@@ -30,7 +30,7 @@ export interface ClientOptions extends gax.GrpcClientOptions,
                                        gax.ClientStubOptions {
   libName?: string;
   libVersion?: string;
-  clientConfig: gax.ClientConfig;
+  clientConfig?: gax.ClientConfig;
   fallback?: boolean;
   apiEndpoint?: string;
 }


### PR DESCRIPTION
Since `google-gax` v1.7.2, `clientConfig` can be omitted. Marking it as not required everywhere.