### PR TITLE
fix: set default timeouts to 60000

### DIFF
--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -31,9 +31,9 @@ const defaultParameters = {
   max_retry_delay_millis: 60000,
   // note: the following four parameters are unused but currently required by google-gax.
   // setting them to some big safe default values.
-  initial_rpc_timeout_millis: 20000,
+  initial_rpc_timeout_millis: 60000,
   rpc_timeout_multiplier: 1.0,
-  max_rpc_timeout_millis: 20000,
+  max_rpc_timeout_millis: 60000,
   total_timeout_millis: 600000,
 };
 

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client_config.json.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client_config.json.baseline
@@ -13,9 +13,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }
       },

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client_config.json.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client_config.json.baseline
@@ -13,9 +13,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }
       },

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client_config.json.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client_config.json.baseline
@@ -13,9 +13,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }
       },

--- a/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client_config.json.baseline
+++ b/typescript/test/testdata/texttospeech/src/v1/text_to_speech_client_config.json.baseline
@@ -13,9 +13,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }
       },

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client_config.json.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client_config.json.baseline
@@ -13,9 +13,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 60000,
           "rpc_timeout_multiplier": 1,
-          "max_rpc_timeout_millis": 20000,
+          "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }
       },

--- a/typescript/test/unit/codemap.ts
+++ b/typescript/test/unit/codemap.ts
@@ -114,9 +114,9 @@ describe('RetryableCodeMap', () => {
           initial_retry_delay_millis: 100,
           retry_delay_multiplier: 1.3,
           max_retry_delay_millis: 60000,
-          initial_rpc_timeout_millis: 20000,
+          initial_rpc_timeout_millis: 60000,
           rpc_timeout_multiplier: 1.0,
-          max_rpc_timeout_millis: 20000,
+          max_rpc_timeout_millis: 60000,
           total_timeout_millis: 600000,
         }),
         'default'


### PR DESCRIPTION
Cc: @schmidt-sebastian 

These timeout values will soon be removed from gax because they are not supported in new gRPC service config, but for now, since gax still uses them, let's set them to 60s and not 20s.