### PR TITLE
chore: operation should be exported only if an API has LRO

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -29,10 +29,11 @@ export interface Callback<
   (err: Error|null|undefined, value?: ResponseObject|null,
    nextRequest?: NextRequestObject, rawResponse?: RawResponseObject): void;
 }
-
+{% if (service.longRunning.length > 0) %}
 export interface Operation<ResultType, MetadataType> extends gax.Operation {
     promise(): Promise<[ResultType, MetadataType, protosTypes.google.longrunning.IOperation]>;
 }
+{%- endif %}
 
 {% if (service.paging.length > 0) %}
 export interface PaginationCallback<


### PR DESCRIPTION
#56 