### PR TITLE
fix: generated test fixes

### DIFF
--- a/templates/typescript_gapic/test/gapic-$service-$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic-$service-$version.ts.njk
@@ -46,6 +46,7 @@ export class Operation{
     promise() {};
 }
 
+{%- if (service.simpleMethods.length > 0) %}
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -58,6 +59,7 @@ function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: F
         } 
     };
 }
+{%- endif %}
 {%- if (service.serverStreaming.length > 0) %}
 function mockServerStreamingGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}) => {
@@ -116,7 +118,7 @@ function mockLongRunningGrpcMethod(expectedRequest: {}, response: {} | null, err
     };
 }
 {%- endif %}
-describe('{{ service.name }}Client', () => {
+describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
     it('has servicePath', () => {
         const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.servicePath;
         assert(servicePath);
@@ -134,7 +136,7 @@ describe('{{ service.name }}Client', () => {
         const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
             fallback: true,
         });

--- a/typescript/test/testdata/keymanager/test/gapic-key_management_service-v1.ts.baseline
+++ b/typescript/test/testdata/keymanager/test/gapic-key_management_service-v1.ts.baseline
@@ -41,7 +41,6 @@ export class Operation{
     constructor(){};
     promise() {};
 }
-
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -54,7 +53,7 @@ function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: F
         } 
     };
 }
-describe('KeyManagementServiceClient', () => {
+describe('v1.KeyManagementServiceClient', () => {
     it('has servicePath', () => {
         const servicePath = keymanagementserviceModule.v1.KeyManagementServiceClient.servicePath;
         assert(servicePath);
@@ -72,7 +71,7 @@ describe('KeyManagementServiceClient', () => {
         const client = new keymanagementserviceModule.v1.KeyManagementServiceClient();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new keymanagementserviceModule.v1.KeyManagementServiceClient({
             fallback: true,
         });

--- a/typescript/test/testdata/redis/test/gapic-cloud_redis-v1beta1.ts.baseline
+++ b/typescript/test/testdata/redis/test/gapic-cloud_redis-v1beta1.ts.baseline
@@ -41,7 +41,6 @@ export class Operation{
     constructor(){};
     promise() {};
 }
-
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -72,7 +71,7 @@ function mockLongRunningGrpcMethod(expectedRequest: {}, response: {} | null, err
         return Promise.resolve([mockOperation]);
     };
 }
-describe('CloudRedisClient', () => {
+describe('v1beta1.CloudRedisClient', () => {
     it('has servicePath', () => {
         const servicePath = cloudredisModule.v1beta1.CloudRedisClient.servicePath;
         assert(servicePath);
@@ -90,7 +89,7 @@ describe('CloudRedisClient', () => {
         const client = new cloudredisModule.v1beta1.CloudRedisClient();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new cloudredisModule.v1beta1.CloudRedisClient({
             fallback: true,
         });

--- a/typescript/test/testdata/showcase/test/gapic-echo-v1beta1.ts.baseline
+++ b/typescript/test/testdata/showcase/test/gapic-echo-v1beta1.ts.baseline
@@ -43,7 +43,6 @@ export class Operation{
     constructor(){};
     promise() {};
 }
-
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -108,7 +107,7 @@ function mockLongRunningGrpcMethod(expectedRequest: {}, response: {} | null, err
         return Promise.resolve([mockOperation]);
     };
 }
-describe('EchoClient', () => {
+describe('v1beta1.EchoClient', () => {
     it('has servicePath', () => {
         const servicePath = echoModule.v1beta1.EchoClient.servicePath;
         assert(servicePath);
@@ -126,7 +125,7 @@ describe('EchoClient', () => {
         const client = new echoModule.v1beta1.EchoClient();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new echoModule.v1beta1.EchoClient({
             fallback: true,
         });

--- a/typescript/test/testdata/texttospeech/test/gapic-text_to_speech-v1.ts.baseline
+++ b/typescript/test/testdata/texttospeech/test/gapic-text_to_speech-v1.ts.baseline
@@ -41,7 +41,6 @@ export class Operation{
     constructor(){};
     promise() {};
 }
-
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -54,7 +53,7 @@ function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: F
         } 
     };
 }
-describe('TextToSpeechClient', () => {
+describe('v1.TextToSpeechClient', () => {
     it('has servicePath', () => {
         const servicePath = texttospeechModule.v1.TextToSpeechClient.servicePath;
         assert(servicePath);
@@ -72,7 +71,7 @@ describe('TextToSpeechClient', () => {
         const client = new texttospeechModule.v1.TextToSpeechClient();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new texttospeechModule.v1.TextToSpeechClient({
             fallback: true,
         });

--- a/typescript/test/testdata/translate/test/gapic-translation_service-v3beta1.ts.baseline
+++ b/typescript/test/testdata/translate/test/gapic-translation_service-v3beta1.ts.baseline
@@ -41,7 +41,6 @@ export class Operation{
     constructor(){};
     promise() {};
 }
-
 function mockSimpleGrpcMethod(expectedRequest: {}, response: {} | null, error: FakeError | null) {
     return (actualRequest: {}, options: {}, callback: Callback) => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
@@ -72,7 +71,7 @@ function mockLongRunningGrpcMethod(expectedRequest: {}, response: {} | null, err
         return Promise.resolve([mockOperation]);
     };
 }
-describe('TranslationServiceClient', () => {
+describe('v3beta1.TranslationServiceClient', () => {
     it('has servicePath', () => {
         const servicePath = translationserviceModule.v3beta1.TranslationServiceClient.servicePath;
         assert(servicePath);
@@ -90,7 +89,7 @@ describe('TranslationServiceClient', () => {
         const client = new translationserviceModule.v3beta1.TranslationServiceClient();
         assert(client);
     });    
-    it('should create a client with gRPC option', () => {
+    it('should create a client with gRPC fallback', () => {
         const client = new translationserviceModule.v3beta1.TranslationServiceClient({
             fallback: true,
         });


### PR DESCRIPTION
Minor fixes for the generated unit tests:

- include version in `describe()` title so that if the library has multiple versions, it's immediately clear which version's tests fail;
- do not emit `mockSimpleGrpcMethod` if there are no simple methods (will fix the long standing https://github.com/googleapis/gapic-generator/issues/2120 that only affects video-intelligence API)
- proper name for fallback test.