### PR TITLE
fix: better default exports in src/index.ts

### DIFF
--- a/templates/typescript_gapic/src/index.ts.njk
+++ b/templates/typescript_gapic/src/index.ts.njk
@@ -18,8 +18,16 @@ limitations under the License.
 {% import "../_license.njk" as license -%}
 {{license.license()}}
 import * as {{ api.naming.version }} from './{{ api.naming.version }}';
-export {{ '{' + api.naming.version + '}' }};
-{% for service in api.services -%}
+{%- for service in api.services %}
 const {{ service.name.toPascalCase() }}Client = {{ api.naming.version }}.{{ service.name.toPascalCase() }}Client;
-export {{ '{' + service.name.toPascalCase() + 'Client' + '}' }};
 {%- endfor %}
+export { {{- api.naming.version }}
+{%- for service in api.services -%}
+, {{ service.name.toPascalCase() + 'Client' }}
+{%- endfor -%}
+};
+export default { {{- api.naming.version }}
+{%- for service in api.services -%}
+, {{ service.name.toPascalCase() + 'Client' }}
+{%- endfor -%}
+};

--- a/templates/typescript_gapic/src/index.ts.njk
+++ b/templates/typescript_gapic/src/index.ts.njk
@@ -26,6 +26,8 @@ export { {{- api.naming.version }}
 , {{ service.name.toPascalCase() + 'Client' }}
 {%- endfor -%}
 };
+// For compatibility with JavaScript libraries we need to provide this default export:
+// tslint:disable-next-line no-default-export
 export default { {{- api.naming.version }}
 {%- for service in api.services -%}
 , {{ service.name.toPascalCase() + 'Client' }}

--- a/typescript/test/testdata/keymanager/src/index.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/index.ts.baseline
@@ -19,4 +19,6 @@
 import * as v1 from './v1';
 const KeyManagementServiceClient = v1.KeyManagementServiceClient;
 export {v1, KeyManagementServiceClient};
+// For compatibility with JavaScript libraries we need to provide this default export:
+// tslint:disable-next-line no-default-export
 export default {v1, KeyManagementServiceClient};

--- a/typescript/test/testdata/keymanager/src/index.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/index.ts.baseline
@@ -17,6 +17,6 @@
 // ** All changes to this file may be overwritten. **
 
 import * as v1 from './v1';
-export {v1};
 const KeyManagementServiceClient = v1.KeyManagementServiceClient;
-export {KeyManagementServiceClient};
+export {v1, KeyManagementServiceClient};
+export default {v1, KeyManagementServiceClient};

--- a/typescript/test/testdata/showcase/src/index.ts.baseline
+++ b/typescript/test/testdata/showcase/src/index.ts.baseline
@@ -17,6 +17,6 @@
 // ** All changes to this file may be overwritten. **
 
 import * as v1beta1 from './v1beta1';
-export {v1beta1};
 const EchoClient = v1beta1.EchoClient;
-export {EchoClient};
+export {v1beta1, EchoClient};
+export default {v1beta1, EchoClient};

--- a/typescript/test/testdata/showcase/src/index.ts.baseline
+++ b/typescript/test/testdata/showcase/src/index.ts.baseline
@@ -19,4 +19,6 @@
 import * as v1beta1 from './v1beta1';
 const EchoClient = v1beta1.EchoClient;
 export {v1beta1, EchoClient};
+// For compatibility with JavaScript libraries we need to provide this default export:
+// tslint:disable-next-line no-default-export
 export default {v1beta1, EchoClient};

--- a/typescript/test/testdata/texttospeech/src/index.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/index.ts.baseline
@@ -19,4 +19,6 @@
 import * as v1 from './v1';
 const TextToSpeechClient = v1.TextToSpeechClient;
 export {v1, TextToSpeechClient};
+// For compatibility with JavaScript libraries we need to provide this default export:
+// tslint:disable-next-line no-default-export
 export default {v1, TextToSpeechClient};

--- a/typescript/test/testdata/texttospeech/src/index.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/index.ts.baseline
@@ -17,6 +17,6 @@
 // ** All changes to this file may be overwritten. **
 
 import * as v1 from './v1';
-export {v1};
 const TextToSpeechClient = v1.TextToSpeechClient;
-export {TextToSpeechClient};
+export {v1, TextToSpeechClient};
+export default {v1, TextToSpeechClient};

--- a/typescript/test/testdata/translate/src/index.ts.baseline
+++ b/typescript/test/testdata/translate/src/index.ts.baseline
@@ -17,6 +17,6 @@
 // ** All changes to this file may be overwritten. **
 
 import * as v3beta1 from './v3beta1';
-export {v3beta1};
 const TranslationServiceClient = v3beta1.TranslationServiceClient;
-export {TranslationServiceClient};
+export {v3beta1, TranslationServiceClient};
+export default {v3beta1, TranslationServiceClient};

--- a/typescript/test/testdata/translate/src/index.ts.baseline
+++ b/typescript/test/testdata/translate/src/index.ts.baseline
@@ -19,4 +19,6 @@
 import * as v3beta1 from './v3beta1';
 const TranslationServiceClient = v3beta1.TranslationServiceClient;
 export {v3beta1, TranslationServiceClient};
+// For compatibility with JavaScript libraries we need to provide this default export:
+// tslint:disable-next-line no-default-export
 export default {v3beta1, TranslationServiceClient};


### PR DESCRIPTION
This improves our exports in `src/index.ts` and make the result of `require('library');` the same as it is now with JavaScript libraries.

(this still works with only one version!)