### PR TITLE
fix: use pagination types from gax

### DIFF
--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -41,7 +41,7 @@ limitations under the License.
     "test": "mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^1.10.0"
+    "google-gax": "^1.11.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -20,11 +20,10 @@ limitations under the License.
 {% import "../../_util.njk" as util -%}
 
 import * as gax from 'google-gax';
-{% if service.longRunning.length > 0 -%}
-import {APICallback, Callback, CallOptions, LROperation, Descriptors, ClientOptions} from 'google-gax';
-{%- else -%}
-import {APICallback, Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
-{%- endif %}
+import {APICallback, Callback, CallOptions, Descriptors, ClientOptions
+{%- if service.longRunning.length > 0 %}, LROperation{%- endif -%}
+{%- if service.paging.length > 0 %}, PaginationCallback, PaginationResponse{%- endif -%}
+} from 'google-gax';
 import * as path from 'path';
 {% if (service.paging.length > 0) %}
 import { Transform } from 'stream';
@@ -33,21 +32,6 @@ import * as protosTypes from '../../protos/protos';
 import * as gapicConfig from './{{ service.name.toSnakeCase() }}_client_config.json';
 
 const version = require('../../../package.json').version;
-
-{% if (service.paging.length > 0) %}
-export interface PaginationCallback<
-    RequestObject, ResponseObject, ResponseType> {
-  (err: Error|null, values?: ResponseType[], nextPageRequest?: RequestObject,
-   rawResponse?: ResponseObject): void;
-}
-
-export interface PaginationResponse<
-    RequestObject, ResponseObject, ResponseType> {
-  values?: ResponseType[];
-  nextPageRequest?: RequestObject;
-  rawResponse?: ResponseObject;
-}
-{% endif %}
 
 /**
 {{- util.printCommentsForService(service) }}

--- a/typescript/test/testdata/keymanager/package.json.baseline
+++ b/typescript/test/testdata/keymanager/package.json.baseline
@@ -24,7 +24,7 @@
     "test": "mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^1.10.0"
+    "google-gax": "^1.11.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -17,7 +17,7 @@
 // ** All changes to this file may be overwritten. **
 
 import * as gax from 'google-gax';
-import {APICallback, Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
+import {APICallback, Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, PaginationResponse} from 'google-gax';
 import * as path from 'path';
 
 import { Transform } from 'stream';
@@ -25,21 +25,6 @@ import * as protosTypes from '../../protos/protos';
 import * as gapicConfig from './key_management_service_client_config.json';
 
 const version = require('../../../package.json').version;
-
-
-export interface PaginationCallback<
-    RequestObject, ResponseObject, ResponseType> {
-  (err: Error|null, values?: ResponseType[], nextPageRequest?: RequestObject,
-   rawResponse?: ResponseObject): void;
-}
-
-export interface PaginationResponse<
-    RequestObject, ResponseObject, ResponseType> {
-  values?: ResponseType[];
-  nextPageRequest?: RequestObject;
-  rawResponse?: ResponseObject;
-}
-
 
 /**
  *  Google Cloud Key Management Service

--- a/typescript/test/testdata/showcase/package.json.baseline
+++ b/typescript/test/testdata/showcase/package.json.baseline
@@ -24,7 +24,7 @@
     "test": "mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^1.10.0"
+    "google-gax": "^1.11.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -17,7 +17,7 @@
 // ** All changes to this file may be overwritten. **
 
 import * as gax from 'google-gax';
-import {APICallback, Callback, CallOptions, LROperation, Descriptors, ClientOptions} from 'google-gax';
+import {APICallback, Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, PaginationResponse} from 'google-gax';
 import * as path from 'path';
 
 import { Transform } from 'stream';
@@ -25,21 +25,6 @@ import * as protosTypes from '../../protos/protos';
 import * as gapicConfig from './echo_client_config.json';
 
 const version = require('../../../package.json').version;
-
-
-export interface PaginationCallback<
-    RequestObject, ResponseObject, ResponseType> {
-  (err: Error|null, values?: ResponseType[], nextPageRequest?: RequestObject,
-   rawResponse?: ResponseObject): void;
-}
-
-export interface PaginationResponse<
-    RequestObject, ResponseObject, ResponseType> {
-  values?: ResponseType[];
-  nextPageRequest?: RequestObject;
-  rawResponse?: ResponseObject;
-}
-
 
 /**
  *  This service is used showcase the four main types of rpcs - unary, server

--- a/typescript/test/testdata/texttospeech/package.json.baseline
+++ b/typescript/test/testdata/texttospeech/package.json.baseline
@@ -24,7 +24,7 @@
     "test": "mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^1.10.0"
+    "google-gax": "^1.11.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -25,8 +25,6 @@ import * as gapicConfig from './text_to_speech_client_config.json';
 
 const version = require('../../../package.json').version;
 
-
-
 /**
  *  Service that implements Google Cloud Text-to-Speech API.
  * @class

--- a/typescript/test/testdata/translate/package.json.baseline
+++ b/typescript/test/testdata/translate/package.json.baseline
@@ -24,7 +24,7 @@
     "test": "mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^1.10.0"
+    "google-gax": "^1.11.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -17,7 +17,7 @@
 // ** All changes to this file may be overwritten. **
 
 import * as gax from 'google-gax';
-import {APICallback, Callback, CallOptions, LROperation, Descriptors, ClientOptions} from 'google-gax';
+import {APICallback, Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, PaginationResponse} from 'google-gax';
 import * as path from 'path';
 
 import { Transform } from 'stream';
@@ -25,21 +25,6 @@ import * as protosTypes from '../../protos/protos';
 import * as gapicConfig from './translation_service_client_config.json';
 
 const version = require('../../../package.json').version;
-
-
-export interface PaginationCallback<
-    RequestObject, ResponseObject, ResponseType> {
-  (err: Error|null, values?: ResponseType[], nextPageRequest?: RequestObject,
-   rawResponse?: ResponseObject): void;
-}
-
-export interface PaginationResponse<
-    RequestObject, ResponseObject, ResponseType> {
-  values?: ResponseType[];
-  nextPageRequest?: RequestObject;
-  rawResponse?: ResponseObject;
-}
-
 
 /**
  *  Provides natural language translation operations.


### PR DESCRIPTION
Using pagination types exported from `google-gax`.

CI won't work until gax v1.11.0 is released.