### PR TITLE
fix: change style of comment in protos for protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "test": "c8 --reporter=lcov mocha build/test/unit"
   },
   "dependencies": {
-    "file-system": "^2.2.2",
     "fs-extra": "^8.1.0",
     "get-stdin": "^7.0.0",
     "google-gax": "^1.9.0",

--- a/typescript/src/start_script.ts
+++ b/typescript/src/start_script.ts
@@ -18,7 +18,7 @@ import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
-import {updateProtoComments} from './util';
+import { updateProtoComments } from './util';
 
 const googleGaxPath = path.dirname(require.resolve('google-gax')); // ...../google-gax/build/src
 const GOOGLE_GAX_PROTOS_DIR = path.join(googleGaxPath, '..', '..', 'protos');

--- a/typescript/src/start_script.ts
+++ b/typescript/src/start_script.ts
@@ -18,7 +18,7 @@ import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
-const fileSystem = require('file-system');
+import {updateProtoComments} from './util';
 
 const googleGaxPath = path.dirname(require.resolve('google-gax')); // ...../google-gax/build/src
 const GOOGLE_GAX_PROTOS_DIR = path.join(googleGaxPath, '..', '..', 'protos');
@@ -102,7 +102,11 @@ try {
       protoDirs.forEach(dir => {
         const protoFile = path.join(dir, proto);
         if (fs.existsSync(protoFile)) {
-          fileSystem.copyFileSync(protoFile, path.join(copyProtoDir, proto));
+          const content = fs.readFileSync(protoFile).toString();
+          const destination = path.join(copyProtoDir, proto);
+          fs.ensureFileSync(destination);
+          const convertedContent = updateProtoComments(content);
+          fs.writeFileSync(destination, convertedContent);
         }
       });
     });

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -79,7 +79,7 @@ export function updateProtoComments(protoContent: string): string {
 
   let lineNo = 0;
   // 1. Skip everything before `package` declaration (license and stuff)
-  for ( ; lineNo < lines.length; ++lineNo) {
+  for (; lineNo < lines.length; ++lineNo) {
     const line = lines[lineNo];
     if (lines[lineNo].match(/^\s*package\s*/)) {
       break;
@@ -90,7 +90,7 @@ export function updateProtoComments(protoContent: string): string {
   // 2. For each // comment, convert it to /** */.
   let inComment = false;
   let lastIndentation = '';
-  for ( ; lineNo < lines.length; ++lineNo) {
+  for (; lineNo < lines.length; ++lineNo) {
     const line = lines[lineNo];
     const match = line.match(/^(\s*)\/\/(.*?)\s*$/);
     if (!match) {
@@ -112,8 +112,7 @@ export function updateProtoComments(protoContent: string): string {
     const safeComment = comment.replace(/\*\//g, '* /');
     if (safeComment.length > 0) {
       resultLines.push(`${indentation} *${safeComment}`);
-    }
-    else {
+    } else {
       resultLines.push(`${indentation} *`);
     }
   }

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -13,7 +13,13 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import { commonPrefix, duration, seconds, milliseconds, updateProtoComments } from '../../src/util';
+import {
+  commonPrefix,
+  duration,
+  seconds,
+  milliseconds,
+  updateProtoComments,
+} from '../../src/util';
 import * as plugin from '../../../pbjs-genfiles/plugin';
 
 describe('util.ts', () => {

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import { commonPrefix, duration, seconds, milliseconds } from '../../src/util';
+import { commonPrefix, duration, seconds, milliseconds, updateProtoComments } from '../../src/util';
 import * as plugin from '../../../pbjs-genfiles/plugin';
 
 describe('util.ts', () => {
@@ -109,6 +109,68 @@ describe('util.ts', () => {
       });
       const result = milliseconds(duration);
       assert.strictEqual(result, 5500);
+    });
+  });
+
+  describe('Update proto comments', () => {
+    it('should update proto comments', () => {
+      const source = `
+// License
+// Should stay unchanged
+
+syntax = "proto3";
+
+package something;
+
+// This block must be converted
+// to a different style of comments
+message MessageA {}
+
+// Single line comments must be processed as well
+message MessageB {
+  // Comments with indentation must be processed
+  // as well, even
+  //
+  // if they consist of several blocks
+  // of text.
+  int32 data = 1; // trailing comments must be left as is
+}
+
+// Unsafe closing sequence */ must be taken care of
+      `;
+      const expectedResult = `
+// License
+// Should stay unchanged
+
+syntax = "proto3";
+
+package something;
+
+/**
+ * This block must be converted
+ * to a different style of comments
+ */
+message MessageA {}
+
+/**
+ * Single line comments must be processed as well
+ */
+message MessageB {
+  /**
+   * Comments with indentation must be processed
+   * as well, even
+   *
+   * if they consist of several blocks
+   * of text.
+   */
+  int32 data = 1; // trailing comments must be left as is
+}
+
+/**
+ * Unsafe closing sequence * / must be taken care of
+ */
+      `;
+      assert.strictEqual(updateProtoComments(source), expectedResult);
     });
   });
 


### PR DESCRIPTION
So this one is weird.

---

**TL;DR:** in this PR we convert all `//` comments to `/** ... */` in all the proto files that are copied to the generated client library.

---

In the monolith generator, we created the whole `src/v*/doc` folder (e.g. [here](https://github.com/googleapis/nodejs-datacatalog/tree/master/src/v1beta1/doc)) that was pretty much the copy of protos with comments, converted to JavaScript for `jsdoc`.

In the micro-generator, we don't do that. Instead, we run `pbjs` to generate `protos/protos.js` and then let `jsdoc` read that file, which just works.

But, I just realized that `jsdoc` does not consider `//` style comments from proto files and does not copy them to the resulting `protos/protos.js`.  Its documentation says [here](https://github.com/protobufjs/protobuf.js#pbjs-for-javascript):

> **ProTip!** Documenting your .proto files with `/** ... */`-blocks or (trailing) `/// ...` lines translates to generated static code.

So... we must convert the proto comments from `//` to `/** ... */` to make them go into the jsdoc. Luckily, we have a great place to do that - right in the code where we copy proto files into the resulting directory. This PR does exactly that.