### PR TITLE
fix: no ts-ignore in generated code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
             npm install
             npm test
             npm run fix
+            npm run compile
       - run:
           name: Run unit tests and gts fix of the generated KMS library
           command: |
@@ -59,6 +60,7 @@ jobs:
             npm install
             npm test
             npm run fix
+            npm run compile
       - run:
           name: Run unit tests and gts fix of the generated Translate library
           command: |
@@ -67,6 +69,7 @@ jobs:
             npm install
             npm test
             npm run fix
+            npm run compile
       - run:
           name: Run unit tests and gts fix of the generated Text-to-Speech library
           command: |
@@ -75,6 +78,7 @@ jobs:
             npm install
             npm test
             npm run fix
+            npm run compile
       - run:
           name: Run linting
           command: |

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -228,10 +228,9 @@ export class {{ service.name }}Client {
     // google.showcase.v1alpha2.Echo.
     const {{ service.name.toCamelCase() }}Stub = gaxGrpc.createStub(
         opts.fallback ?
-          // @ts-ignore Do not check types for loaded protos
-          protos.lookupService('{{api.naming.protoPackage}}.{{ service.name }}') : 
-          // @ts-ignore Do not check types for loaded protos
-          protos.{{api.naming.protoPackage}}.{{ service.name }},
+          (protos as protobuf.Root).lookupService('{{api.naming.protoPackage}}.{{ service.name }}') :
+          // tslint:disable-next-line no-any
+          (protos as any).{{api.naming.protoPackage}}.{{ service.name }},
         opts) as Promise<{[method: string]: Function}>;
 
     const {{ service.name.toCamelCase() }}StubMethods =

--- a/templates/typescript_gapic/tslint.json.njk
+++ b/templates/typescript_gapic/tslint.json.njk
@@ -1,6 +1,3 @@
 {
-  "extends": "gts/tslint.json",
-  "rules": {
-    "ban-ts-ignore": false
-  }
+  "extends": "gts/tslint.json"
 }

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -192,10 +192,9 @@ export class KeyManagementServiceClient {
     // google.showcase.v1alpha2.Echo.
     const keyManagementServiceStub = gaxGrpc.createStub(
         opts.fallback ?
-          // @ts-ignore Do not check types for loaded protos
-          protos.lookupService('google.cloud.kms.v1.KeyManagementService') : 
-          // @ts-ignore Do not check types for loaded protos
-          protos.google.cloud.kms.v1.KeyManagementService,
+          (protos as protobuf.Root).lookupService('google.cloud.kms.v1.KeyManagementService') :
+          // tslint:disable-next-line no-any
+          (protos as any).google.cloud.kms.v1.KeyManagementService,
         opts) as Promise<{[method: string]: Function}>;
 
     const keyManagementServiceStubMethods =

--- a/typescript/test/testdata/keymanager/tslint.json.baseline
+++ b/typescript/test/testdata/keymanager/tslint.json.baseline
@@ -1,6 +1,3 @@
 {
-  "extends": "gts/tslint.json",
-  "rules": {
-    "ban-ts-ignore": false
-  }
+  "extends": "gts/tslint.json"
 }

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -212,10 +212,9 @@ export class EchoClient {
     // google.showcase.v1alpha2.Echo.
     const echoStub = gaxGrpc.createStub(
         opts.fallback ?
-          // @ts-ignore Do not check types for loaded protos
-          protos.lookupService('google.showcase.v1beta1.Echo') : 
-          // @ts-ignore Do not check types for loaded protos
-          protos.google.showcase.v1beta1.Echo,
+          (protos as protobuf.Root).lookupService('google.showcase.v1beta1.Echo') :
+          // tslint:disable-next-line no-any
+          (protos as any).google.showcase.v1beta1.Echo,
         opts) as Promise<{[method: string]: Function}>;
 
     const echoStubMethods =

--- a/typescript/test/testdata/showcase/tslint.json.baseline
+++ b/typescript/test/testdata/showcase/tslint.json.baseline
@@ -1,6 +1,3 @@
 {
-  "extends": "gts/tslint.json",
-  "rules": {
-    "ban-ts-ignore": false
-  }
+  "extends": "gts/tslint.json"
 }

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -155,10 +155,9 @@ export class TextToSpeechClient {
     // google.showcase.v1alpha2.Echo.
     const textToSpeechStub = gaxGrpc.createStub(
         opts.fallback ?
-          // @ts-ignore Do not check types for loaded protos
-          protos.lookupService('google.cloud.texttospeech.v1.TextToSpeech') : 
-          // @ts-ignore Do not check types for loaded protos
-          protos.google.cloud.texttospeech.v1.TextToSpeech,
+          (protos as protobuf.Root).lookupService('google.cloud.texttospeech.v1.TextToSpeech') :
+          // tslint:disable-next-line no-any
+          (protos as any).google.cloud.texttospeech.v1.TextToSpeech,
         opts) as Promise<{[method: string]: Function}>;
 
     const textToSpeechStubMethods =

--- a/typescript/test/testdata/texttospeech/tslint.json.baseline
+++ b/typescript/test/testdata/texttospeech/tslint.json.baseline
@@ -1,6 +1,3 @@
 {
-  "extends": "gts/tslint.json",
-  "rules": {
-    "ban-ts-ignore": false
-  }
+  "extends": "gts/tslint.json"
 }

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -226,10 +226,9 @@ export class TranslationServiceClient {
     // google.showcase.v1alpha2.Echo.
     const translationServiceStub = gaxGrpc.createStub(
         opts.fallback ?
-          // @ts-ignore Do not check types for loaded protos
-          protos.lookupService('google.cloud.translation.v3beta1.TranslationService') : 
-          // @ts-ignore Do not check types for loaded protos
-          protos.google.cloud.translation.v3beta1.TranslationService,
+          (protos as protobuf.Root).lookupService('google.cloud.translation.v3beta1.TranslationService') :
+          // tslint:disable-next-line no-any
+          (protos as any).google.cloud.translation.v3beta1.TranslationService,
         opts) as Promise<{[method: string]: Function}>;
 
     const translationServiceStubMethods =

--- a/typescript/test/testdata/translate/tslint.json.baseline
+++ b/typescript/test/testdata/translate/tslint.json.baseline
@@ -1,6 +1,3 @@
 {
-  "extends": "gts/tslint.json",
-  "rules": {
-    "ban-ts-ignore": false
-  }
+  "extends": "gts/tslint.json"
 }


### PR DESCRIPTION
1. `@ts-ignore` is bad  (`any` is also bad but better). Sooner or later we'll figure out how to get rid of that `any` as well.

2. To catch the problem that happened with `cloudbuild` (stopped compiling after `gts fix`), let's try compiling the generating code once more after fixing its formatting in CircleCI.