### PR TITLE
refactor: make sure templates can be located anywhere

### DIFF
--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -21,7 +21,13 @@ import { API } from './schema/api';
 import { processTemplates } from './templater';
 import { commonPrefix } from './util';
 
-const templateDirectory = 'templates/typescript_gapic';
+const templateDirectory = path.join(
+  __dirname,
+  '..',
+  '..',
+  'templates',
+  'typescript_gapic'
+);
 // If needed, we can make it possible to load templates from different locations
 // to generate code for other languages.
 
@@ -83,8 +89,6 @@ export class Generator {
     const api = this.buildAPIObject();
     await this.processTemplates(api);
     // TODO: error handling
-    // console.warn(JSON.stringify(api.services, null, ' '));
-    // console.warn(JSON.stringify(api, null, ' '));
 
     const outputBuffer = plugin.google.protobuf.compiler.CodeGeneratorResponse.encode(
       this.response

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -131,8 +131,11 @@ function pagingField(messages: MessagesMap, method: MethodDescriptorProto) {
 
 function pagingFieldName(messages: MessagesMap, method: MethodDescriptorProto) {
   const repeatedFields = pagingField(messages, method);
-  if (repeatedFields && repeatedFields.name) return repeatedFields.name;
-  else return undefined;
+  if (repeatedFields && repeatedFields.name) {
+    return repeatedFields.name;
+  } else {
+    return undefined;
+  }
 }
 
 function pagingResponseType(


### PR DESCRIPTION
We use relative paths to templates which makes it hard to use the generator when the current working directory is different. Fixing that by passing the base path parameter to `nunjucks` in `nunjucks.configure`.

Not including any tests here because this is a refactor and existing tests cover this code (and they still work).

(also, ran `gts fix` that changed one unrelated function)