### PR TITLE
chore: move string manipulation methods to template

### DIFF
--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -9,3 +9,8 @@
             {{ chain }}.{{ method.headerRequestParams.slice(-1)[0] }} = '';
 {%- endif %}
 {%- endmacro -%}
+
+{%- macro toInterface(inputType) -%}
+{%- set inputType = inputType | replace('\.([^.]+)$', '.I$1') -%}
+    {{ inputType }}
+{%- endmacro -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -1,5 +1,5 @@
 {%- macro initRequestWithHeaderParam(method) -%}
-            const request: protosTypes{{ method.inputInterface }} = {};
+            const request: protosTypes{{ toInterface(method.inputInterface) }} = {};
 {%- if method.headerRequestParams.length > 1 %}
 {%- set chain = "request" -%}
 {%- for field in method.headerRequestParams.slice(0, -1) %}
@@ -10,7 +10,12 @@
 {%- endif %}
 {%- endmacro -%}
 
-{%- macro toInterface(inputType) -%}
-{%- set inputType = inputType | replace('\.([^.]+)$', '.I$1') -%}
-    {{ inputType }}
+{%- macro toInterface(type) -%}
+{%- set index = type.lastIndexOf('.') -%}
+{{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
+{%- endmacro -%}
+
+{%- macro toLRInterface(type, inputType) -%}
+{%- set index = inputType.lastIndexOf('.') -%}
+{{ inputType.substring(0, index + 1) + 'I' + type }}
 {%- endmacro -%}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -1,5 +1,7 @@
 {% import "../../_license.njk" as license -%}
 {{license.license()}}
+{% import "../../_util.njk" as util -%}
+
 import * as gax from 'google-gax';
 import * as path from 'path';
 
@@ -325,31 +327,31 @@ export class {{ service.name }}Client {
   {{ method.comments }} 
   */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          protosTypes{{ method.outputInterface }},
-          protosTypes{{ method.inputInterface }}|undefined,
+          protosTypes{{ util.toInterface(method.outputInterface) }},
+          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined,
           {}|undefined>): void;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          protosTypes{{ method.outputInterface }},
-          protosTypes{{ method.inputInterface }}|undefined, {}|undefined>,
+          protosTypes{{ util.toInterface(method.outputInterface) }},
+          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-          protosTypes{{ method.outputInterface }},
-          protosTypes{{ method.inputInterface }}|undefined,
+          protosTypes{{ util.toInterface(method.outputInterface) }},
+          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;
@@ -386,7 +388,7 @@ export class {{ service.name }}Client {
   }
 {%- elif method.serverStreaming %}
   {{ method.name.toCamelCase() }}(
-      request?: protosTypes{{ method.inputInterface }},
+      request?: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
     gax.CancellableStream{
     request = request || {}; 
@@ -397,21 +399,21 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       options: gax.CallOptions,
       callback: Callback<
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined>):
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
   {{ method.name.toCamelCase() }}(
       callback: Callback<
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined>):
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
   {{ method.name.toCamelCase() }}(
       optionsOrCallback: gax.CallOptions|Callback<
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined>,
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-        protosTypes{{ method.outputInterface }},
-        protosTypes{{ method.inputInterface }}|undefined, {}|undefined>):
+        protosTypes{{ util.toInterface(method.outputInterface) }},
+        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream {
     if (optionsOrCallback instanceof Function && callback === undefined) {
         callback = optionsOrCallback;
@@ -427,31 +429,31 @@ export class {{ service.name }}Client {
   {{ method.comments }} 
   */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
         Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
-        protosTypes{{ method.outputInterface }}|undefined, {}|undefined
+        protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
           Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
-          protosTypes{{ method.outputInterface }}|undefined,
+          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>): void;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
           Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
-          protosTypes{{ method.outputInterface }}|undefined, {}|undefined>,
+          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
           Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
-          protosTypes{{ method.outputInterface }}|undefined,
+          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
         Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
-        protosTypes{{ method.outputInterface }}|undefined, {}|undefined
+        protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;
@@ -480,34 +482,34 @@ export class {{ service.name }}Client {
   {{ method.comments }} 
   */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
         protosTypes{{ method.pagingResponseType }}[],
-        protosTypes{{ method.inputInterface }}|null, 
-        protosTypes{{ method.outputInterface }}
+        protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
+        protosTypes{{ util.toInterface(method.outputInterface) }}
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
           protosTypes{{ method.pagingResponseType }}[],
-          protosTypes{{ method.inputInterface }}|null,
-          protosTypes{{ method.outputInterface }}>): void;
+          protosTypes{{ util.toInterface(method.inputInterface) }}|null,
+          protosTypes{{ util.toInterface(method.outputInterface) }}>): void;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ method.inputInterface }},
+      request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes{{ method.pagingResponseType }}[],
-          protosTypes{{ method.inputInterface }}|null, 
-          protosTypes{{ method.outputInterface }}>,
+          protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
+          protosTypes{{ util.toInterface(method.outputInterface) }}>,
       callback?: Callback<
           protosTypes{{ method.pagingResponseType }}[],
-          protosTypes{{ method.inputInterface }}|null,
-          protosTypes{{ method.outputInterface }}>):
+          protosTypes{{ util.toInterface(method.inputInterface) }}|null,
+          protosTypes{{ util.toInterface(method.outputInterface) }}>):
       Promise<[
         protosTypes{{ method.pagingResponseType }}[],
-        protosTypes{{ method.inputInterface }}|null, 
-        protosTypes{{ method.outputInterface }}
+        protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
+        protosTypes{{ util.toInterface(method.outputInterface) }}
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -432,27 +432,27 @@ export class {{ service.name }}Client {
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
+        Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType) }}>,
         protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
+          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>): void;
   {{ method.name.toCamelCase() }}(
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
+          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType)}}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-          Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
+          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
-        Operation<protosTypes{{ method.longRunningResponseType }}, protosTypes{{ method.longRunningMetadataType }}>,
+        Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
         protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -199,10 +199,7 @@ function longrunning(method: MethodDescriptorProto) {
 function longRunningResponseType(method: MethodDescriptorProto) {
   if (method.options && method.options['.google.longrunning.operationInfo']) {
     if (method.options['.google.longrunning.operationInfo'].responseType) {
-      return toLRInterface(
-        method.options['.google.longrunning.operationInfo'].responseType,
-        method.inputType!.toString()
-      );
+      return method.options['.google.longrunning.operationInfo'].responseType;
     }
   }
   return undefined;
@@ -211,10 +208,7 @@ function longRunningResponseType(method: MethodDescriptorProto) {
 function longRunningMetadataType(method: MethodDescriptorProto) {
   if (method.options && method.options['.google.longrunning.operationInfo']) {
     if (method.options['.google.longrunning.operationInfo'].metadataType) {
-      return toLRInterface(
-        method.options['.google.longrunning.operationInfo'].metadataType,
-        method.inputType!.toString()
-      );
+      return method.options['.google.longrunning.operationInfo'].metadataType;
     }
   }
   return undefined;
@@ -276,13 +270,6 @@ function pagingResponseType(
     return typeName.replace(/\.([^.]+)$/, '.I$1');
   }
   return undefined;
-}
-
-// Convert long running type to the interface
-// eg: WaitResponse -> .google.showcase.v1beta1.IWaitResponse
-// eg: WaitMetadata -> .google.showcase.v1beta1.IWaitMetadata
-function toLRInterface(type: string, inputType: string) {
-  return inputType.replace(/\.([^.]+)$/, '.I' + type);
 }
 
 export function getHeaderParams(rule: plugin.google.api.IHttpRule): string[] {

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -278,10 +278,6 @@ function pagingResponseType(
   return undefined;
 }
 
-function toInterface(type: string) {
-  return type.replace(/\.([^.]+)$/, '.I$1');
-}
-
 // Convert long running type to the interface
 // eg: WaitResponse -> .google.showcase.v1beta1.IWaitResponse
 // eg: WaitMetadata -> .google.showcase.v1beta1.IWaitMetadata
@@ -338,8 +334,8 @@ function augmentMethod(
       streaming: streaming(method),
       pagingFieldName: pagingFieldName(messages, method),
       pagingResponseType: pagingResponseType(messages, method),
-      inputInterface: toInterface(method.inputType!),
-      outputInterface: toInterface(method.outputType!),
+      inputInterface: method.inputType!,
+      outputInterface: method.outputType!,
       comments: service.commentsMap.getMethodComments(method.name!),
       methodConfig: getMethodConfig(
         service.grpcServiceConfig,

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -230,6 +230,13 @@ function longRunningMetadataType(method: MethodDescriptorProto) {
   return undefined;
 }
 
+// convert from input interface to message name
+// eg: .google.showcase.v1beta1.EchoRequest -> EchoRequest
+function toMessageName(messageType: string): string {
+  const arr = messageType.split('.');
+  return arr[arr.length - 1];
+}
+
 function streaming(method: MethodDescriptorProto) {
   if (method.serverStreaming && method.clientStreaming) {
     return 'BIDI_STREAMING';


### PR DESCRIPTION
fix #95 
