### PR TITLE
fix: use TypeScript 3.6 in the generated code

### DIFF
--- a/templates/typescript_gapic/package.json.njk
+++ b/templates/typescript_gapic/package.json.njk
@@ -56,7 +56,7 @@ limitations under the License.
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/typescript/test/testdata/keymanager/package.json.baseline
+++ b/typescript/test/testdata/keymanager/package.json.baseline
@@ -39,7 +39,7 @@
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/typescript/test/testdata/redis/package.json.baseline
+++ b/typescript/test/testdata/redis/package.json.baseline
@@ -39,7 +39,7 @@
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/typescript/test/testdata/showcase/package.json.baseline
+++ b/typescript/test/testdata/showcase/package.json.baseline
@@ -39,7 +39,7 @@
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/typescript/test/testdata/texttospeech/package.json.baseline
+++ b/typescript/test/testdata/texttospeech/package.json.baseline
@@ -39,7 +39,7 @@
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/typescript/test/testdata/translate/package.json.baseline
+++ b/typescript/test/testdata/translate/package.json.baseline
@@ -39,7 +39,7 @@
     "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },


### PR DESCRIPTION
As discussed in #161 - let's generate the code with TypeScript 3.6, because 3.7 breaks things.