### PR TITLE
fix: compatibility with gapic-generator

### DIFF
--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -32,11 +32,6 @@ limitations under the License.
 {{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
 {%- endmacro -%}
 
-{%- macro toLRInterface(type, inputType) -%}
-{%- set index = inputType.lastIndexOf('.') -%}
-{{ inputType.substring(0, index + 1) + 'I' + type }}
-{%- endmacro -%}
-
 {%- macro printCommentsForParams(method) -%}
 {%- set commentsMap = method.paramComment -%}
 {%- for oneComment in commentsMap -%}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -227,9 +227,9 @@ export class {{ service.name }}Client {
 
 {%- for method in service.longRunning %}
     const {{ method.name.toCamelCase() }}Response = protoFilesRoot.lookup(
-      '{{ method.longRunning.responseType }}') as gax.protobuf.Type;
+      '{{ method.longRunningResponseType }}') as gax.protobuf.Type;
     const {{ method.name.toCamelCase() }}Metadata = protoFilesRoot.lookup(
-      '{{ method.longRunning.metadataType }}') as gax.protobuf.Type;
+      '{{ method.longRunningMetadataType }}') as gax.protobuf.Type;
 {%- endfor %}
 
     this._descriptors.longrunning = {

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -144,12 +144,19 @@ export class {{ service.name }}Client {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gaxModule.version}`,
       `gapic/${version}`,
       `gl-web/${gaxModule.version}`
     ];
+    if (typeof process !== 'undefined' && 'versions' in process) {
+      clientHeader.push(`gl-node/${process.versions.node}`);
+    } else {
+      clientHeader.push(`gl-web/${gaxModule.version}`);
+    }
+    if (!opts.fallback) {
+      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+    }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
@@ -164,6 +171,10 @@ export class {{ service.name }}Client {
         nodejsProtoPath
     );
 {%- if (service.pathTemplates.length > 0) %}
+
+    // This API contains "path templates"; forward-slash-separated
+    // identifiers to uniquely identify resources within the API.
+    // Create useful helper objects for these.
     this._pathTemplates = {
 {%- for template in service.pathTemplates %}
       {{ template.name.toCamelCase() }}PathTemplate: new gaxModule.PathTemplate(
@@ -200,8 +211,8 @@ export class {{ service.name }}Client {
 {%- endfor %}
     };
 {%- endif %}
-    
 {%- if (service.longRunning.length > 0) %}
+
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
@@ -457,27 +468,27 @@ export class {{ service.name }}Client {
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType) }}>,
+        Operation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType) }}>,
         protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          Operation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>): void;
   {{ method.name.toCamelCase() }}(
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType)}}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          Operation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType)}}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-          Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          Operation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
-        Operation<protosTypes{{ util.toLRInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toLRInterface(method.longRunningMetadataType, method.inputType)  }}>,
+        Operation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
         protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
@@ -513,7 +524,7 @@ export class {{ service.name }}Client {
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        protosTypes{{ method.pagingResponseType }}[],
+        protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
         protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
         protosTypes{{ util.toInterface(method.outputInterface) }}
       ]>;
@@ -521,21 +532,21 @@ export class {{ service.name }}Client {
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          protosTypes{{ method.pagingResponseType }}[],
+          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
           protosTypes{{ util.toInterface(method.inputInterface) }}|null,
           protosTypes{{ util.toInterface(method.outputInterface) }}>): void;
   {{ method.name.toCamelCase() }}(
       request: protosTypes{{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          protosTypes{{ method.pagingResponseType }}[],
+          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
           protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
           protosTypes{{ util.toInterface(method.outputInterface) }}>,
       callback?: Callback<
-          protosTypes{{ method.pagingResponseType }}[],
+          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
           protosTypes{{ util.toInterface(method.inputInterface) }}|null,
           protosTypes{{ util.toInterface(method.outputInterface) }}>):
       Promise<[
-        protosTypes{{ method.pagingResponseType }}[],
+        protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
         protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
         protosTypes{{ util.toInterface(method.outputInterface) }}
       ]>|void {

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -108,7 +108,11 @@ export class Generator {
 
   private buildAPIObject(): API {
     const protoFilesToGenerate = this.request.protoFile.filter(
-      pf => pf.name && this.request.fileToGenerate.includes(pf.name)
+      pf => pf.name && 
+      this.request.fileToGenerate.includes(pf.name) &&
+      // ignoring some common package names
+      pf.package !== 'google.longrunning' &&
+      pf.package !== 'google.cloud'
     );
     const packageNamesToGenerate = protoFilesToGenerate.map(
       pf => pf.package || ''

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -108,11 +108,12 @@ export class Generator {
 
   private buildAPIObject(): API {
     const protoFilesToGenerate = this.request.protoFile.filter(
-      pf => pf.name && 
-      this.request.fileToGenerate.includes(pf.name) &&
-      // ignoring some common package names
-      pf.package !== 'google.longrunning' &&
-      pf.package !== 'google.cloud'
+      pf =>
+        pf.name &&
+        this.request.fileToGenerate.includes(pf.name) &&
+        // ignoring some common package names
+        pf.package !== 'google.longrunning' &&
+        pf.package !== 'google.cloud'
     );
     const packageNamesToGenerate = protoFilesToGenerate.map(
       pf => pf.package || ''

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -144,12 +144,19 @@ export class KeyManagementServiceClient {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gaxModule.version}`,
       `gapic/${version}`,
       `gl-web/${gaxModule.version}`
     ];
+    if (typeof process !== 'undefined' && 'versions' in process) {
+      clientHeader.push(`gl-node/${process.versions.node}`);
+    } else {
+      clientHeader.push(`gl-web/${gaxModule.version}`);
+    }
+    if (!opts.fallback) {
+      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+    }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -140,12 +140,19 @@ export class EchoClient {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gaxModule.version}`,
       `gapic/${version}`,
       `gl-web/${gaxModule.version}`
     ];
+    if (typeof process !== 'undefined' && 'versions' in process) {
+      clientHeader.push(`gl-node/${process.versions.node}`);
+    } else {
+      clientHeader.push(`gl-web/${gaxModule.version}`);
+    }
+    if (!opts.fallback) {
+      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+    }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
@@ -175,6 +182,7 @@ export class EchoClient {
       collect: new gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
       chat: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING)
     };
+
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -195,9 +195,9 @@ export class EchoClient {
       grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined
     }).operationsClient(opts);
     const waitResponse = protoFilesRoot.lookup(
-      'WaitResponse') as gax.protobuf.Type;
+      '.google.showcase.v1beta1.WaitResponse') as gax.protobuf.Type;
     const waitMetadata = protoFilesRoot.lookup(
-      'WaitMetadata') as gax.protobuf.Type;
+      '.google.showcase.v1beta1.WaitMetadata') as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
       wait: new gaxModule.LongrunningDescriptor(

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -121,12 +121,19 @@ export class TextToSpeechClient {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gaxModule.version}`,
       `gapic/${version}`,
       `gl-web/${gaxModule.version}`
     ];
+    if (typeof process !== 'undefined' && 'versions' in process) {
+      clientHeader.push(`gl-node/${process.versions.node}`);
+    } else {
+      clientHeader.push(`gl-web/${gaxModule.version}`);
+    }
+    if (!opts.fallback) {
+      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+    }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -138,12 +138,19 @@ export class TranslationServiceClient {
 
     // Determine the client header string.
     const clientHeader = [
-      `gl-node/${process.version}`,
       `grpc/${gaxGrpc.grpcVersion}`,
       `gax/${gaxModule.version}`,
       `gapic/${version}`,
       `gl-web/${gaxModule.version}`
     ];
+    if (typeof process !== 'undefined' && 'versions' in process) {
+      clientHeader.push(`gl-node/${process.versions.node}`);
+    } else {
+      clientHeader.push(`gl-web/${gaxModule.version}`);
+    }
+    if (!opts.fallback) {
+      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+    }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
@@ -157,6 +164,10 @@ export class TranslationServiceClient {
         require("../../protos/protos.json") :
         nodejsProtoPath
     );
+
+    // This API contains "path templates"; forward-slash-separated
+    // identifiers to uniquely identify resources within the API.
+    // Create useful helper objects for these.
     this._pathTemplates = {
       locationPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/locations/{location}'
@@ -173,6 +184,7 @@ export class TranslationServiceClient {
       listGlossaries:
           new gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'glossaries')
     };
+
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -197,17 +197,17 @@ export class TranslationServiceClient {
       grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined
     }).operationsClient(opts);
     const batchTranslateTextResponse = protoFilesRoot.lookup(
-      'BatchTranslateResponse') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.BatchTranslateResponse') as gax.protobuf.Type;
     const batchTranslateTextMetadata = protoFilesRoot.lookup(
-      'BatchTranslateMetadata') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.BatchTranslateMetadata') as gax.protobuf.Type;
     const createGlossaryResponse = protoFilesRoot.lookup(
-      'Glossary') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.Glossary') as gax.protobuf.Type;
     const createGlossaryMetadata = protoFilesRoot.lookup(
-      'CreateGlossaryMetadata') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.CreateGlossaryMetadata') as gax.protobuf.Type;
     const deleteGlossaryResponse = protoFilesRoot.lookup(
-      'DeleteGlossaryResponse') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.DeleteGlossaryResponse') as gax.protobuf.Type;
     const deleteGlossaryMetadata = protoFilesRoot.lookup(
-      'DeleteGlossaryMetadata') as gax.protobuf.Type;
+      '.google.cloud.translation.v3beta1.DeleteGlossaryMetadata') as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
       batchTranslateText: new gaxModule.LongrunningDescriptor(

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_proto_list.json.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_proto_list.json.baseline
@@ -1,4 +1,3 @@
 [
-  "../../protos/google/cloud/translate/v3beta1/translation_service.proto",
-  "../../protos/google/cloud/common_resources.proto"
+  "../../protos/google/cloud/translate/v3beta1/translation_service.proto"
 ]


### PR DESCRIPTION
A set of fixes caused by manual comparison of the generated `translate` TS library with the original JS one.

1. Fully qualified types for long running operations (see the baseline changes for LRO types). It's what gapic-generator does, and it's very important for cases where we have several versions available (e.g. for `translate`, we'll have `v3beta1` and `v3` and we must load the correct versions of types).

2. Client headers: we should set `grpc` header if we use gRPC, set `gl-node` if we use Node.js, and set `gl-web` header if it's not Node.js (so it's likely a browser).

3. Removed handling of interface name in the code from `pagingResponseType()` since we now have it in the templates.

4. Do not include common protos (such as common resources) to the list of required proto files.