### PR TITLE
fix: make git log file readable by everyone

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN gapic-generator-typescript --version
 RUN protoc --version
 
 # Save git log output for debugging purposes
-COPY ./gitlog.txt /root/
+COPY ./gitlog.txt /
+RUN chmod 666 /gitlog.txt
 
 ENTRYPOINT [ "/usr/local/bin/start.sh" ]

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,7 +5,7 @@
 # Dump the version of the current code to stderr
 echo "gapic-generator-typescript: https://github.com/googleapis/gapic-generator-typescript" 1>&2
 echo "Latest commit: " 1>&2
-cat /root/gitlog.txt 1>&2
+cat /gitlog.txt 1>&2
 echo 1>&2
 
 # Change directory to the input directory. 


### PR DESCRIPTION
Minor fix: we want this debug file with `git log` output be readable for every `--user`. Not related to the current problems caused by `--user` flag but uncovered while debugging.