### PR TITLE
fix: no proto.list

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -13,4 +13,8 @@ gapic-generator-typescript \
   --output-dir /out \
   $* \
   `find /in -name '*.proto'`
+
+# The proto.list is only needed for generation, removing it
+rm -f /out/proto.list
+
 exit 0


### PR DESCRIPTION
We don't want it to be generated. It's a little bit hard to remove it from the generator code (some tests refactor is needed) so for now I'll just `rm -f` it from the Docker entry script.