### PR TITLE
fix: require @types/long

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gapic-generator-typescript": "build/src/start_script.js"
   },
   "scripts": {
+    "baseline": "node build/tools/update-baselines.js",
     "test": "c8 --reporter=lcov mocha build/test/unit",
     "docker-test": "sh docker/test.sh",
     "codecov": "c8 --reporter=lcov mocha build/test/unit && c8 report",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gapic-generator-typescript": "build/src/start_script.js"
   },
   "scripts": {
-    "baseline": "node build/tools/update-baselines.js",
     "test": "c8 --reporter=lcov mocha build/test/unit",
     "docker-test": "sh docker/test.sh",
     "codecov": "c8 --reporter=lcov mocha build/test/unit && c8 report",

--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -27,6 +27,7 @@ limitations under the License.
     "build/protos"
   ],
   "dependencies": {
+    "@types/long": "^4.0.0",
     "google-gax": "^1.8.0"
   },
   "devDependencies": {

--- a/typescript/test/testdata/keymanager/package.json.baseline
+++ b/typescript/test/testdata/keymanager/package.json.baseline
@@ -10,6 +10,7 @@
     "build/protos"
   ],
   "dependencies": {
+    "@types/long": "^4.0.0",
     "google-gax": "^1.8.0"
   },
   "devDependencies": {

--- a/typescript/test/testdata/showcase/package.json.baseline
+++ b/typescript/test/testdata/showcase/package.json.baseline
@@ -10,6 +10,7 @@
     "build/protos"
   ],
   "dependencies": {
+    "@types/long": "^4.0.0",
     "google-gax": "^1.8.0"
   },
   "devDependencies": {

--- a/typescript/test/testdata/texttospeech/package.json.baseline
+++ b/typescript/test/testdata/texttospeech/package.json.baseline
@@ -10,6 +10,7 @@
     "build/protos"
   ],
   "dependencies": {
+    "@types/long": "^4.0.0",
     "google-gax": "^1.8.0"
   },
   "devDependencies": {

--- a/typescript/test/testdata/translate/package.json.baseline
+++ b/typescript/test/testdata/translate/package.json.baseline
@@ -10,6 +10,7 @@
     "build/protos"
   ],
   "dependencies": {
+    "@types/long": "^4.0.0",
     "google-gax": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This does not look like a 100% clean solution but I checked that pub/sub does exactly this https://github.com/googleapis/nodejs-pubsub/blob/master/package.json#L60.

The generated `protos.d.ts` uses `Long` type and we must do so as well to make sure all types are imported properly.