### PR TITLE
fix: ignore http-proxy-agent for webpack

### DIFF
--- a/templates/typescript_gapic/webpack.config.js.njk
+++ b/templates/typescript_gapic/webpack.config.js.njk
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {

--- a/typescript/test/testdata/keymanager/webpack.config.js.baseline
+++ b/typescript/test/testdata/keymanager/webpack.config.js.baseline
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {

--- a/typescript/test/testdata/redis/webpack.config.js.baseline
+++ b/typescript/test/testdata/redis/webpack.config.js.baseline
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {

--- a/typescript/test/testdata/showcase/webpack.config.js.baseline
+++ b/typescript/test/testdata/showcase/webpack.config.js.baseline
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {

--- a/typescript/test/testdata/texttospeech/webpack.config.js.baseline
+++ b/typescript/test/testdata/texttospeech/webpack.config.js.baseline
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {

--- a/typescript/test/testdata/translate/webpack.config.js.baseline
+++ b/typescript/test/testdata/translate/webpack.config.js.baseline
@@ -51,7 +51,7 @@ module.exports = {
         use: 'null-loader'
       },
       {
-        test: /node_modules[\\/]https-proxy-agent/,
+        test: /node_modules[\\/]https?-proxy-agent/,
         use: 'null-loader'
       },
       {


### PR DESCRIPTION
Minor fix: some packages depend on `http-proxy-agent` (not just `https-proxy-agent`) which we don't need in webpack bundle. Replacing it with `null-loader` as well.