### PR TITLE
test: add paging method in unit test

### DIFF
--- a/templates/typescript_gapic/test/gapic-$service-$version.js.njk
+++ b/templates/typescript_gapic/test/gapic-$service-$version.js.njk
@@ -295,6 +295,30 @@ describe('{{ service.name }}Client', () => {
             });
             stream.write(request);
         });
-{%- endfor %}
     });
+{%- endfor %}
+{%- for method in service.paging %}
+    describe('{{ method.name.toCamelCase() }}', () => {
+        it('invokes {{ method.name.toCamelCase() }} without error', done => {
+            const client = new {{ service.name }}Module.{{ api.naming.version }}.{{ service.name }}Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus', 
+            });
+            // Mock request
+            const request = {};
+            // Mock response
+            const expectedResponse = {};
+            // Mock Grpc layer
+            client._innerApiCalls.{{ method.name.toCamelCase() }} = (actualRequest, options, callback) => {
+                assert.deepStrictEqual(actualRequest, request);
+                callback(null, expectedResponse);
+            };
+            client.{{ method.name.toCamelCase() }}(request, (err, response) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(response, expectedResponse);
+                done();
+            });
+        });
+    });
+{%- endfor %}
 });


### PR DESCRIPTION
Add paging method unit test for generated client library.

TODO: init request and response based on structure function, now the test only uses empty request to trigger the method and get empty response back.
#18 