### PR TITLE
fix: remove most of @ts-ignores from the generated code

### DIFF
--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -6,7 +6,7 @@
   "description": "{{ api.naming.productName }} client for Node.js",
   "main": "build/src/index.js",
   "dependencies": {
-    "google-gax": "^1.7.2"
+    "google-gax": "^1.7.3"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -139,15 +139,14 @@ export class {{ service.name }}Client {
 
     const operationsClient = gaxModule.lro({
       auth: this.auth,
-      // @ts-ignore
-      grpc: gaxGrpc.grpc,
+      grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined
     }).operationsClient(opts);
 
 {%- for method in service.longRunning %}
     const {{ method.name.toCamelCase() }}Response = protoFilesRoot.lookup(
-      '{{ method.longRunning.responseType }}');
+      '{{ method.longRunning.responseType }}') as gax.protobuf.Type;
     const {{ method.name.toCamelCase() }}Metadata = protoFilesRoot.lookup(
-      '{{ method.longRunning.metadataType }}');
+      '{{ method.longRunning.metadataType }}') as gax.protobuf.Type;
 {%- endfor %}
 
     this._descriptors.longrunning = {
@@ -156,9 +155,7 @@ export class {{ service.name }}Client {
       {{- longRunningJoiner() }}
       {{ method.name.toCamelCase() }}: new gaxModule.LongrunningDescriptor(
         operationsClient,
-        // @ts-ignore
         {{ method.name.toCamelCase() }}Response.decode.bind({{ method.name.toCamelCase() }}Response),
-        // @ts-ignore
         {{ method.name.toCamelCase() }}Metadata.decode.bind({{ method.name.toCamelCase() }}Metadata))
 {%- endfor %}
     };
@@ -177,13 +174,12 @@ export class {{ service.name }}Client {
     // Put together the "service stub" for
     // google.showcase.v1alpha2.Echo.
     const {{ service.name.toCamelCase() }}Stub = gaxGrpc.createStub(
-        // @ts-ignore We cannot check types that are loaded in runtime.
         opts.fallback ?
-          // @ts-ignore
+          // @ts-ignore Do not check types for loaded protos
           protos.lookupService('{{api.naming.protoPackage}}.{{ service.name }}') : 
-          // @ts-ignore
+          // @ts-ignore Do not check types for loaded protos
           protos.{{api.naming.protoPackage}}.{{ service.name }},
-        opts);
+        opts) as Promise<{[method: string]: Function}>;
 
     const {{ service.name.toCamelCase() }}StubMethods =
         [
@@ -195,10 +191,8 @@ export class {{ service.name }}Client {
     ];
 
     for (const methodName of {{ service.name.toCamelCase() }}StubMethods) {
-      // @ts-ignore
       const innerCallPromise = {{ service.name.toCamelCase() }}Stub.then(
-        // @ts-ignore
-        stub => (...args: Array<{}>) => {
+        (stub: {[method: string]: Function}) => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
         (err: Error|null|undefined) => () => {

--- a/templates/typescript_gapic/tslint.json.njk
+++ b/templates/typescript_gapic/tslint.json.njk
@@ -1,3 +1,6 @@
 {
-  "extends": "gts/tslint.json"
+  "extends": "gts/tslint.json",
+  "rules": {
+    "ban-ts-ignore": false
+  }
 }

--- a/typescript/test/test_application_js/package.json
+++ b/typescript/test/test_application_js/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "showcase": "file:./showcase-0.1.0.tgz",
+    "@grpc/grpc-js": "^0.6.8",
+    "grpc": "^1.23.3",
     "is-docker": "^2.0.0",
     "karma": "^4.3.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/typescript/test/testdata/echo_client_baseline.ts.txt
+++ b/typescript/test/testdata/echo_client_baseline.ts.txt
@@ -143,20 +143,17 @@ export class EchoClient {
 
     const operationsClient = gaxModule.lro({
       auth: this.auth,
-      // @ts-ignore
-      grpc: gaxGrpc.grpc,
+      grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined
     }).operationsClient(opts);
     const waitResponse = protoFilesRoot.lookup(
-      'WaitResponse');
+      'WaitResponse') as gax.protobuf.Type;
     const waitMetadata = protoFilesRoot.lookup(
-      'WaitMetadata');
+      'WaitMetadata') as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
       wait: new gaxModule.LongrunningDescriptor(
         operationsClient,
-        // @ts-ignore
         waitResponse.decode.bind(waitResponse),
-        // @ts-ignore
         waitMetadata.decode.bind(waitMetadata))
     };
 
@@ -173,22 +170,19 @@ export class EchoClient {
     // Put together the "service stub" for
     // google.showcase.v1alpha2.Echo.
     const echoStub = gaxGrpc.createStub(
-        // @ts-ignore We cannot check types that are loaded in runtime.
         opts.fallback ?
-          // @ts-ignore
+          // @ts-ignore Do not check types for loaded protos
           protos.lookupService('google.showcase.v1beta1.Echo') : 
-          // @ts-ignore
+          // @ts-ignore Do not check types for loaded protos
           protos.google.showcase.v1beta1.Echo,
-        opts);
+        opts) as Promise<{[method: string]: Function}>;
 
     const echoStubMethods =
         ['echo', 'expand', 'collect', 'chat', 'pagedExpand', 'wait'];
 
     for (const methodName of echoStubMethods) {
-      // @ts-ignore
       const innerCallPromise = echoStub.then(
-        // @ts-ignore
-        stub => (...args: Array<{}>) => {
+        (stub: {[method: string]: Function}) => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
         (err: Error|null|undefined) => () => {


### PR DESCRIPTION
We still have `@ts-ignore` in the places where we load protos dynamically, I need to think and figure out if we can get rid of them. But those are the only places.