### PR TITLE
fix: fixing config name

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import * as packageJson from '../../package.json';
 import * as protosTypes from '../../protos/protos';
-import * as gapicConfig from './echo_client_config.json';
+import * as gapicConfig from './{{ service.name.toLowerCase() }}_client_config.json';
 
 const version = packageJson.version;
 


### PR DESCRIPTION
We had one `echo` left in the templates. Replacing it with the proper `{{ template }}`.