### PR TITLE
fix: proper handling of paging field name

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -162,7 +162,7 @@ export class {{ service.name }}Client {
 {%- for method in service.paging %}
       {{- pagingJoiner() }}
       {{ method.name.toCamelCase() }}:
-          new gaxModule.PageDescriptor('pageToken', 'nextPageToken', '{{ method.pagingFieldName }}')
+          new gaxModule.PageDescriptor('pageToken', 'nextPageToken', '{{ method.pagingFieldName.toCamelCase() }}')
 {%- endfor %}
     };
 {%- endif %}

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -324,7 +324,7 @@ function pagingField(messages: MessagesMap, method: MethodDescriptorProto) {
 
 function pagingFieldName(messages: MessagesMap, method: MethodDescriptorProto) {
   const field = pagingField(messages, method);
-  return field?.name?.toCamelCase();
+  return field?.name;
 }
 
 function pagingResponseType(


### PR DESCRIPTION
After some thinking I realized that #173 is better to be fixed in templates.

@schmidt-sebastian The idea here is to leave all TypeScript specifics in templates, and the general logic in the code. If we ever decide to generate some other language with the same code, it should only need the new templates and hopefully no code changes (not that we really planned that, but it's a good guidance). So I just moved `.toCamelCase()` from one place to another :)