### PR TITLE
feat: parse child_type resource

### DIFF
--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -16,6 +16,7 @@ import * as plugin from '../../../pbjs-genfiles/plugin';
 import { CommentsMap, Comment } from './comments';
 import * as objectHash from 'object-hash';
 import { milliseconds } from '../util';
+import { ResourceDescriptor, ResourceDatabase } from './resourceDatabase';
 
 const defaultNonIdempotentRetryCodesName = 'non_idempotent';
 const defaultNonIdempotentCodes: plugin.google.rpc.Code[] = [];
@@ -184,22 +185,14 @@ interface ServiceDescriptorProto
   grpcServiceConfig: plugin.grpc.service_config.ServiceConfig;
 }
 
-export interface ResourceDescriptor
-  extends plugin.google.api.IResourceDescriptor {
-  name: string;
-  params: string[];
-}
-
-export interface ResourceMap {
-  [name: string]: ResourceDescriptor;
-}
-
 export interface ServicesMap {
   [name: string]: ServiceDescriptorProto;
 }
+
 export interface MessagesMap {
   [name: string]: plugin.google.protobuf.IDescriptorProto;
 }
+
 export interface EnumsMap {
   [name: string]: plugin.google.protobuf.IEnumDescriptorProto;
 }
@@ -479,7 +472,7 @@ function augmentService(
   service: plugin.google.protobuf.IServiceDescriptorProto,
   commentsMap: CommentsMap,
   grpcServiceConfig: plugin.grpc.service_config.ServiceConfig,
-  resourceMap: ResourceMap
+  resourceDatabase: ResourceDatabase
 ) {
   const augmentedService = service as ServiceDescriptorProto;
   augmentedService.packageName = packageName;
@@ -530,32 +523,36 @@ function augmentService(
       '.google.api.oauthScopes'
     ].split(',');
   }
-  augmentedService.pathTemplates = [];
+
+  // Build a list of resources referenced by this service
+  const uniqueResources: { [name: string]: ResourceDescriptor } = {};
   for (const property of Object.keys(messages)) {
-    const m = messages[property];
-    if (m?.field) {
-      const fields = m.field;
-      for (const fieldDescriptor of fields) {
-        if (fieldDescriptor?.options) {
-          const option = fieldDescriptor.options;
-          if (option?.['.google.api.resourceReference']) {
-            const resourceReference = option['.google.api.resourceReference'];
-            const type = resourceReference.type;
-            if (!type || !resourceMap[type.toString()]) {
-              const resourceJson = JSON.stringify(resourceReference);
-              console.warn(
-                `Warning: in service proto ${service.name} message ${property} refers to an unknown resource: ${resourceJson}`
-              );
-              continue;
-            }
-            const resource = resourceMap[resourceReference.type!.toString()];
-            if (augmentedService.pathTemplates.includes(resource)) continue;
-            augmentedService.pathTemplates.push(resource);
-          }
-        }
+    const errorLocation = `service ${service.name} message ${property}`;
+    for (const fieldDescriptor of messages[property].field ?? []) {
+      // note: ResourceDatabase can accept `undefined` values, so we happily use optional chaining here.
+      const resourceReference =
+        fieldDescriptor.options?.['.google.api.resourceReference'];
+
+      // 1. If this resource reference has .child_type, figure out if we have any known parent resources
+      const parentResources = resourceDatabase.getParentResourcesByChildType(
+        resourceReference?.childType,
+        errorLocation
+      );
+      parentResources.map(
+        resource => (uniqueResources[resource.name] = resource)
+      );
+
+      // 2. If this resource reference has .type, we should have a know resource with this type.
+      const resource = resourceDatabase.getResourceByType(
+        resourceReference?.type,
+        errorLocation
+      );
+      if (resource) {
+        uniqueResources[resource.name] = resource;
       }
     }
   }
+  augmentedService.pathTemplates = Object.values(uniqueResources);
   return augmentedService;
 }
 
@@ -571,7 +568,7 @@ export class Proto {
     fd: plugin.google.protobuf.IFileDescriptorProto,
     packageName: string,
     grpcServiceConfig: plugin.grpc.service_config.ServiceConfig,
-    resourceMap: ResourceMap
+    resourceDatabase: ResourceDatabase
   ) {
     fd.enumType = fd.enumType || [];
     fd.messageType = fd.messageType || [];
@@ -605,7 +602,7 @@ export class Proto {
           service,
           commentsMap,
           grpcServiceConfig,
-          resourceMap
+          resourceDatabase
         )
       )
       .reduce((map, service) => {

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -533,7 +533,7 @@ function augmentService(
       const resourceReference =
         fieldDescriptor.options?.['.google.api.resourceReference'];
 
-      // 1. If this resource reference has .child_type, figure out if we have any known parent resources
+      // 1. If this resource reference has .child_type, figure out if we have any known parent resources.
       const parentResources = resourceDatabase.getParentResourcesByChildType(
         resourceReference?.childType,
         errorLocation
@@ -542,7 +542,7 @@ function augmentService(
         resource => (uniqueResources[resource.name] = resource)
       );
 
-      // 2. If this resource reference has .type, we should have a know resource with this type.
+      // 2. If this resource reference has .type, we should have a known resource with this type.
       const resource = resourceDatabase.getResourceByType(
         resourceReference?.type,
         errorLocation

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -86,24 +86,6 @@ export class ResourceDatabase {
     this.types[resourceDescriptor.type!] = resourceDescriptor;
   }
 
-  getResourceByName(
-    name: string | null | undefined,
-    errorLocation?: string
-  ): ResourceDescriptor | undefined {
-    if (!name) {
-      return undefined;
-    }
-    if (!this.names[name]) {
-      if (errorLocation) {
-        console.warn(
-          `Warning: ${errorLocation} refers to an unknown resource: ${name}`
-        );
-      }
-      return undefined;
-    }
-    return this.names[name];
-  }
-
   getResourceByType(
     type: string | null | undefined,
     errorLocation?: string
@@ -145,6 +127,7 @@ export class ResourceDatabase {
     errorLocation?: string
   ): ResourceDescriptor[] {
     // childType looks like "datacatalog.googleapis.com/EntryGroup"
+    // its pattern would be like "projects/{project}/locations/{location}/entryGroups/{entry_group}"
     const result: ResourceDescriptor[] = [];
 
     if (!childType) {

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -1,0 +1,178 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as plugin from '../../../pbjs-genfiles/plugin';
+
+export interface ResourceDescriptor
+  extends plugin.google.api.IResourceDescriptor {
+  name: string;
+  params: string[];
+}
+
+export class ResourceDatabase {
+  private names: { [name: string]: ResourceDescriptor };
+  private patterns: { [pattern: string]: ResourceDescriptor };
+  private types: { [type: string]: ResourceDescriptor };
+
+  constructor() {
+    this.names = {};
+    this.patterns = {};
+    this.types = {};
+  }
+
+  registerResource(
+    resource: plugin.google.api.IResourceDescriptor | undefined,
+    errorLocation?: string
+  ) {
+    if (!resource) {
+      return;
+    }
+
+    if (!resource.type) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to a resource which does not have a type: ${resource}`
+        );
+      }
+      return;
+    }
+
+    const arr = resource.type.match(/\/([^.]+)$/);
+    if (!arr?.[1]) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to a resource which does not have a proper name: ${resource}`
+        );
+      }
+      return;
+    }
+    const name = arr[1];
+
+    const pattern = resource.pattern;
+    if (!pattern?.[0]) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to a resource which does not have a proper pattern: ${resource}`
+        );
+      }
+      return;
+    }
+    const params = pattern[0].match(/{[a-zA-Z]+}/g) || [];
+    for (let i = 0; i < params.length; i++) {
+      params[i] = params[i].replace('{', '').replace('}', '');
+    }
+
+    const resourceDescriptor: ResourceDescriptor = Object.assign(
+      {
+        name,
+        params,
+      },
+      resource
+    );
+
+    this.names[resourceDescriptor.name] = resourceDescriptor;
+    this.patterns[pattern?.[0]] = resourceDescriptor;
+    this.types[resourceDescriptor.type!] = resourceDescriptor;
+  }
+
+  getResourceByName(
+    name: string | null | undefined,
+    errorLocation?: string
+  ): ResourceDescriptor | undefined {
+    if (!name) {
+      return undefined;
+    }
+    if (!this.names[name]) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to an unknown resource: ${name}`
+        );
+      }
+      return undefined;
+    }
+    return this.names[name];
+  }
+
+  getResourceByType(
+    type: string | null | undefined,
+    errorLocation?: string
+  ): ResourceDescriptor | undefined {
+    if (!type) {
+      return undefined;
+    }
+    if (!this.types[type]) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to an unknown resource: ${type}`
+        );
+      }
+      return undefined;
+    }
+    return this.types[type];
+  }
+
+  getResourceByPattern(
+    pattern: string | null | undefined,
+    errorLocation?: string
+  ): ResourceDescriptor | undefined {
+    if (!pattern) {
+      return undefined;
+    }
+    if (!this.patterns[pattern]) {
+      if (errorLocation) {
+        console.warn(
+          `Warning: ${errorLocation} refers to an unknown resource: ${pattern}`
+        );
+      }
+      return undefined;
+    }
+    return this.patterns[pattern];
+  }
+
+  getParentResourcesByChildType(
+    childType: string | null | undefined,
+    errorLocation?: string
+  ): ResourceDescriptor[] {
+    // childType looks like "datacatalog.googleapis.com/EntryGroup"
+    const result: ResourceDescriptor[] = [];
+
+    if (!childType) {
+      return result;
+    }
+
+    const childResource = this.getResourceByType(childType, errorLocation);
+    if (!childResource) {
+      return result;
+    }
+
+    const childPattern = childResource.pattern?.[0];
+    if (!childPattern) {
+      return result;
+    }
+
+    let pattern = '';
+    for (const segment of childPattern.split('/')) {
+      if (pattern !== '') {
+        pattern += '/';
+      }
+      pattern += segment;
+      const parent = this.getResourceByPattern(pattern);
+      if (parent) {
+        result.push(parent);
+      }
+    }
+
+    return result;
+  }
+}

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -21,12 +21,10 @@ export interface ResourceDescriptor
 }
 
 export class ResourceDatabase {
-  private names: { [name: string]: ResourceDescriptor };
   private patterns: { [pattern: string]: ResourceDescriptor };
   private types: { [type: string]: ResourceDescriptor };
 
   constructor() {
-    this.names = {};
     this.patterns = {};
     this.types = {};
   }
@@ -81,7 +79,6 @@ export class ResourceDatabase {
       resource
     );
 
-    this.names[resourceDescriptor.name] = resourceDescriptor;
     this.patterns[pattern?.[0]] = resourceDescriptor;
     this.types[resourceDescriptor.type!] = resourceDescriptor;
   }

--- a/typescript/test/unit/resourceDatabase.ts
+++ b/typescript/test/unit/resourceDatabase.ts
@@ -75,22 +75,6 @@ describe('ResourceDatabase', () => {
     assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
   });
 
-  it('can get registered resource by name', () => {
-    const rdb = new ResourceDatabase();
-    const resource: plugin.google.api.IResourceDescriptor = {
-      type: resourceType,
-      pattern: [resourcePattern],
-    };
-
-    rdb.registerResource(resource, errorLocation);
-    const registeredResource = rdb.getResourceByName(resourceName);
-    assert(registeredResource);
-    assert.strictEqual(registeredResource!.type, resourceType);
-    assert.strictEqual(registeredResource!.name, resourceName);
-    assert.deepStrictEqual(registeredResource!.pattern, [resourcePattern]);
-    assert.strictEqual(warnings.length, 0);
-  });
-
   it('can get registered resource by type', () => {
     const rdb = new ResourceDatabase();
     const resource: plugin.google.api.IResourceDescriptor = {
@@ -131,7 +115,7 @@ describe('ResourceDatabase', () => {
     };
 
     rdb.registerResource(resource, errorLocation);
-    const registeredResource = rdb.getResourceByName(resourceName);
+    const registeredResource = rdb.getResourceByType(resourceType);
     assert(registeredResource);
     assert.deepStrictEqual(registeredResource!.params, resourceParameters);
     assert.strictEqual(warnings.length, 0);
@@ -140,7 +124,7 @@ describe('ResourceDatabase', () => {
   it('warns if cannot find resource by name', () => {
     const rdb = new ResourceDatabase();
 
-    const notFoundResource = rdb.getResourceByName(resourceName, errorLocation);
+    const notFoundResource = rdb.getResourceByType(resourceType, errorLocation);
     assert.strictEqual(notFoundResource, undefined);
     assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
   });

--- a/typescript/test/unit/resourceDatabase.ts
+++ b/typescript/test/unit/resourceDatabase.ts
@@ -1,0 +1,186 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as plugin from '../../../pbjs-genfiles/plugin';
+import {
+  ResourceDatabase,
+  ResourceDescriptor,
+} from '../../src/schema/resourceDatabase';
+import * as assert from 'assert';
+
+describe('ResourceDatabase', () => {
+  let warnings: string[] = [];
+  const savedWarn = console.warn;
+  const errorLocation = 'ERROR LOCATION';
+  const resourceName = 'Example';
+  const resourceType = 'examples.googleapis.com/Example';
+  const resourcePattern = 'locations/{location}/examples/{example}';
+  const resourceParameters = ['location', 'example'];
+  const parentResourceName = 'Location';
+  const parentResourceType = 'locations.googleapis.com/Location';
+  const parentResourcePattern = 'locations/{location}';
+
+  beforeEach(() => {
+    warnings = [];
+    console.warn = (message: string) => {
+      warnings.push(message);
+    };
+  });
+
+  afterEach(() => {
+    console.warn = savedWarn;
+  });
+
+  it('warns when registering resource with no type', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: '',
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('warns when registering resource with malformed type', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: 'examples.googleapis.com',
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('warns when registering resource with no pattern', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('can get registered resource by name', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    const registeredResource = rdb.getResourceByName(resourceName);
+    assert(registeredResource);
+    assert.strictEqual(registeredResource!.type, resourceType);
+    assert.strictEqual(registeredResource!.name, resourceName);
+    assert.deepStrictEqual(registeredResource!.pattern, [resourcePattern]);
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('can get registered resource by type', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    const registeredResource = rdb.getResourceByType(resourceType);
+    assert(registeredResource);
+    assert.strictEqual(registeredResource!.type, resourceType);
+    assert.strictEqual(registeredResource!.name, resourceName);
+    assert.deepStrictEqual(registeredResource!.pattern, [resourcePattern]);
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('can get registered resource by pattern', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    const registeredResource = rdb.getResourceByPattern(resourcePattern);
+    assert(registeredResource);
+    assert.strictEqual(registeredResource!.type, resourceType);
+    assert.strictEqual(registeredResource!.name, resourceName);
+    assert.deepStrictEqual(registeredResource!.pattern, [resourcePattern]);
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('extracts parameters from pattern', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [resourcePattern],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    const registeredResource = rdb.getResourceByName(resourceName);
+    assert(registeredResource);
+    assert.deepStrictEqual(registeredResource!.params, resourceParameters);
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('warns if cannot find resource by name', () => {
+    const rdb = new ResourceDatabase();
+
+    const notFoundResource = rdb.getResourceByName(resourceName, errorLocation);
+    assert.strictEqual(notFoundResource, undefined);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('warns if cannot find resource by type', () => {
+    const rdb = new ResourceDatabase();
+
+    const notFoundResource = rdb.getResourceByType(resourceType, errorLocation);
+    assert.strictEqual(notFoundResource, undefined);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('warns if cannot find resource by pattern', () => {
+    const rdb = new ResourceDatabase();
+
+    const notFoundResource = rdb.getResourceByPattern(
+      resourcePattern,
+      errorLocation
+    );
+    assert.strictEqual(notFoundResource, undefined);
+    assert(warnings.filter(w => w.includes(errorLocation)).length > 0);
+  });
+
+  it('returns known parent resources', () => {
+    const rdb = new ResourceDatabase();
+    const parentResource: plugin.google.api.IResourceDescriptor = {
+      type: parentResourceType,
+      pattern: [parentResourcePattern],
+    };
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [resourcePattern],
+    };
+    rdb.registerResource(parentResource);
+    rdb.registerResource(resource);
+
+    const parentResources = rdb.getParentResourcesByChildType(resourceType);
+    assert.strictEqual(parentResources.length, 2);
+    assert.strictEqual(parentResources[0].name, parentResourceName);
+    assert.strictEqual(parentResources[1].name, resourceName);
+    assert.strictEqual(warnings.length, 0);
+  });
+});


### PR DESCRIPTION
This PR adds support for `.child_type`, also moving most of the resource related code into a separate `ResourceDatabase` class.

After talking to @noahdietz and @lukesneeringer, it turns out that the easiest way to support `.child_type` is to split the corresponding pattern by segments, then find all possible prefixes that correspond to known resources, and register them (to generate helper functions later).

No baseline changes (that means that the APIs included in baselines are not affected). The first known affected API is datacatalog (cc: @bcoe - this should fix it).

Note: we only support the first pattern of multi-pattern resources for now, hence `[0]` here and there. This will be taken care of separately in January, since it will be an incompatible change.