### PR TITLE
fix: use c8 for coverage

### DIFF
--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -37,8 +37,8 @@ limitations under the License.
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -46,6 +46,7 @@ limitations under the License.
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",

--- a/typescript/test/testdata/keymanager/package.json.baseline
+++ b/typescript/test/testdata/keymanager/package.json.baseline
@@ -20,8 +20,8 @@
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",

--- a/typescript/test/testdata/redis/package.json.baseline
+++ b/typescript/test/testdata/redis/package.json.baseline
@@ -20,8 +20,8 @@
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",

--- a/typescript/test/testdata/showcase/package.json.baseline
+++ b/typescript/test/testdata/showcase/package.json.baseline
@@ -20,8 +20,8 @@
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",

--- a/typescript/test/testdata/texttospeech/package.json.baseline
+++ b/typescript/test/testdata/texttospeech/package.json.baseline
@@ -20,8 +20,8 @@
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",

--- a/typescript/test/testdata/translate/package.json.baseline
+++ b/typescript/test/testdata/translate/package.json.baseline
@@ -20,8 +20,8 @@
     "lint": "gts check",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
-    "system-test": "mocha build/system-test",
-    "test": "mocha build/test"
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test"
   },
   "dependencies": {
     "google-gax": "^1.11.0"
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.0.0",
+    "c8": "^6.0.0",
     "gts": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",


### PR DESCRIPTION
Fixes #130.

This only affects the new libraries.