### PR TITLE
feat: expose service stub as public member

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -40,13 +40,13 @@ const version = require('../../../package.json').version;
  */
 export class {{ service.name }}Client {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _{{ service.name.toCamelCase() }}Stub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   {%- if (service.pathTemplates.length > 0) %}
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   {%- endif %}
   private _terminated = false;
   auth: gax.GoogleAuth;
+  {{ service.name.toCamelCase() }}Stub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of {{ service.name }}Client.
@@ -221,7 +221,7 @@ export class {{ service.name }}Client {
 
     // Put together the "service stub" for
     // {{api.naming.protoPackage}}.{{ service.name }}.
-    this._{{ service.name.toCamelCase() }}Stub = gaxGrpc.createStub(
+    this.{{ service.name.toCamelCase() }}Stub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('{{api.naming.protoPackage}}.{{ service.name }}') :
           // tslint:disable-next-line no-any
@@ -240,7 +240,7 @@ export class {{ service.name }}Client {
     ];
 
     for (const methodName of {{ service.name.toCamelCase() }}StubMethods) {
-      const innerCallPromise = this._{{ service.name.toCamelCase() }}Stub.then(
+      const innerCallPromise = this.{{ service.name.toCamelCase() }}Stub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -611,7 +611,7 @@ export class {{ service.name }}Client {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._{{ service.name.toCamelCase() }}Stub.then(stub => {
+      return this.{{ service.name.toCamelCase() }}Stub.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -43,10 +43,10 @@ const version = require('../../../package.json').version;
  */
 export class KeyManagementServiceClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _keyManagementServiceStub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   private _terminated = false;
   auth: gax.GoogleAuth;
+  keyManagementServiceStub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of KeyManagementServiceClient.
@@ -162,7 +162,7 @@ export class KeyManagementServiceClient {
 
     // Put together the "service stub" for
     // google.cloud.kms.v1.KeyManagementService.
-    this._keyManagementServiceStub = gaxGrpc.createStub(
+    this.keyManagementServiceStub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('google.cloud.kms.v1.KeyManagementService') :
           // tslint:disable-next-line no-any
@@ -175,7 +175,7 @@ export class KeyManagementServiceClient {
         ['listKeyRings', 'listCryptoKeys', 'listCryptoKeyVersions', 'listImportJobs', 'getKeyRing', 'getCryptoKey', 'getCryptoKeyVersion', 'getPublicKey', 'getImportJob', 'createKeyRing', 'createCryptoKey', 'createCryptoKeyVersion', 'importCryptoKeyVersion', 'createImportJob', 'updateCryptoKey', 'updateCryptoKeyVersion', 'encrypt', 'decrypt', 'asymmetricSign', 'asymmetricDecrypt', 'updateCryptoKeyPrimaryVersion', 'destroyCryptoKeyVersion', 'restoreCryptoKeyVersion'];
 
     for (const methodName of keyManagementServiceStubMethods) {
-      const innerCallPromise = this._keyManagementServiceStub.then(
+      const innerCallPromise = this.keyManagementServiceStub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -2074,7 +2074,7 @@ export class KeyManagementServiceClient {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._keyManagementServiceStub.then(stub => {
+      return this.keyManagementServiceStub.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -47,11 +47,11 @@ const version = require('../../../package.json').version;
  */
 export class CloudRedisClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _cloudRedisStub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
   auth: gax.GoogleAuth;
+  cloudRedisStub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of CloudRedisClient.
@@ -236,7 +236,7 @@ export class CloudRedisClient {
 
     // Put together the "service stub" for
     // google.cloud.redis.v1beta1.CloudRedis.
-    this._cloudRedisStub = gaxGrpc.createStub(
+    this.cloudRedisStub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('google.cloud.redis.v1beta1.CloudRedis') :
           // tslint:disable-next-line no-any
@@ -249,7 +249,7 @@ export class CloudRedisClient {
         ['listInstances', 'getInstance', 'createInstance', 'updateInstance', 'importInstance', 'exportInstance', 'failoverInstance', 'deleteInstance'];
 
     for (const methodName of cloudRedisStubMethods) {
-      const innerCallPromise = this._cloudRedisStub.then(
+      const innerCallPromise = this.cloudRedisStub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -1045,7 +1045,7 @@ export class CloudRedisClient {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._cloudRedisStub.then(stub => {
+      return this.cloudRedisStub.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -36,10 +36,10 @@ const version = require('../../../package.json').version;
  */
 export class EchoClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _echoStub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   private _terminated = false;
   auth: gax.GoogleAuth;
+  echoStub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of EchoClient.
@@ -180,7 +180,7 @@ export class EchoClient {
 
     // Put together the "service stub" for
     // google.showcase.v1beta1.Echo.
-    this._echoStub = gaxGrpc.createStub(
+    this.echoStub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('google.showcase.v1beta1.Echo') :
           // tslint:disable-next-line no-any
@@ -193,7 +193,7 @@ export class EchoClient {
         ['echo', 'expand', 'collect', 'chat', 'pagedExpand', 'wait'];
 
     for (const methodName of echoStubMethods) {
-      const innerCallPromise = this._echoStub.then(
+      const innerCallPromise = this.echoStub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -586,7 +586,7 @@ export class EchoClient {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._echoStub.then(stub => {
+      return this.echoStub.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -32,10 +32,10 @@ const version = require('../../../package.json').version;
  */
 export class TextToSpeechClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _textToSpeechStub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   private _terminated = false;
   auth: gax.GoogleAuth;
+  textToSpeechStub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of TextToSpeechClient.
@@ -137,7 +137,7 @@ export class TextToSpeechClient {
 
     // Put together the "service stub" for
     // google.cloud.texttospeech.v1.TextToSpeech.
-    this._textToSpeechStub = gaxGrpc.createStub(
+    this.textToSpeechStub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('google.cloud.texttospeech.v1.TextToSpeech') :
           // tslint:disable-next-line no-any
@@ -150,7 +150,7 @@ export class TextToSpeechClient {
         ['listVoices', 'synthesizeSpeech'];
 
     for (const methodName of textToSpeechStubMethods) {
-      const innerCallPromise = this._textToSpeechStub.then(
+      const innerCallPromise = this.textToSpeechStub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -355,7 +355,7 @@ export class TextToSpeechClient {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._textToSpeechStub.then(stub => {
+      return this.textToSpeechStub.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -33,11 +33,11 @@ const version = require('../../../package.json').version;
  */
 export class TranslationServiceClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
-  private _translationServiceStub: Promise<{[name: string]: Function}>;
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
   auth: gax.GoogleAuth;
+  translationServiceStub: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of TranslationServiceClient.
@@ -198,7 +198,7 @@ export class TranslationServiceClient {
 
     // Put together the "service stub" for
     // google.cloud.translation.v3beta1.TranslationService.
-    this._translationServiceStub = gaxGrpc.createStub(
+    this.translationServiceStub = gaxGrpc.createStub(
         opts.fallback ?
           (protos as protobuf.Root).lookupService('google.cloud.translation.v3beta1.TranslationService') :
           // tslint:disable-next-line no-any
@@ -211,7 +211,7 @@ export class TranslationServiceClient {
         ['translateText', 'detectLanguage', 'getSupportedLanguages', 'batchTranslateText', 'createGlossary', 'listGlossaries', 'getGlossary', 'deleteGlossary'];
 
     for (const methodName of translationServiceStubMethods) {
-      const innerCallPromise = this._translationServiceStub.then(
+      const innerCallPromise = this.translationServiceStub.then(
         stub => (...args: Array<{}>) => {
           return stub[methodName].apply(stub, args);
         },
@@ -1118,7 +1118,7 @@ export class TranslationServiceClient {
    */
   close(): Promise<void> {
     if (!this._terminated) {
-      return this._translationServiceStub.then(stub => {
+      return this.translationServiceStub.then(stub => {
         this._terminated = true;
         stub.close();
       });


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator/issues/2127 by exposing service stub directly. All the extra logic that needs to have a service stub can then depend on this new field.

@callmehiphop: this will help us remove changes to the generated code in Pub/Sub.