### PR TITLE
fix: mapping proto types to TypeScript types

### DIFF
--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -79,8 +79,12 @@ limitations under the License.
  * @param { {{- convertParamType(oneComment.paramType) -}} } {{ printRequestField(oneComment) }}
 {%- endif -%}
 {%- set lines = oneComment.comments -%}
-{%- for line in lines %} 
- *  {{ line.replaceAll('*/', '* /') | safe}} 
+{%- for line in lines %}
+{%- if line.length > 0 %}
+ *  {{ line.replaceAll('*/', '* /') | safe}}
+{%- else %} 
+ *
+{%- endif -%}
 {%- endfor -%}
 {%- endfor -%}
 {%- endif %}
@@ -109,19 +113,19 @@ limitations under the License.
 
 {%- macro printReturnSimpleMethod(method) %}
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [{{- toMessageName(method.outputType) -}}]{@link {{ method.outputType.substring(1) }}}.
+ *   The first element of the array is an object representing {{ typeLink(method.outputType) }}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
 {%- endmacro -%}
 
 {%- macro printReturnPagingServerMethod(method) %}
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [{{- toMessageName(method.outputType) -}}]{@link {{ method.outputType.substring(1) }}}.
+ *   The first element of the array is an object representing {{ typeLink(method.outputType) }}.
  *   
  *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [{{- toMessageName(method.outputType) -}}]{@link {{ method.outputType.substring(1) }}} in a single response.
+ *   The first element is Array of {{ typeLink(method.outputType) }} in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [{{- toMessageName(method.outputType) -}}]{@link {{ method.outputType.substring(1) }}}.
+ *   an object representing {{ typeLink(method.outputType) }}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
 {%- endmacro -%}
@@ -129,21 +133,20 @@ limitations under the License.
 
 {%- macro printReturnClientStreamingMethod(method) %}
  * @returns {Stream} - A writable stream which accepts objects representing 
- * [{{- toMessageName(method.inputType) -}}]{@link {{ method.inputType.substring(1) }}}.
+ * {{ typeLink(method.inputType) }}.
 {%- endmacro -%}
 
 {%- macro printReturnBidiStreamingMethod(method) %}
  * @returns {Stream} 
  *   An object stream which is both readable and writable. It accepts objects
- *   representing [{{- toMessageName(method.inputType) -}}]{@link {{ method.inputType.substring(1) }}} for write() method, and
- *   will emit objects representing [{{- toMessageName(method.outputType) -}}]{@link {{ method.outputType.substring(1) }}} on 'data' event asynchronously.
+ *   representing {{ typeLink(method.inputType) }} for write() method, and
+ *   will emit objects representing {{ typeLink(method.outputType) }} on 'data' event asynchronously.
 {%- endmacro -%}
 
 {%- macro printReturnPageStream(method) %}
  * @returns {Stream}
- *   An object stream which emits an object representing [{{- toMessageName(method.pagingResponseType) -}}]{@link {{ method.pagingResponseType.substring(1) }}} on 'data' event.
+ *   An object stream which emits an object representing {{ typeLink(method.pagingResponseType) }} on 'data' event.
 {%- endmacro -%}
-
 
 {%- macro printRequestField(oneComment) %}
 {%- if oneComment.fieldBehavior and oneComment.fieldBehavior === 1 -%}
@@ -153,13 +156,22 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endif -%}
 {%- endmacro -%}
 
+{%- macro typeLink(type) -%}
+{%- set tsType = typescriptType(type) -%}
+{%- if tsType.length > 0 -%}
+{{ tsType }}
+{%- else -%}
+[{{- toMessageName(type) -}}]{@link {{ type.substring(1) }}}
+{%- endif -%}
+{%- endmacro -%}
+
 {%- macro toMessageName(messageType) -%}
 {%- set arr = messageType.split('.') %}
 {{- arr[arr.length - 1] -}}
 {%- endmacro -%}
 
 {%- macro initRequestWithHeaderParam(method) -%}
-            const request: protosTypes{{ toInterface(method.inputInterface) }} = {};
+            const request: {{ toInterface(method.inputInterface) }} = {};
 {%- if method.headerRequestParams.length > 1 %}
 {%- set chain = "request" -%}
 {%- for field in method.headerRequestParams.slice(0, -1) %}
@@ -170,20 +182,33 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endif %}
 {%- endmacro -%}
 
+{%- macro typescriptType(protobufType) -%}
+{#- protobufType can be an array (TYPE_STRING[]), hence .startsWith -#}
+{%- if protobufType.startsWith('TYPE_BYTES') -%}
+{%- set type = protobufType.replace('TYPE_BYTES', 'Buffer') -%}
+{%- elif protobufType.startsWith('TYPE_BOOL') -%}
+{%- set type = protobufType.replace('TYPE_BOOL', 'boolean') -%}
+{%- elif protobufType.startsWith('TYPE_STRING') -%}
+{%- set type = protobufType.replace('TYPE_STRING', 'string') -%}
+{%- elif protobufType.startsWith('TYPE_') -%}
+{#- any other type is essentially a number: int32, uint32, etc. -#}
+{%- set type = protobufType.replace(r/TYPE_\w+/, 'number') -%}
+{%- else -%}
+{%- set type = '' -%}
+{%- endif -%}
+{{ type }}
+{%- endmacro -%}
+
 {%- macro toInterface(type) -%}
+{%- set tsType = typescriptType(type) -%}
+{%- if tsType.length > 0 -%}
+{{ tsType }}
+{%- else -%}
 {%- set index = type.lastIndexOf('.') -%}
-{{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
+protosTypes{{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
+{%- endif -%}
 {%- endmacro -%}
 
 {%- macro convertParamType(paramType) -%}
-{%- if paramType.includes('TYPE_BYTES') %}
-{%- set type = paramType.replace('TYPE_BYTES', 'Buffer') %}
-{%- elif paramType.includes('TYPE_BOOL') %}
-{%- set type = paramType.replace('TYPE_BOOL', 'boolean') %}
-{%- elif paramType.includes('TYPE_STRING') %}
-{%- set type = paramType.replace('TYPE_STRING', 'string') %}
-{%- else %}
-{%- set type = 'number' %}
-{%- endif %}
-          {{- type -}}
+          {{- typescriptType(paramType) -}}
 {%- endmacro -%}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -331,34 +331,34 @@ export class {{ service.name }}Client {
 
 {%- for method in service.simpleMethods %}
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          protosTypes{{ util.toInterface(method.outputInterface) }},
-          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined,
+          {{ util.toInterface(method.outputInterface) }},
+          {{ util.toInterface(method.inputInterface) }}|undefined,
           {}|undefined>): void;
 /**
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          protosTypes{{ util.toInterface(method.outputInterface) }},
-          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
+          {{ util.toInterface(method.outputInterface) }},
+          {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-          protosTypes{{ util.toInterface(method.outputInterface) }},
-          protosTypes{{ util.toInterface(method.inputInterface) }}|undefined,
+          {{ util.toInterface(method.outputInterface) }},
+          {{ util.toInterface(method.inputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;
@@ -398,7 +398,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request?: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
     gax.CancellableStream{
     request = request || {}; 
@@ -409,24 +409,24 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       options: gax.CallOptions,
       callback: Callback<
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
   {{ method.name.toCamelCase() }}(
       callback: Callback<
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
 /**
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
       optionsOrCallback: gax.CallOptions|Callback<
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-        protosTypes{{ util.toInterface(method.outputInterface) }},
-        protosTypes{{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
+        {{ util.toInterface(method.outputInterface) }},
+        {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream {
     if (optionsOrCallback instanceof Function && callback === undefined) {
         callback = optionsOrCallback;
@@ -439,34 +439,34 @@ export class {{ service.name }}Client {
 {% endfor %}
 {%- for method in service.longRunning %}
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        LROperation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType) }}>,
-        protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
+        LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType) }}>,
+        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          LROperation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
-          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
+          LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          {{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>): void;
 /**
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          LROperation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType)}}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
-          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined>,
+          LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType)}}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
-          LROperation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
-          protosTypes{{ util.toInterface(method.outputInterface) }}|undefined,
+          LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
+          {{ util.toInterface(method.outputInterface) }}|undefined,
           {}|undefined>):
       Promise<[
-        LROperation<protosTypes{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, protosTypes{{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
-        protosTypes{{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
+        LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
+        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;
@@ -492,37 +492,37 @@ export class {{ service.name }}Client {
 {%- endfor %}
 {%- for method in service.paging %}
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
       Promise<[
-        protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
-        protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
-        protosTypes{{ util.toInterface(method.outputInterface) }}
+        {{ util.toInterface(method.pagingResponseType) }}[],
+        {{ util.toInterface(method.inputInterface) }}|null,
+        {{ util.toInterface(method.outputInterface) }}
       ]>;
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       options: gax.CallOptions,
       callback: Callback<
-          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
-          protosTypes{{ util.toInterface(method.inputInterface) }}|null,
-          protosTypes{{ util.toInterface(method.outputInterface) }}>): void;
+          {{ util.toInterface(method.pagingResponseType) }}[],
+          {{ util.toInterface(method.inputInterface) }}|null,
+          {{ util.toInterface(method.outputInterface) }}>): void;
 /**
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: gax.CallOptions|Callback<
-          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
-          protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
-          protosTypes{{ util.toInterface(method.outputInterface) }}>,
+          {{ util.toInterface(method.pagingResponseType) }}[],
+          {{ util.toInterface(method.inputInterface) }}|null,
+          {{ util.toInterface(method.outputInterface) }}>,
       callback?: Callback<
-          protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
-          protosTypes{{ util.toInterface(method.inputInterface) }}|null,
-          protosTypes{{ util.toInterface(method.outputInterface) }}>):
+          {{ util.toInterface(method.pagingResponseType) }}[],
+          {{ util.toInterface(method.inputInterface) }}|null,
+          {{ util.toInterface(method.outputInterface) }}>):
       Promise<[
-        protosTypes{{ util.toInterface(method.pagingResponseType) }}[],
-        protosTypes{{ util.toInterface(method.inputInterface) }}|null, 
-        protosTypes{{ util.toInterface(method.outputInterface) }}
+        {{ util.toInterface(method.pagingResponseType) }}[],
+        {{ util.toInterface(method.inputInterface) }}|null,
+        {{ util.toInterface(method.outputInterface) }}
       ]>|void {
     request = request || {};
     let options: gax.CallOptions;
@@ -550,7 +550,7 @@ export class {{ service.name }}Client {
 {{- util.printCommentsPageStream(method) }}
  */
   {{ method.name.toCamelCase() }}Stream(
-      request?: protosTypes{{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions | {}):
     Transform{
     request = request || {}; 

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -330,7 +330,15 @@ function pagingResponseType(
   method: MethodDescriptorProto
 ) {
   const field = pagingField(messages, method);
-  return field?.typeName; //.google.showcase.v1beta1.EchoResponse
+  if (!field || !field.type) {
+    return undefined;
+  }
+  if (
+    field.type === plugin.google.protobuf.FieldDescriptorProto.Type.TYPE_MESSAGE
+  ) {
+    return field.typeName; //.google.showcase.v1beta1.EchoResponse
+  }
+  return plugin.google.protobuf.FieldDescriptorProto.Type[field.type];
 }
 
 export function getHeaderParams(rule: plugin.google.api.IHttpRule): string[] {

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -275,7 +275,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -335,7 +335,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The [name][google.cloud.kms.v1.CryptoKey.name] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -394,7 +394,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -456,8 +456,8 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   The [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] public key to 
+ * @param {string} request.name
+ *   The [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] public key to
  *   get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -516,7 +516,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The [name][google.cloud.kms.v1.ImportJob.name] of the [ImportJob][google.cloud.kms.v1.ImportJob] to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -575,13 +575,13 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the location associated with the 
+ * @param {string} request.parent
+ *   Required. The resource name of the location associated with the
  *   [KeyRings][google.cloud.kms.v1.KeyRing], in the format `projects/* /locations/*`.
- * @param {string} request.keyRingId 
- *   Required. It must be unique within a location and match the regular 
+ * @param {string} request.keyRingId
+ *   Required. It must be unique within a location and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
- * @param {google.cloud.kms.v1.KeyRing} request.keyRing 
+ * @param {google.cloud.kms.v1.KeyRing} request.keyRing
  *   A [KeyRing][google.cloud.kms.v1.KeyRing] with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -644,19 +644,19 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The [name][google.cloud.kms.v1.KeyRing.name] of the KeyRing associated with the 
+ * @param {string} request.parent
+ *   Required. The [name][google.cloud.kms.v1.KeyRing.name] of the KeyRing associated with the
  *   [CryptoKeys][google.cloud.kms.v1.CryptoKey].
- * @param {string} request.cryptoKeyId 
- *   Required. It must be unique within a KeyRing and match the regular 
+ * @param {string} request.cryptoKeyId
+ *   Required. It must be unique within a KeyRing and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
- * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey 
+ * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
  *   A [CryptoKey][google.cloud.kms.v1.CryptoKey] with initial field values.
- * @param {boolean} request.skipInitialVersionCreation 
- *   If set to true, the request will create a [CryptoKey][google.cloud.kms.v1.CryptoKey] without any 
- *   [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion]. You must manually call 
- *   [CreateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion] or 
- *   [ImportCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion] 
+ * @param {boolean} request.skipInitialVersionCreation
+ *   If set to true, the request will create a [CryptoKey][google.cloud.kms.v1.CryptoKey] without any
+ *   [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion]. You must manually call
+ *   [CreateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion] or
+ *   [ImportCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]
  *   before you can use this [CryptoKey][google.cloud.kms.v1.CryptoKey].
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -719,10 +719,10 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The [name][google.cloud.kms.v1.CryptoKey.name] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] associated with 
+ * @param {string} request.parent
+ *   Required. The [name][google.cloud.kms.v1.CryptoKey.name] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] associated with
  *   the [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].
- * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion
  *   A [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -785,35 +785,35 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The [name][google.cloud.kms.v1.CryptoKey.name] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to 
+ * @param {string} request.parent
+ *   Required. The [name][google.cloud.kms.v1.CryptoKey.name] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to
  *   be imported into.
- * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm} request.algorithm 
- *   Required. The [algorithm][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm] of 
- *   the key being imported. This does not need to match the 
- *   [version_template][google.cloud.kms.v1.CryptoKey.version_template] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] this 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm} request.algorithm
+ *   Required. The [algorithm][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm] of
+ *   the key being imported. This does not need to match the
+ *   [version_template][google.cloud.kms.v1.CryptoKey.version_template] of the [CryptoKey][google.cloud.kms.v1.CryptoKey] this
  *   version imports into.
- * @param {string} request.importJob 
- *   Required. The [name][google.cloud.kms.v1.ImportJob.name] of the [ImportJob][google.cloud.kms.v1.ImportJob] that was used to 
+ * @param {string} request.importJob
+ *   Required. The [name][google.cloud.kms.v1.ImportJob.name] of the [ImportJob][google.cloud.kms.v1.ImportJob] that was used to
  *   wrap this key material.
- * @param {Buffer} request.rsaAesWrappedKey 
- *   Wrapped key material produced with 
- *   [RSA_OAEP_3072_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256] 
- *   or 
+ * @param {Buffer} request.rsaAesWrappedKey
+ *   Wrapped key material produced with
+ *   [RSA_OAEP_3072_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256]
+ *   or
  *   [RSA_OAEP_4096_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256]. 
- *   
- *   This field contains the concatenation of two wrapped keys: 
- *   <ol> 
- *     <li>An ephemeral AES-256 wrapping key wrapped with the 
- *         [public_key][google.cloud.kms.v1.ImportJob.public_key] using RSAES-OAEP with SHA-1, 
- *         MGF1 with SHA-1, and an empty label. 
- *     </li> 
- *     <li>The key to be imported, wrapped with the ephemeral AES-256 key 
- *         using AES-KWP (RFC 5649). 
- *     </li> 
+ *
+ *   This field contains the concatenation of two wrapped keys:
+ *   <ol>
+ *     <li>An ephemeral AES-256 wrapping key wrapped with the
+ *         [public_key][google.cloud.kms.v1.ImportJob.public_key] using RSAES-OAEP with SHA-1,
+ *         MGF1 with SHA-1, and an empty label.
+ *     </li>
+ *     <li>The key to be imported, wrapped with the ephemeral AES-256 key
+ *         using AES-KWP (RFC 5649).
+ *     </li>
  *   </ol> 
- *   
- *   This format is the same as the format produced by PKCS#11 mechanism 
+ *
+ *   This format is the same as the format produced by PKCS#11 mechanism
  *   CKM_RSA_AES_KEY_WRAP.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -874,13 +874,13 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] associated with the 
+ * @param {string} request.parent
+ *   Required. The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] associated with the
  *   [ImportJobs][google.cloud.kms.v1.ImportJob].
- * @param {string} request.importJobId 
- *   Required. It must be unique within a KeyRing and match the regular 
+ * @param {string} request.importJobId
+ *   Required. It must be unique within a KeyRing and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
- * @param {google.cloud.kms.v1.ImportJob} request.importJob 
+ * @param {google.cloud.kms.v1.ImportJob} request.importJob
  *   Required. An [ImportJob][google.cloud.kms.v1.ImportJob] with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -939,9 +939,9 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey 
+ * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
  *   [CryptoKey][google.cloud.kms.v1.CryptoKey] with updated values.
- * @param {google.protobuf.FieldMask} request.updateMask 
+ * @param {google.protobuf.FieldMask} request.updateMask
  *   Required list of fields to be updated in this request.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1006,9 +1006,9 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion
  *   [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with updated values.
- * @param {google.protobuf.FieldMask} request.updateMask 
+ * @param {google.protobuf.FieldMask} request.updateMask
  *   Required list of fields to be updated in this request.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1069,30 +1069,30 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] or [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] 
+ * @param {string} request.name
+ *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] or [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
  *   to use for encryption. 
- *   
- *   If a [CryptoKey][google.cloud.kms.v1.CryptoKey] is specified, the server will use its 
+ *
+ *   If a [CryptoKey][google.cloud.kms.v1.CryptoKey] is specified, the server will use its
  *   [primary version][google.cloud.kms.v1.CryptoKey.primary].
- * @param {Buffer} request.plaintext 
+ * @param {Buffer} request.plaintext
  *   Required. The data to encrypt. Must be no larger than 64KiB. 
- *   
- *   The maximum size depends on the key version's 
- *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For 
- *   [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE] keys, the plaintext must be no larger 
- *   than 64KiB. For [HSM][google.cloud.kms.v1.ProtectionLevel.HSM] keys, the combined length of the 
- *   plaintext and additional_authenticated_data fields must be no larger than 
+ *
+ *   The maximum size depends on the key version's
+ *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For
+ *   [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE] keys, the plaintext must be no larger
+ *   than 64KiB. For [HSM][google.cloud.kms.v1.ProtectionLevel.HSM] keys, the combined length of the
+ *   plaintext and additional_authenticated_data fields must be no larger than
  *   8KiB.
- * @param {Buffer} request.additionalAuthenticatedData 
- *   Optional data that, if specified, must also be provided during decryption 
+ * @param {Buffer} request.additionalAuthenticatedData
+ *   Optional data that, if specified, must also be provided during decryption
  *   through [DecryptRequest.additional_authenticated_data][google.cloud.kms.v1.DecryptRequest.additional_authenticated_data]. 
- *   
- *   The maximum size depends on the key version's 
- *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For 
- *   [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE] keys, the AAD must be no larger than 
- *   64KiB. For [HSM][google.cloud.kms.v1.ProtectionLevel.HSM] keys, the combined length of the 
- *   plaintext and additional_authenticated_data fields must be no larger than 
+ *
+ *   The maximum size depends on the key version's
+ *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For
+ *   [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE] keys, the AAD must be no larger than
+ *   64KiB. For [HSM][google.cloud.kms.v1.ProtectionLevel.HSM] keys, the combined length of the
+ *   plaintext and additional_authenticated_data fields must be no larger than
  *   8KiB.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1152,14 +1152,14 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to use for decryption. 
+ * @param {string} request.name
+ *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to use for decryption.
  *   The server will choose the appropriate version.
- * @param {Buffer} request.ciphertext 
- *   Required. The encrypted data originally returned in 
+ * @param {Buffer} request.ciphertext
+ *   Required. The encrypted data originally returned in
  *   [EncryptResponse.ciphertext][google.cloud.kms.v1.EncryptResponse.ciphertext].
- * @param {Buffer} request.additionalAuthenticatedData 
- *   Optional data that must match the data originally supplied in 
+ * @param {Buffer} request.additionalAuthenticatedData
+ *   Optional data that must match the data originally supplied in
  *   [EncryptRequest.additional_authenticated_data][google.cloud.kms.v1.EncryptRequest.additional_authenticated_data].
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1220,11 +1220,11 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   Required. The resource name of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use for signing.
- * @param {google.cloud.kms.v1.Digest} request.digest 
- *   Required. The digest of the data to sign. The digest must be produced with 
- *   the same digest algorithm as specified by the key version's 
+ * @param {google.cloud.kms.v1.Digest} request.digest
+ *   Required. The digest of the data to sign. The digest must be produced with
+ *   the same digest algorithm as specified by the key version's
  *   [algorithm][google.cloud.kms.v1.CryptoKeyVersion.algorithm].
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1285,11 +1285,11 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. The resource name of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use for 
+ * @param {string} request.name
+ *   Required. The resource name of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use for
  *   decryption.
- * @param {Buffer} request.ciphertext 
- *   Required. The data encrypted with the named [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s public 
+ * @param {Buffer} request.ciphertext
+ *   Required. The data encrypted with the named [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s public
  *   key using OAEP.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1350,9 +1350,9 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to update.
- * @param {string} request.cryptoKeyVersionId 
+ * @param {string} request.cryptoKeyVersionId
  *   The id of the child [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use as primary.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1422,7 +1422,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The resource name of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to destroy.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1487,7 +1487,7 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   The resource name of the [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to restore.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1533,7 +1533,7 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.kms.v1.IKeyRing[],
-        protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null,
         protosTypes.google.cloud.kms.v1.IListKeyRingsResponse
       ]>;
   listKeyRings(
@@ -1548,21 +1548,21 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the location associated with the 
+ * @param {string} request.parent
+ *   Required. The resource name of the location associated with the
  *   [KeyRings][google.cloud.kms.v1.KeyRing], in the format `projects/* /locations/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [KeyRings][google.cloud.kms.v1.KeyRing] to include in the 
- *   response.  Further [KeyRings][google.cloud.kms.v1.KeyRing] can subsequently be obtained by 
- *   including the [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [KeyRings][google.cloud.kms.v1.KeyRing] to include in the
+ *   response.  Further [KeyRings][google.cloud.kms.v1.KeyRing] can subsequently be obtained by
+ *   including the [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token] in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token].
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1581,7 +1581,7 @@ export class KeyManagementServiceClient {
       request: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.kms.v1.IKeyRing[],
-          protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null, 
+          protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null,
           protosTypes.google.cloud.kms.v1.IListKeyRingsResponse>,
       callback?: Callback<
           protosTypes.google.cloud.kms.v1.IKeyRing[],
@@ -1589,7 +1589,7 @@ export class KeyManagementServiceClient {
           protosTypes.google.cloud.kms.v1.IListKeyRingsResponse>):
       Promise<[
         protosTypes.google.cloud.kms.v1.IKeyRing[],
-        protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListKeyRingsRequest|null,
         protosTypes.google.cloud.kms.v1.IListKeyRingsResponse
       ]>|void {
     request = request || {};
@@ -1627,21 +1627,21 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the location associated with the 
+ * @param {string} request.parent
+ *   Required. The resource name of the location associated with the
  *   [KeyRings][google.cloud.kms.v1.KeyRing], in the format `projects/* /locations/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [KeyRings][google.cloud.kms.v1.KeyRing] to include in the 
- *   response.  Further [KeyRings][google.cloud.kms.v1.KeyRing] can subsequently be obtained by 
- *   including the [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [KeyRings][google.cloud.kms.v1.KeyRing] to include in the
+ *   response.  Further [KeyRings][google.cloud.kms.v1.KeyRing] can subsequently be obtained by
+ *   including the [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token] in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListKeyRingsResponse.next_page_token][google.cloud.kms.v1.ListKeyRingsResponse.next_page_token].
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1665,7 +1665,7 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.kms.v1.ICryptoKey[],
-        protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null,
         protosTypes.google.cloud.kms.v1.IListCryptoKeysResponse
       ]>;
   listCryptoKeys(
@@ -1680,23 +1680,23 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [CryptoKeys][google.cloud.kms.v1.CryptoKey] to include in the 
- *   response.  Further [CryptoKeys][google.cloud.kms.v1.CryptoKey] can subsequently be obtained by 
- *   including the [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [CryptoKeys][google.cloud.kms.v1.CryptoKey] to include in the
+ *   response.  Further [CryptoKeys][google.cloud.kms.v1.CryptoKey] can subsequently be obtained by
+ *   including the [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token] in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token].
- * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView
  *   The fields of the primary version to include in the response.
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1715,7 +1715,7 @@ export class KeyManagementServiceClient {
       request: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.kms.v1.ICryptoKey[],
-          protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null, 
+          protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null,
           protosTypes.google.cloud.kms.v1.IListCryptoKeysResponse>,
       callback?: Callback<
           protosTypes.google.cloud.kms.v1.ICryptoKey[],
@@ -1723,7 +1723,7 @@ export class KeyManagementServiceClient {
           protosTypes.google.cloud.kms.v1.IListCryptoKeysResponse>):
       Promise<[
         protosTypes.google.cloud.kms.v1.ICryptoKey[],
-        protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest|null,
         protosTypes.google.cloud.kms.v1.IListCryptoKeysResponse
       ]>|void {
     request = request || {};
@@ -1761,23 +1761,23 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [CryptoKeys][google.cloud.kms.v1.CryptoKey] to include in the 
- *   response.  Further [CryptoKeys][google.cloud.kms.v1.CryptoKey] can subsequently be obtained by 
- *   including the [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [CryptoKeys][google.cloud.kms.v1.CryptoKey] to include in the
+ *   response.  Further [CryptoKeys][google.cloud.kms.v1.CryptoKey] can subsequently be obtained by
+ *   including the [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token] in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListCryptoKeysResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token].
- * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView
  *   The fields of the primary version to include in the response.
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1801,7 +1801,7 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.kms.v1.ICryptoKeyVersion[],
-        protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
         protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsResponse
       ]>;
   listCryptoKeyVersions(
@@ -1816,24 +1816,24 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to list, in the format
  *   `projects/* /locations/* /keyRings/* /cryptoKeys/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] to 
- *   include in the response. Further [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] can 
- *   subsequently be obtained by including the 
- *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token] in a subsequent request. 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] to
+ *   include in the response. Further [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] can
+ *   subsequently be obtained by including the
+ *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token] in a subsequent request.
  *   If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token].
- * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view
  *   The fields to include in the response.
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1852,7 +1852,7 @@ export class KeyManagementServiceClient {
       request: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.kms.v1.ICryptoKeyVersion[],
-          protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null, 
+          protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
           protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsResponse>,
       callback?: Callback<
           protosTypes.google.cloud.kms.v1.ICryptoKeyVersion[],
@@ -1860,7 +1860,7 @@ export class KeyManagementServiceClient {
           protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsResponse>):
       Promise<[
         protosTypes.google.cloud.kms.v1.ICryptoKeyVersion[],
-        protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
         protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsResponse
       ]>|void {
     request = request || {};
@@ -1898,24 +1898,24 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] to list, in the format
  *   `projects/* /locations/* /keyRings/* /cryptoKeys/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] to 
- *   include in the response. Further [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] can 
- *   subsequently be obtained by including the 
- *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token] in a subsequent request. 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] to
+ *   include in the response. Further [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] can
+ *   subsequently be obtained by including the
+ *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token] in a subsequent request.
  *   If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListCryptoKeyVersionsResponse.next_page_token][google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token].
- * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view 
+ * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view
  *   The fields to include in the response.
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1939,7 +1939,7 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.kms.v1.IImportJob[],
-        protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null,
         protosTypes.google.cloud.kms.v1.IListImportJobsResponse
       ]>;
   listImportJobs(
@@ -1954,21 +1954,21 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [ImportJobs][google.cloud.kms.v1.ImportJob] to include in the 
- *   response. Further [ImportJobs][google.cloud.kms.v1.ImportJob] can subsequently be obtained by 
- *   including the [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [ImportJobs][google.cloud.kms.v1.ImportJob] to include in the
+ *   response. Further [ImportJobs][google.cloud.kms.v1.ImportJob] can subsequently be obtained by
+ *   including the [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token] in a subsequent
  *   request. If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token].
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1987,7 +1987,7 @@ export class KeyManagementServiceClient {
       request: protosTypes.google.cloud.kms.v1.IListImportJobsRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.kms.v1.IImportJob[],
-          protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null, 
+          protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null,
           protosTypes.google.cloud.kms.v1.IListImportJobsResponse>,
       callback?: Callback<
           protosTypes.google.cloud.kms.v1.IImportJob[],
@@ -1995,7 +1995,7 @@ export class KeyManagementServiceClient {
           protosTypes.google.cloud.kms.v1.IListImportJobsResponse>):
       Promise<[
         protosTypes.google.cloud.kms.v1.IImportJob[],
-        protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null, 
+        protosTypes.google.cloud.kms.v1.IListImportJobsRequest|null,
         protosTypes.google.cloud.kms.v1.IListImportJobsResponse
       ]>|void {
     request = request || {};
@@ -2033,21 +2033,21 @@ export class KeyManagementServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format 
+ * @param {string} request.parent
+ *   Required. The resource name of the [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
- * @param {number} request.pageSize 
- *   Optional limit on the number of [ImportJobs][google.cloud.kms.v1.ImportJob] to include in the 
- *   response. Further [ImportJobs][google.cloud.kms.v1.ImportJob] can subsequently be obtained by 
- *   including the [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token] in a subsequent 
+ * @param {number} request.pageSize
+ *   Optional limit on the number of [ImportJobs][google.cloud.kms.v1.ImportJob] to include in the
+ *   response. Further [ImportJobs][google.cloud.kms.v1.ImportJob] can subsequently be obtained by
+ *   including the [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token] in a subsequent
  *   request. If unspecified, the server will pick an appropriate default.
- * @param {string} request.pageToken 
- *   Optional pagination token, returned earlier via 
+ * @param {string} request.pageToken
+ *   Optional pagination token, returned earlier via
  *   [ListImportJobsResponse.next_page_token][google.cloud.kms.v1.ListImportJobsResponse.next_page_token].
- * @param {string} request.filter 
+ * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
- * @param {string} request.orderBy 
- *   Optional. Specify how the results should be sorted. If not specified, the 
+ * @param {string} request.orderBy
+ *   Optional. Specify how the results should be sorted. If not specified, the
  *   results will be sorted in the default order.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -348,9 +348,9 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. Redis instance resource name using the form: 
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}` 
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  *   where `location_id` refers to a GCP region.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -421,20 +421,20 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the instance location using the form: 
- *       `projects/{project_id}/locations/{location_id}` 
+ * @param {string} request.parent
+ *   Required. The resource name of the instance location using the form:
+ *       `projects/{project_id}/locations/{location_id}`
  *   where `location_id` refers to a GCP region.
- * @param {string} request.instanceId 
- *   Required. The logical name of the Redis instance in the customer project 
+ * @param {string} request.instanceId
+ *   Required. The logical name of the Redis instance in the customer project
  *   with the following restrictions: 
- *   
- *   * Must contain only lowercase letters, numbers, and hyphens. 
- *   * Must start with a letter. 
- *   * Must be between 1-40 characters. 
- *   * Must end with a number or a letter. 
+ *
+ *   * Must contain only lowercase letters, numbers, and hyphens.
+ *   * Must start with a letter.
+ *   * Must be between 1-40 characters.
+ *   * Must end with a number or a letter.
  *   * Must be unique within the customer project / location
- * @param {google.cloud.redis.v1beta1.Instance} request.instance 
+ * @param {google.cloud.redis.v1beta1.Instance} request.instance
  *   Required. A Redis [Instance] resource
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -497,17 +497,17 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {google.protobuf.FieldMask} request.updateMask 
- *   Required. Mask of fields to update. At least one path must be supplied in 
- *   this field. The elements of the repeated paths field may only include these 
+ * @param {google.protobuf.FieldMask} request.updateMask
+ *   Required. Mask of fields to update. At least one path must be supplied in
+ *   this field. The elements of the repeated paths field may only include these
  *   fields from [Instance][google.cloud.redis.v1beta1.Instance]: 
- *   
- *    *   `displayName` 
- *    *   `labels` 
- *    *   `memorySizeGb` 
+ *
+ *    *   `displayName`
+ *    *   `labels`
+ *    *   `memorySizeGb`
  *    *   `redisConfig`
- * @param {google.cloud.redis.v1beta1.Instance} request.instance 
- *   Required. Update description. 
+ * @param {google.cloud.redis.v1beta1.Instance} request.instance
+ *   Required. Update description.
  *   Only fields specified in update_mask are updated.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -573,11 +573,11 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. Redis instance resource name using the form: 
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}` 
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  *   where `location_id` refers to a GCP region.
- * @param {google.cloud.redis.v1beta1.InputConfig} request.inputConfig 
+ * @param {google.cloud.redis.v1beta1.InputConfig} request.inputConfig
  *   Required. Specify data to be imported.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -641,11 +641,11 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. Redis instance resource name using the form: 
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}` 
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  *   where `location_id` refers to a GCP region.
- * @param {google.cloud.redis.v1beta1.OutputConfig} request.outputConfig 
+ * @param {google.cloud.redis.v1beta1.OutputConfig} request.outputConfig
  *   Required. Specify data to be exported.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -705,12 +705,12 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. Redis instance resource name using the form: 
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}` 
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  *   where `location_id` refers to a GCP region.
- * @param {google.cloud.redis.v1beta1.FailoverInstanceRequest.DataProtectionMode} [request.dataProtectionMode] 
- *   Optional. Available data protection modes that the user can choose. If it's 
+ * @param {google.cloud.redis.v1beta1.FailoverInstanceRequest.DataProtectionMode} [request.dataProtectionMode]
+ *   Optional. Available data protection modes that the user can choose. If it's
  *   unspecified, data protection mode will be LIMITED_DATA_LOSS by default.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -770,9 +770,9 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
- *   Required. Redis instance resource name using the form: 
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}` 
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  *   where `location_id` refers to a GCP region.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -817,7 +817,7 @@ export class CloudRedisClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.redis.v1beta1.IInstance[],
-        protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null, 
+        protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null,
         protosTypes.google.cloud.redis.v1beta1.IListInstancesResponse
       ]>;
   listInstances(
@@ -839,20 +839,20 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the instance location using the form: 
- *       `projects/{project_id}/locations/{location_id}` 
+ * @param {string} request.parent
+ *   Required. The resource name of the instance location using the form:
+ *       `projects/{project_id}/locations/{location_id}`
  *   where `location_id` refers to a GCP region.
- * @param {number} request.pageSize 
+ * @param {number} request.pageSize
  *   The maximum number of items to return. 
- *   
- *   If not specified, a default value of 1000 will be used by the service. 
- *   Regardless of the page_size value, the response may include a partial list 
- *   and a caller should only rely on response's 
- *   [next_page_token][CloudRedis.ListInstancesResponse.next_page_token] 
+ *
+ *   If not specified, a default value of 1000 will be used by the service.
+ *   Regardless of the page_size value, the response may include a partial list
+ *   and a caller should only rely on response's
+ *   [next_page_token][CloudRedis.ListInstancesResponse.next_page_token]
  *   to determine if there are more instances left to be queried.
- * @param {string} request.pageToken 
- *   The next_page_token value returned from a previous List request, 
+ * @param {string} request.pageToken
+ *   The next_page_token value returned from a previous List request,
  *   if any.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -871,7 +871,7 @@ export class CloudRedisClient {
       request: protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.redis.v1beta1.IInstance[],
-          protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null, 
+          protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null,
           protosTypes.google.cloud.redis.v1beta1.IListInstancesResponse>,
       callback?: Callback<
           protosTypes.google.cloud.redis.v1beta1.IInstance[],
@@ -879,7 +879,7 @@ export class CloudRedisClient {
           protosTypes.google.cloud.redis.v1beta1.IListInstancesResponse>):
       Promise<[
         protosTypes.google.cloud.redis.v1beta1.IInstance[],
-        protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null, 
+        protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest|null,
         protosTypes.google.cloud.redis.v1beta1.IListInstancesResponse
       ]>|void {
     request = request || {};
@@ -917,20 +917,20 @@ export class CloudRedisClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. The resource name of the instance location using the form: 
- *       `projects/{project_id}/locations/{location_id}` 
+ * @param {string} request.parent
+ *   Required. The resource name of the instance location using the form:
+ *       `projects/{project_id}/locations/{location_id}`
  *   where `location_id` refers to a GCP region.
- * @param {number} request.pageSize 
+ * @param {number} request.pageSize
  *   The maximum number of items to return. 
- *   
- *   If not specified, a default value of 1000 will be used by the service. 
- *   Regardless of the page_size value, the response may include a partial list 
- *   and a caller should only rely on response's 
- *   [next_page_token][CloudRedis.ListInstancesResponse.next_page_token] 
+ *
+ *   If not specified, a default value of 1000 will be used by the service.
+ *   Regardless of the page_size value, the response may include a partial list
+ *   and a caller should only rely on response's
+ *   [next_page_token][CloudRedis.ListInstancesResponse.next_page_token]
  *   to determine if there are more instances left to be queried.
- * @param {string} request.pageToken 
- *   The next_page_token value returned from a previous List request, 
+ * @param {string} request.pageToken
+ *   The next_page_token value returned from a previous List request,
  *   if any.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -288,9 +288,9 @@ export class EchoClient {
 /**
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.content 
+ * @param {string} request.content
  *   The content to be echoed by the server.
- * @param {google.rpc.Status} request.error 
+ * @param {google.rpc.Status} request.error
  *   The error to be thrown by the server.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -330,9 +330,9 @@ export class EchoClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.content 
+ * @param {string} request.content
  *   The content that will be split into words and returned on the stream.
- * @param {google.rpc.Status} request.error 
+ * @param {google.rpc.Status} request.error
  *   The error that is thrown after all words are sent on the stream.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -432,14 +432,14 @@ export class EchoClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {google.protobuf.Timestamp} request.endTime 
+ * @param {google.protobuf.Timestamp} request.endTime
  *   The time that this operation will complete.
- * @param {google.protobuf.Duration} request.ttl 
+ * @param {google.protobuf.Duration} request.ttl
  *   The duration of this operation.
- * @param {google.rpc.Status} request.error 
- *   The error that will be returned by the server. If this code is specified 
+ * @param {google.rpc.Status} request.error
+ *   The error that will be returned by the server. If this code is specified
  *   to be the OK rpc code, an empty response will be returned.
- * @param {google.showcase.v1beta1.WaitResponse} request.success 
+ * @param {google.showcase.v1beta1.WaitResponse} request.success
  *   The response to be returned on operation completion.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -477,7 +477,7 @@ export class EchoClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.showcase.v1beta1.IEchoResponse[],
-        protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null, 
+        protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null,
         protosTypes.google.showcase.v1beta1.IPagedExpandResponse
       ]>;
   pagedExpand(
@@ -493,11 +493,11 @@ export class EchoClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.content 
+ * @param {string} request.content
  *   The string to expand.
- * @param {number} request.pageSize 
+ * @param {number} request.pageSize
  *   The amount of words to returned in each page.
- * @param {string} request.pageToken 
+ * @param {string} request.pageToken
  *   The position of the page to be returned.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -516,7 +516,7 @@ export class EchoClient {
       request: protosTypes.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.showcase.v1beta1.IEchoResponse[],
-          protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null, 
+          protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null,
           protosTypes.google.showcase.v1beta1.IPagedExpandResponse>,
       callback?: Callback<
           protosTypes.google.showcase.v1beta1.IEchoResponse[],
@@ -524,7 +524,7 @@ export class EchoClient {
           protosTypes.google.showcase.v1beta1.IPagedExpandResponse>):
       Promise<[
         protosTypes.google.showcase.v1beta1.IEchoResponse[],
-        protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null, 
+        protosTypes.google.showcase.v1beta1.IPagedExpandRequest|null,
         protosTypes.google.showcase.v1beta1.IPagedExpandResponse
       ]>|void {
     request = request || {};
@@ -555,11 +555,11 @@ export class EchoClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.content 
+ * @param {string} request.content
  *   The string to expand.
- * @param {number} request.pageSize 
+ * @param {number} request.pageSize
  *   The amount of words to returned in each page.
- * @param {string} request.pageToken 
+ * @param {string} request.pageToken
  *   The position of the page to be returned.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -249,14 +249,14 @@ export class TextToSpeechClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} [request.languageCode] 
- *   Optional. Recommended. 
- *   [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag. If 
- *   specified, the ListVoices call will only return voices that can be used to 
- *   synthesize this language_code. E.g. when specifying "en-NZ", you will get 
- *   supported "en-*" voices; when specifying "no", you will get supported 
- *   "no-*" (Norwegian) and "nb-*" (Norwegian Bokmal) voices; specifying "zh" 
- *   will also get supported "cmn-*" voices; specifying "zh-hk" will also get 
+ * @param {string} [request.languageCode]
+ *   Optional. Recommended.
+ *   [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag. If
+ *   specified, the ListVoices call will only return voices that can be used to
+ *   synthesize this language_code. E.g. when specifying "en-NZ", you will get
+ *   supported "en-*" voices; when specifying "no", you will get supported
+ *   "no-*" (Norwegian) and "nb-*" (Norwegian Bokmal) voices; specifying "zh"
+ *   will also get supported "cmn-*" voices; specifying "zh-hk" will also get
  *   supported "yue-*" voices.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -309,11 +309,11 @@ export class TextToSpeechClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {google.cloud.texttospeech.v1.SynthesisInput} request.input 
+ * @param {google.cloud.texttospeech.v1.SynthesisInput} request.input
  *   Required. The Synthesizer requires either plain text or SSML as input.
- * @param {google.cloud.texttospeech.v1.VoiceSelectionParams} request.voice 
+ * @param {google.cloud.texttospeech.v1.VoiceSelectionParams} request.voice
  *   Required. The desired voice of the synthesized audio.
- * @param {google.cloud.texttospeech.v1.AudioConfig} request.audioConfig 
+ * @param {google.cloud.texttospeech.v1.AudioConfig} request.audioConfig
  *   Required. The configuration of the synthesized audio.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -311,67 +311,67 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string[]} request.contents 
- *   Required. The content of the input in string format. 
- *   We recommend the total content be less than 30k codepoints. 
+ * @param {string[]} request.contents
+ *   Required. The content of the input in string format.
+ *   We recommend the total content be less than 30k codepoints.
  *   Use BatchTranslateText for larger text.
- * @param {string} [request.mimeType] 
- *   Optional. The format of the source text, for example, "text/html", 
+ * @param {string} [request.mimeType]
+ *   Optional. The format of the source text, for example, "text/html",
  *    "text/plain". If left blank, the MIME type defaults to "text/html".
- * @param {string} [request.sourceLanguageCode] 
- *   Optional. The BCP-47 language code of the input text if 
- *   known, for example, "en-US" or "sr-Latn". Supported language codes are 
- *   listed in Language Support. If the source language isn't specified, the API 
- *   attempts to identify the source language automatically and returns the 
+ * @param {string} [request.sourceLanguageCode]
+ *   Optional. The BCP-47 language code of the input text if
+ *   known, for example, "en-US" or "sr-Latn". Supported language codes are
+ *   listed in Language Support. If the source language isn't specified, the API
+ *   attempts to identify the source language automatically and returns the
  *   source language within the response.
- * @param {string} request.targetLanguageCode 
- *   Required. The BCP-47 language code to use for translation of the input 
+ * @param {string} request.targetLanguageCode
+ *   Required. The BCP-47 language code to use for translation of the input
  *   text, set to one of the language codes listed in Language Support.
- * @param {string} request.parent 
- *   Required. Project or location to make a call. Must refer to a caller's 
+ * @param {string} request.parent
+ *   Required. Project or location to make a call. Must refer to a caller's
  *   project. 
- *   
- *   Format: `projects/{project-id}` or 
+ *
+ *   Format: `projects/{project-id}` or
  *   `projects/{project-id}/locations/{location-id}`. 
- *   
- *   For global calls, use `projects/{project-id}/locations/global` or 
+ *
+ *   For global calls, use `projects/{project-id}/locations/global` or
  *   `projects/{project-id}`. 
- *   
- *   Non-global location is required for requests using AutoML models or 
+ *
+ *   Non-global location is required for requests using AutoML models or
  *   custom glossaries. 
- *   
- *   Models and glossaries must be within the same region (have same 
+ *
+ *   Models and glossaries must be within the same region (have same
  *   location-id), otherwise an INVALID_ARGUMENT (400) error is returned.
- * @param {string} [request.model] 
+ * @param {string} [request.model]
  *   Optional. The `model` type requested for this translation. 
- *   
+ *
  *   The format depends on model type: 
- *   
- *   - AutoML Translation models: 
+ *
+ *   - AutoML Translation models:
  *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
- *   
- *   - General (built-in) models: 
- *     `projects/{project-id}/locations/{location-id}/models/general/nmt`, 
+ *
+ *   - General (built-in) models:
+ *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
  *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- *   
- *   
- *   For global (non-regionalized) requests, use `location-id` `global`. 
- *   For example, 
+ * 
+ *
+ *   For global (non-regionalized) requests, use `location-id` `global`.
+ *   For example,
  *   `projects/{project-id}/locations/global/models/general/nmt`. 
- *   
+ *
  *   If missing, the system decides which google base model to use.
- * @param {google.cloud.translation.v3beta1.TranslateTextGlossaryConfig} [request.glossaryConfig] 
- *   Optional. Glossary to be applied. The glossary must be 
- *   within the same region (have the same location-id) as the model, otherwise 
+ * @param {google.cloud.translation.v3beta1.TranslateTextGlossaryConfig} [request.glossaryConfig]
+ *   Optional. Glossary to be applied. The glossary must be
+ *   within the same region (have the same location-id) as the model, otherwise
  *   an INVALID_ARGUMENT (400) error is returned.
- * @param {number} [request.labels] 
+ * @param {number[]} [request.labels]
  *   Optional. The labels with user-defined metadata for the request. 
- *   
- *   Label keys and values can be no longer than 63 characters 
- *   (Unicode codepoints), can only contain lowercase letters, numeric 
- *   characters, underscores and dashes. International characters are allowed. 
+ *
+ *   Label keys and values can be no longer than 63 characters
+ *   (Unicode codepoints), can only contain lowercase letters, numeric
+ *   characters, underscores and dashes. International characters are allowed.
  *   Label values are optional. Label keys must start with a letter. 
- *   
+ *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -430,41 +430,41 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. Project or location to make a call. Must refer to a caller's 
+ * @param {string} request.parent
+ *   Required. Project or location to make a call. Must refer to a caller's
  *   project. 
- *   
- *   Format: `projects/{project-id}/locations/{location-id}` or 
+ *
+ *   Format: `projects/{project-id}/locations/{location-id}` or
  *   `projects/{project-id}`. 
- *   
- *   For global calls, use `projects/{project-id}/locations/global` or 
+ *
+ *   For global calls, use `projects/{project-id}/locations/global` or
  *   `projects/{project-id}`. 
- *   
- *   Only models within the same region (has same location-id) can be used. 
+ *
+ *   Only models within the same region (has same location-id) can be used.
  *   Otherwise an INVALID_ARGUMENT (400) error is returned.
- * @param {string} [request.model] 
+ * @param {string} [request.model]
  *   Optional. The language detection model to be used. 
- *   
- *   Format: 
+ *
+ *   Format:
  *   `projects/{project-id}/locations/{location-id}/models/language-detection/{model-id}` 
- *   
- *   Only one language detection model is currently supported: 
+ *
+ *   Only one language detection model is currently supported:
  *   `projects/{project-id}/locations/{location-id}/models/language-detection/default`. 
- *   
+ *
  *   If not specified, the default model is used.
- * @param {string} request.content 
+ * @param {string} request.content
  *   The content of the input stored as a string.
- * @param {string} [request.mimeType] 
- *   Optional. The format of the source text, for example, "text/html", 
+ * @param {string} [request.mimeType]
+ *   Optional. The format of the source text, for example, "text/html",
  *   "text/plain". If left blank, the MIME type defaults to "text/html".
- * @param {number} request.labels 
+ * @param {number[]} request.labels
  *   Optional. The labels with user-defined metadata for the request. 
- *   
- *   Label keys and values can be no longer than 63 characters 
- *   (Unicode codepoints), can only contain lowercase letters, numeric 
- *   characters, underscores and dashes. International characters are allowed. 
+ *
+ *   Label keys and values can be no longer than 63 characters
+ *   (Unicode codepoints), can only contain lowercase letters, numeric
+ *   characters, underscores and dashes. International characters are allowed.
  *   Label values are optional. Label keys must start with a letter. 
- *   
+ *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -523,38 +523,38 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
- *   Required. Project or location to make a call. Must refer to a caller's 
+ * @param {string} request.parent
+ *   Required. Project or location to make a call. Must refer to a caller's
  *   project. 
- *   
- *   Format: `projects/{project-id}` or 
+ *
+ *   Format: `projects/{project-id}` or
  *   `projects/{project-id}/locations/{location-id}`. 
- *   
- *   For global calls, use `projects/{project-id}/locations/global` or 
+ *
+ *   For global calls, use `projects/{project-id}/locations/global` or
  *   `projects/{project-id}`. 
- *   
+ *
  *   Non-global location is required for AutoML models. 
- *   
- *   Only models within the same region (have same location-id) can be used, 
+ *
+ *   Only models within the same region (have same location-id) can be used,
  *   otherwise an INVALID_ARGUMENT (400) error is returned.
- * @param {string} [request.displayLanguageCode] 
- *   Optional. The language to use to return localized, human readable names 
- *   of supported languages. If missing, then display names are not returned 
+ * @param {string} [request.displayLanguageCode]
+ *   Optional. The language to use to return localized, human readable names
+ *   of supported languages. If missing, then display names are not returned
  *   in a response.
- * @param {string} [request.model] 
+ * @param {string} [request.model]
  *   Optional. Get supported languages of this model. 
- *   
+ *
  *   The format depends on model type: 
- *   
- *   - AutoML Translation models: 
+ *
+ *   - AutoML Translation models:
  *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
- *   
- *   - General (built-in) models: 
- *     `projects/{project-id}/locations/{location-id}/models/general/nmt`, 
+ *
+ *   - General (built-in) models:
+ *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
  *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- *   
- *   
- *   Returns languages supported by the specified model. 
+ * 
+ *
+ *   Returns languages supported by the specified model.
  *   If missing, we get supported languages of Google general base (PBMT) model.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -614,7 +614,7 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   Required. The name of the glossary to retrieve.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -680,57 +680,57 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
+ * @param {string} request.parent
  *   Required. Location to make a call. Must refer to a caller's project. 
- *   
+ *
  *   Format: `projects/{project-id}/locations/{location-id}`. 
- *   
+ *
  *   The `global` location is not supported for batch translation. 
- *   
- *   Only AutoML Translation models or glossaries within the same region (have 
- *   the same location-id) can be used, otherwise an INVALID_ARGUMENT (400) 
+ *
+ *   Only AutoML Translation models or glossaries within the same region (have
+ *   the same location-id) can be used, otherwise an INVALID_ARGUMENT (400)
  *   error is returned.
- * @param {string} request.sourceLanguageCode 
+ * @param {string} request.sourceLanguageCode
  *   Required. Source language code.
- * @param {string[]} request.targetLanguageCodes 
+ * @param {string[]} request.targetLanguageCodes
  *   Required. Specify up to 10 language codes here.
- * @param {number} [request.models] 
- *   Optional. The models to use for translation. Map's key is target language 
- *   code. Map's value is model name. Value can be a built-in general model, 
+ * @param {number[]} [request.models]
+ *   Optional. The models to use for translation. Map's key is target language
+ *   code. Map's value is model name. Value can be a built-in general model,
  *   or an AutoML Translation model. 
- *   
+ *
  *   The value format depends on model type: 
- *   
- *   - AutoML Translation models: 
+ *
+ *   - AutoML Translation models:
  *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
- *   
- *   - General (built-in) models: 
- *     `projects/{project-id}/locations/{location-id}/models/general/nmt`, 
+ *
+ *   - General (built-in) models:
+ *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
  *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- *   
- *   
- *   If the map is empty or a specific model is 
+ * 
+ *
+ *   If the map is empty or a specific model is
  *   not requested for a language pair, then default google model (nmt) is used.
- * @param {number} request.inputConfigs 
- *   Required. Input configurations. 
- *   The total number of files matched should be <= 1000. 
- *   The total content size should be <= 100M Unicode codepoints. 
+ * @param {number[]} request.inputConfigs
+ *   Required. Input configurations.
+ *   The total number of files matched should be <= 1000.
+ *   The total content size should be <= 100M Unicode codepoints.
  *   The files must use UTF-8 encoding.
- * @param {google.cloud.translation.v3beta1.OutputConfig} request.outputConfig 
- *   Required. Output configuration. 
- *   If 2 input configs match to the same file (that is, same input path), 
+ * @param {google.cloud.translation.v3beta1.OutputConfig} request.outputConfig
+ *   Required. Output configuration.
+ *   If 2 input configs match to the same file (that is, same input path),
  *   we don't generate output for duplicate inputs.
- * @param {number} [request.glossaries] 
- *   Optional. Glossaries to be applied for translation. 
+ * @param {number[]} [request.glossaries]
+ *   Optional. Glossaries to be applied for translation.
  *   It's keyed by target language code.
- * @param {number} [request.labels] 
+ * @param {number[]} [request.labels]
  *   Optional. The labels with user-defined metadata for the request. 
- *   
- *   Label keys and values can be no longer than 63 characters 
- *   (Unicode codepoints), can only contain lowercase letters, numeric 
- *   characters, underscores and dashes. International characters are allowed. 
+ *
+ *   Label keys and values can be no longer than 63 characters
+ *   (Unicode codepoints), can only contain lowercase letters, numeric
+ *   characters, underscores and dashes. International characters are allowed.
  *   Label values are optional. Label keys must start with a letter. 
- *   
+ *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -790,9 +790,9 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
+ * @param {string} request.parent
  *   Required. The project name.
- * @param {google.cloud.translation.v3beta1.Glossary} request.glossary 
+ * @param {google.cloud.translation.v3beta1.Glossary} request.glossary
  *   Required. The glossary to create.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -853,7 +853,7 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.name 
+ * @param {string} request.name
  *   Required. The name of the glossary to delete.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -898,7 +898,7 @@ export class TranslationServiceClient {
       options?: gax.CallOptions):
       Promise<[
         protosTypes.google.cloud.translation.v3beta1.IGlossary[],
-        protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null, 
+        protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
         protosTypes.google.cloud.translation.v3beta1.IListGlossariesResponse
       ]>;
   listGlossaries(
@@ -914,19 +914,19 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
+ * @param {string} request.parent
  *   Required. The name of the project from which to list all of the glossaries.
- * @param {number} [request.pageSize] 
- *   Optional. Requested page size. The server may return fewer glossaries than 
+ * @param {number} [request.pageSize]
+ *   Optional. Requested page size. The server may return fewer glossaries than
  *   requested. If unspecified, the server picks an appropriate default.
- * @param {string} [request.pageToken] 
- *   Optional. A token identifying a page of results the server should return. 
- *   Typically, this is the value of [ListGlossariesResponse.next_page_token] 
- *   returned from the previous call to `ListGlossaries` method. 
+ * @param {string} [request.pageToken]
+ *   Optional. A token identifying a page of results the server should return.
+ *   Typically, this is the value of [ListGlossariesResponse.next_page_token]
+ *   returned from the previous call to `ListGlossaries` method.
  *   The first page is returned if `page_token`is empty or missing.
- * @param {string} [request.filter] 
- *   Optional. Filter specifying constraints of a list operation. 
- *   Filtering is not supported yet, and the parameter currently has no effect. 
+ * @param {string} [request.filter]
+ *   Optional. Filter specifying constraints of a list operation.
+ *   Filtering is not supported yet, and the parameter currently has no effect.
  *   If missing, no filtering is performed.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -945,7 +945,7 @@ export class TranslationServiceClient {
       request: protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest,
       optionsOrCallback?: gax.CallOptions|Callback<
           protosTypes.google.cloud.translation.v3beta1.IGlossary[],
-          protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null, 
+          protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
           protosTypes.google.cloud.translation.v3beta1.IListGlossariesResponse>,
       callback?: Callback<
           protosTypes.google.cloud.translation.v3beta1.IGlossary[],
@@ -953,7 +953,7 @@ export class TranslationServiceClient {
           protosTypes.google.cloud.translation.v3beta1.IListGlossariesResponse>):
       Promise<[
         protosTypes.google.cloud.translation.v3beta1.IGlossary[],
-        protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null, 
+        protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
         protosTypes.google.cloud.translation.v3beta1.IListGlossariesResponse
       ]>|void {
     request = request || {};
@@ -991,19 +991,19 @@ export class TranslationServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
- * @param {string} request.parent 
+ * @param {string} request.parent
  *   Required. The name of the project from which to list all of the glossaries.
- * @param {number} [request.pageSize] 
- *   Optional. Requested page size. The server may return fewer glossaries than 
+ * @param {number} [request.pageSize]
+ *   Optional. Requested page size. The server may return fewer glossaries than
  *   requested. If unspecified, the server picks an appropriate default.
- * @param {string} [request.pageToken] 
- *   Optional. A token identifying a page of results the server should return. 
- *   Typically, this is the value of [ListGlossariesResponse.next_page_token] 
- *   returned from the previous call to `ListGlossaries` method. 
+ * @param {string} [request.pageToken]
+ *   Optional. A token identifying a page of results the server should return.
+ *   Typically, this is the value of [ListGlossariesResponse.next_page_token]
+ *   returned from the previous call to `ListGlossaries` method.
  *   The first page is returned if `page_token`is empty or missing.
- * @param {string} [request.filter] 
- *   Optional. Filter specifying constraints of a list operation. 
- *   Filtering is not supported yet, and the parameter currently has no effect. 
+ * @param {string} [request.filter]
+ *   Optional. Filter specifying constraints of a list operation.
+ *   Filtering is not supported yet, and the parameter currently has no effect.
  *   If missing, no filtering is performed.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.


### PR DESCRIPTION
A set of template changes to properly convert the return types of the calls to TypeScript types. It's hard to get an idea from reading the diff; the three main changes are these:

1. Be more careful when converting types for auto-pagination. Sometimes the pagination result is a basic type like `string` (it affects Firestore). So, when dumping types, if it's a basic TypeScript type, dump it as is:

![image](https://user-images.githubusercontent.com/4015807/70274095-59da4f00-1760-11ea-97c4-7f34250995b6.png)

2. Same problem: pagination type is not always a message, might be a primitive type as well.

![image](https://user-images.githubusercontent.com/4015807/70274166-7aa2a480-1760-11ea-8cfc-8e7e36f7118d.png)

3. Proper type conversion (the old code incorrectly produced `number` instead of `number[]` in JSDoc comments).

![image](https://user-images.githubusercontent.com/4015807/70274400-f1d83880-1760-11ea-9233-a64d259da9c3.png)

Upd. Minor fixes to remove extra spaces that make the result so hard to read :( 