### PR TITLE
fix: use camel case for path template names

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -579,7 +579,7 @@ export class {{ service.name }}Client {
 {%- endfor %}
    * @returns {string} Resource name string.
    */
-  {{ template.name.toLowerCase() }}Path(
+  {{ template.name.toCamelCase() }}Path(
 {%- set paramJoiner = joiner() %}
 {%- for param in template.params %}
 {{-paramJoiner()-}}{{ param }}:string


### PR DESCRIPTION
Path template names must be camel-cased, not lowercased. This issue created compatibility problem in https://github.com/googleapis/nodejs-datacatalog/issues/79.