### PR TITLE
fix: trim trailing whitespace in code, templates, and generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 This tool is a TypeScript client library generator for network APIs specified
 by [protocol
-buffers](https://developers.google.com/protocol-buffers/) (including, but 
-not limited to, [client libraries](https://www.npmjs.com/search?q=%40google-cloud) 
+buffers](https://developers.google.com/protocol-buffers/) (including, but
+not limited to, [client libraries](https://www.npmjs.com/search?q=%40google-cloud)
 for Google Cloud APIs).
 
-It can be used for any API that uses protocol buffers and follows the conventions 
+It can be used for any API that uses protocol buffers and follows the conventions
 described in [API Improvement Proposals](https://aip.dev/).
 
 ## Getting started
 
-The [Showcase API](https://github.com/googleapis/gapic-showcase) is a good API to 
+The [Showcase API](https://github.com/googleapis/gapic-showcase) is a good API to
 play with if you want to start generating your own client libraries. It has several
 services, we'll use `Echo` service as an example.
 
@@ -119,12 +119,12 @@ $ gapic-generator-typescript -I . \
   google/cloud/common_resources.proto
 ```
 
-Line by line:  
-`-I .` means pass the current directory (i.e. `googleapis`) to `protoc`  
-`--output_dir /tmp/translate-v3-typescript` is where to put the result  
+Line by line:
+`-I .` means pass the current directory (i.e. `googleapis`) to `protoc`
+`--output_dir /tmp/translate-v3-typescript` is where to put the result
 `--grpc-service-config google/cloud/translate/v3/translate_grpc_service_config.json`
-is an optional configuration file for timeouts and stuff  
-Then we add all the `translate` `v3` proto file to the command line, as well as the 
+is an optional configuration file for timeouts and stuff
+Then we add all the `translate` `v3` proto file to the command line, as well as the
 proto file that defines common resources (some APIs need it, some others don't).
 
 If you like the changes, make sure that tests pass!

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -35,14 +35,19 @@ limitations under the License.
 {%- macro printCommentsForService(service) -%}
 {%- set lines = service.comments -%}
 {% for line in lines %}
- * {{ line | safe}}
+{%- set trimmed = line.replace(r/\s+$/, '') -%}
+{%- if trimmed.length > 0 %}
+ * {{ trimmed.replaceAll('*/', '* /') | safe}}
+{%- else %}
+ *
+{%- endif %}
 {%- endfor %}
 {%- endmacro -%}
 
 {%- macro printCommentsForMethod(method) -%}
 {%- set lines = method.comments -%}
 {% for line in lines %}
- *{{ line.replaceAll('*/', '* /') | safe}}
+ *{{ line.replaceAll('*/', '* /').replace(r/\s+$/, '') | safe}}
 {%- endfor %}
 {%- endmacro -%}
 
@@ -80,9 +85,10 @@ limitations under the License.
 {%- endif -%}
 {%- set lines = oneComment.comments -%}
 {%- for line in lines %}
-{%- if line.length > 0 %}
- *  {{ line.replaceAll('*/', '* /') | safe}}
-{%- else %} 
+{%- set trimmed = line.replace(r/\s+$/, '') -%}
+{%- if trimmed.length > 0 %}
+ *  {{ trimmed.replaceAll('*/', '* /') | safe}}
+{%- else %}
  *
 {%- endif -%}
 {%- endfor -%}
@@ -141,12 +147,12 @@ limitations under the License.
 {%- endmacro -%}
 
 {%- macro printReturnClientStreamingMethod(method) %}
- * @returns {Stream} - A writable stream which accepts objects representing 
+ * @returns {Stream} - A writable stream which accepts objects representing
  * {{ typeLink(method.inputType) }}.
 {%- endmacro -%}
 
 {%- macro printReturnBidiStreamingMethod(method) %}
- * @returns {Stream} 
+ * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {{ typeLink(method.inputType) }} for write() method, and
  *   will emit objects representing {{ typeLink(method.outputType) }} on 'data' event asynchronously.

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -383,7 +383,7 @@ export class {{ service.name }}Client {
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
-  } 
+  }
 {%- endfor %}
 {% for method in service.streaming %}
 {%- if method.serverStreaming and method.clientStreaming %}
@@ -404,7 +404,7 @@ export class {{ service.name }}Client {
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
     gax.CancellableStream{
-    request = request || {}; 
+    request = request || {};
     options = options || {};
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options);
   }
@@ -491,7 +491,7 @@ export class {{ service.name }}Client {
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
-  } 
+  }
 {%- endfor %}
 {%- for method in service.paging %}
   {{ method.name.toCamelCase() }}(
@@ -547,7 +547,7 @@ export class {{ service.name }}Client {
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
-  } 
+  }
 
 /**
 {{- util.printCommentsPageStream(method) }}
@@ -556,7 +556,7 @@ export class {{ service.name }}Client {
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.{{ method.name.toCamelCase() }}.createStream(
       this._innerApiCalls.{{ method.name.toCamelCase() }} as gax.GaxCall,
@@ -603,7 +603,7 @@ export class {{ service.name }}Client {
   match{{ param.capitalize() }}From{{ template.name }}Name({{ template.name.toLowerCase() }}Name: string) {
     return this._pathTemplates.{{ template.name.toLowerCase() }}PathTemplate.match({{ template.name.toLowerCase() }}Name).{{ param }};
   }
-{%- endfor %}  
+{%- endfor %}
 {%- endfor %}
 {%- endif %}
 

--- a/typescript/test/protos/google/showcase/v1beta1/echo.proto
+++ b/typescript/test/protos/google/showcase/v1beta1/echo.proto
@@ -96,7 +96,7 @@ service Echo {
 }
 
 // The request message used for the Echo, Collect and Chat methods. If content
-// is set in this message then the request will succeed. If status is set in 
+// is set in this message then the request will succeed. If status is set in
 // this message then the status will be returned as an error.
 message EchoRequest {
   oneof response {

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -28,14 +28,14 @@ const version = require('../../../package.json').version;
 
 /**
  *  Google Cloud Key Management Service
- * 
+ *
  *  Manages cryptographic keys and operations using those keys. Implements a REST
  *  model with the following objects:
- * 
+ *
  *  * [KeyRing][google.cloud.kms.v1.KeyRing]
  *  * [CryptoKey][google.cloud.kms.v1.CryptoKey]
  *  * [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
- * 
+ *
  *  If you are using manual gRPC libraries, see
  *  [Using gRPC with Cloud KMS](https://cloud.google.com/kms/docs/grpc).
  * @class
@@ -800,7 +800,7 @@ export class KeyManagementServiceClient {
  *   Wrapped key material produced with
  *   [RSA_OAEP_3072_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256]
  *   or
- *   [RSA_OAEP_4096_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256]. 
+ *   [RSA_OAEP_4096_SHA1_AES_256][google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256].
  *
  *   This field contains the concatenation of two wrapped keys:
  *   <ol>
@@ -811,7 +811,7 @@ export class KeyManagementServiceClient {
  *     <li>The key to be imported, wrapped with the ephemeral AES-256 key
  *         using AES-KWP (RFC 5649).
  *     </li>
- *   </ol> 
+ *   </ol>
  *
  *   This format is the same as the format produced by PKCS#11 mechanism
  *   CKM_RSA_AES_KEY_WRAP.
@@ -1071,12 +1071,12 @@ export class KeyManagementServiceClient {
  *   The request object that will be sent.
  * @param {string} request.name
  *   Required. The resource name of the [CryptoKey][google.cloud.kms.v1.CryptoKey] or [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
- *   to use for encryption. 
+ *   to use for encryption.
  *
  *   If a [CryptoKey][google.cloud.kms.v1.CryptoKey] is specified, the server will use its
  *   [primary version][google.cloud.kms.v1.CryptoKey.primary].
  * @param {Buffer} request.plaintext
- *   Required. The data to encrypt. Must be no larger than 64KiB. 
+ *   Required. The data to encrypt. Must be no larger than 64KiB.
  *
  *   The maximum size depends on the key version's
  *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For
@@ -1086,7 +1086,7 @@ export class KeyManagementServiceClient {
  *   8KiB.
  * @param {Buffer} request.additionalAuthenticatedData
  *   Optional data that, if specified, must also be provided during decryption
- *   through [DecryptRequest.additional_authenticated_data][google.cloud.kms.v1.DecryptRequest.additional_authenticated_data]. 
+ *   through [DecryptRequest.additional_authenticated_data][google.cloud.kms.v1.DecryptRequest.additional_authenticated_data].
  *
  *   The maximum size depends on the key version's
  *   [protection_level][google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]. For
@@ -1615,7 +1615,7 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listKeyRings(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listKeyRings}, but returns a NodeJS Stream object.
@@ -1657,7 +1657,7 @@ export class KeyManagementServiceClient {
       request?: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listKeyRings.createStream(
       this._innerApiCalls.listKeyRings as gax.GaxCall,
@@ -1754,7 +1754,7 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listCryptoKeys(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listCryptoKeys}, but returns a NodeJS Stream object.
@@ -1798,7 +1798,7 @@ export class KeyManagementServiceClient {
       request?: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listCryptoKeys.createStream(
       this._innerApiCalls.listCryptoKeys as gax.GaxCall,
@@ -1896,7 +1896,7 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listCryptoKeyVersions(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listCryptoKeyVersions}, but returns a NodeJS Stream object.
@@ -1941,7 +1941,7 @@ export class KeyManagementServiceClient {
       request?: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listCryptoKeyVersions.createStream(
       this._innerApiCalls.listCryptoKeyVersions as gax.GaxCall,
@@ -2036,7 +2036,7 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listImportJobs(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listImportJobs}, but returns a NodeJS Stream object.
@@ -2078,7 +2078,7 @@ export class KeyManagementServiceClient {
       request?: protosTypes.google.cloud.kms.v1.IListImportJobsRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listImportJobs.createStream(
       this._innerApiCalls.listImportJobs as gax.GaxCall,

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -28,9 +28,9 @@ const version = require('../../../package.json').version;
 
 /**
  *  Configures and manages Cloud Memorystore for Redis instances
- * 
+ *
  *  Google Cloud Memorystore for Redis v1beta1
- * 
+ *
  *  The `redis.googleapis.com` service implements the Google Cloud Memorystore
  *  for Redis API and defines the following resource model for managing Redis
  *  instances:
@@ -39,7 +39,7 @@ const version = require('../../../package.json').version;
  *  * Each location has a collection of Redis instances, named: `/instances/*`
  *  * As such, Redis instances are resources of the form:
  *    `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
- * 
+ *
  *  Note that location_id must be refering to a GCP `region`; for example:
  *  * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
  * @class
@@ -428,7 +428,7 @@ export class CloudRedisClient {
  *   where `location_id` refers to a GCP region.
  * @param {string} request.instanceId
  *   Required. The logical name of the Redis instance in the customer project
- *   with the following restrictions: 
+ *   with the following restrictions:
  *
  *   * Must contain only lowercase letters, numbers, and hyphens.
  *   * Must start with a letter.
@@ -501,7 +501,7 @@ export class CloudRedisClient {
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required. Mask of fields to update. At least one path must be supplied in
  *   this field. The elements of the repeated paths field may only include these
- *   fields from [Instance][google.cloud.redis.v1beta1.Instance]: 
+ *   fields from [Instance][google.cloud.redis.v1beta1.Instance]:
  *
  *    *   `displayName`
  *    *   `labels`
@@ -845,7 +845,7 @@ export class CloudRedisClient {
  *       `projects/{project_id}/locations/{location_id}`
  *   where `location_id` refers to a GCP region.
  * @param {number} request.pageSize
- *   The maximum number of items to return. 
+ *   The maximum number of items to return.
  *
  *   If not specified, a default value of 1000 will be used by the service.
  *   Regardless of the page_size value, the response may include a partial list
@@ -906,7 +906,7 @@ export class CloudRedisClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listInstances(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listInstances}, but returns a NodeJS Stream object.
@@ -928,7 +928,7 @@ export class CloudRedisClient {
  *       `projects/{project_id}/locations/{location_id}`
  *   where `location_id` refers to a GCP region.
  * @param {number} request.pageSize
- *   The maximum number of items to return. 
+ *   The maximum number of items to return.
  *
  *   If not specified, a default value of 1000 will be used by the service.
  *   Regardless of the page_size value, the response may include a partial list
@@ -947,7 +947,7 @@ export class CloudRedisClient {
       request?: protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listInstances.createStream(
       this._innerApiCalls.listInstances as gax.GaxCall,

--- a/typescript/test/testdata/showcase/protos/google/showcase/v1beta1/echo.proto.baseline
+++ b/typescript/test/testdata/showcase/protos/google/showcase/v1beta1/echo.proto.baseline
@@ -96,7 +96,7 @@ service Echo {
 }
 
 // The request message used for the Echo, Collect and Chat methods. If content
-// is set in this message then the request will succeed. If status is set in 
+// is set in this message then the request will succeed. If status is set in
 // this message then the status will be returned as an error.
 message EchoRequest {
   oneof response {

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -344,7 +344,7 @@ export class EchoClient {
       request?: protosTypes.google.showcase.v1beta1.IExpandRequest,
       options?: gax.CallOptions):
     gax.CancellableStream{
-    request = request || {}; 
+    request = request || {};
     options = options || {};
     return this._innerApiCalls.expand(request, options);
   }
@@ -367,7 +367,7 @@ export class EchoClient {
  *
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Stream} - A writable stream which accepts objects representing 
+ * @returns {Stream} - A writable stream which accepts objects representing
  * [EchoRequest]{@link google.showcase.v1beta1.EchoRequest}.
  */
   collect(
@@ -393,7 +393,7 @@ export class EchoClient {
  *
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Stream} 
+ * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
  *   representing [EchoRequest]{@link google.showcase.v1beta1.EchoRequest} for write() method, and
  *   will emit objects representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse} on 'data' event asynchronously.
@@ -536,7 +536,7 @@ export class EchoClient {
     }
     options = options || {};
     return this._innerApiCalls.pagedExpand(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link pagedExpand}, but returns a NodeJS Stream object.
@@ -568,7 +568,7 @@ export class EchoClient {
       request?: protosTypes.google.showcase.v1beta1.IPagedExpandRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.pagedExpand.createStream(
       this._innerApiCalls.pagedExpand as gax.GaxCall,

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -330,35 +330,35 @@ export class TranslationServiceClient {
  *   text, set to one of the language codes listed in Language Support.
  * @param {string} request.parent
  *   Required. Project or location to make a call. Must refer to a caller's
- *   project. 
+ *   project.
  *
  *   Format: `projects/{project-id}` or
- *   `projects/{project-id}/locations/{location-id}`. 
+ *   `projects/{project-id}/locations/{location-id}`.
  *
  *   For global calls, use `projects/{project-id}/locations/global` or
- *   `projects/{project-id}`. 
+ *   `projects/{project-id}`.
  *
  *   Non-global location is required for requests using AutoML models or
- *   custom glossaries. 
+ *   custom glossaries.
  *
  *   Models and glossaries must be within the same region (have same
  *   location-id), otherwise an INVALID_ARGUMENT (400) error is returned.
  * @param {string} [request.model]
- *   Optional. The `model` type requested for this translation. 
+ *   Optional. The `model` type requested for this translation.
  *
- *   The format depends on model type: 
+ *   The format depends on model type:
  *
  *   - AutoML Translation models:
- *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
+ *     `projects/{project-id}/locations/{location-id}/models/{model-id}`
  *
  *   - General (built-in) models:
  *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
- *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- * 
+ *     `projects/{project-id}/locations/{location-id}/models/general/base`
+ *
  *
  *   For global (non-regionalized) requests, use `location-id` `global`.
  *   For example,
- *   `projects/{project-id}/locations/global/models/general/nmt`. 
+ *   `projects/{project-id}/locations/global/models/general/nmt`.
  *
  *   If missing, the system decides which google base model to use.
  * @param {google.cloud.translation.v3beta1.TranslateTextGlossaryConfig} [request.glossaryConfig]
@@ -366,12 +366,12 @@ export class TranslationServiceClient {
  *   within the same region (have the same location-id) as the model, otherwise
  *   an INVALID_ARGUMENT (400) error is returned.
  * @param {number[]} [request.labels]
- *   Optional. The labels with user-defined metadata for the request. 
+ *   Optional. The labels with user-defined metadata for the request.
  *
  *   Label keys and values can be no longer than 63 characters
  *   (Unicode codepoints), can only contain lowercase letters, numeric
  *   characters, underscores and dashes. International characters are allowed.
- *   Label values are optional. Label keys must start with a letter. 
+ *   Label values are optional. Label keys must start with a letter.
  *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
@@ -433,24 +433,24 @@ export class TranslationServiceClient {
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. Project or location to make a call. Must refer to a caller's
- *   project. 
+ *   project.
  *
  *   Format: `projects/{project-id}/locations/{location-id}` or
- *   `projects/{project-id}`. 
+ *   `projects/{project-id}`.
  *
  *   For global calls, use `projects/{project-id}/locations/global` or
- *   `projects/{project-id}`. 
+ *   `projects/{project-id}`.
  *
  *   Only models within the same region (has same location-id) can be used.
  *   Otherwise an INVALID_ARGUMENT (400) error is returned.
  * @param {string} [request.model]
- *   Optional. The language detection model to be used. 
+ *   Optional. The language detection model to be used.
  *
  *   Format:
- *   `projects/{project-id}/locations/{location-id}/models/language-detection/{model-id}` 
+ *   `projects/{project-id}/locations/{location-id}/models/language-detection/{model-id}`
  *
  *   Only one language detection model is currently supported:
- *   `projects/{project-id}/locations/{location-id}/models/language-detection/default`. 
+ *   `projects/{project-id}/locations/{location-id}/models/language-detection/default`.
  *
  *   If not specified, the default model is used.
  * @param {string} request.content
@@ -459,12 +459,12 @@ export class TranslationServiceClient {
  *   Optional. The format of the source text, for example, "text/html",
  *   "text/plain". If left blank, the MIME type defaults to "text/html".
  * @param {number[]} request.labels
- *   Optional. The labels with user-defined metadata for the request. 
+ *   Optional. The labels with user-defined metadata for the request.
  *
  *   Label keys and values can be no longer than 63 characters
  *   (Unicode codepoints), can only contain lowercase letters, numeric
  *   characters, underscores and dashes. International characters are allowed.
- *   Label values are optional. Label keys must start with a letter. 
+ *   Label values are optional. Label keys must start with a letter.
  *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
@@ -526,15 +526,15 @@ export class TranslationServiceClient {
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. Project or location to make a call. Must refer to a caller's
- *   project. 
+ *   project.
  *
  *   Format: `projects/{project-id}` or
- *   `projects/{project-id}/locations/{location-id}`. 
+ *   `projects/{project-id}/locations/{location-id}`.
  *
  *   For global calls, use `projects/{project-id}/locations/global` or
- *   `projects/{project-id}`. 
+ *   `projects/{project-id}`.
  *
- *   Non-global location is required for AutoML models. 
+ *   Non-global location is required for AutoML models.
  *
  *   Only models within the same region (have same location-id) can be used,
  *   otherwise an INVALID_ARGUMENT (400) error is returned.
@@ -543,17 +543,17 @@ export class TranslationServiceClient {
  *   of supported languages. If missing, then display names are not returned
  *   in a response.
  * @param {string} [request.model]
- *   Optional. Get supported languages of this model. 
+ *   Optional. Get supported languages of this model.
  *
- *   The format depends on model type: 
+ *   The format depends on model type:
  *
  *   - AutoML Translation models:
- *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
+ *     `projects/{project-id}/locations/{location-id}/models/{model-id}`
  *
  *   - General (built-in) models:
  *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
- *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- * 
+ *     `projects/{project-id}/locations/{location-id}/models/general/base`
+ *
  *
  *   Returns languages supported by the specified model.
  *   If missing, we get supported languages of Google general base (PBMT) model.
@@ -682,11 +682,11 @@ export class TranslationServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. Location to make a call. Must refer to a caller's project. 
+ *   Required. Location to make a call. Must refer to a caller's project.
  *
- *   Format: `projects/{project-id}/locations/{location-id}`. 
+ *   Format: `projects/{project-id}/locations/{location-id}`.
  *
- *   The `global` location is not supported for batch translation. 
+ *   The `global` location is not supported for batch translation.
  *
  *   Only AutoML Translation models or glossaries within the same region (have
  *   the same location-id) can be used, otherwise an INVALID_ARGUMENT (400)
@@ -698,17 +698,17 @@ export class TranslationServiceClient {
  * @param {number[]} [request.models]
  *   Optional. The models to use for translation. Map's key is target language
  *   code. Map's value is model name. Value can be a built-in general model,
- *   or an AutoML Translation model. 
+ *   or an AutoML Translation model.
  *
- *   The value format depends on model type: 
+ *   The value format depends on model type:
  *
  *   - AutoML Translation models:
- *     `projects/{project-id}/locations/{location-id}/models/{model-id}` 
+ *     `projects/{project-id}/locations/{location-id}/models/{model-id}`
  *
  *   - General (built-in) models:
  *     `projects/{project-id}/locations/{location-id}/models/general/nmt`,
- *     `projects/{project-id}/locations/{location-id}/models/general/base` 
- * 
+ *     `projects/{project-id}/locations/{location-id}/models/general/base`
+ *
  *
  *   If the map is empty or a specific model is
  *   not requested for a language pair, then default google model (nmt) is used.
@@ -725,12 +725,12 @@ export class TranslationServiceClient {
  *   Optional. Glossaries to be applied for translation.
  *   It's keyed by target language code.
  * @param {number[]} [request.labels]
- *   Optional. The labels with user-defined metadata for the request. 
+ *   Optional. The labels with user-defined metadata for the request.
  *
  *   Label keys and values can be no longer than 63 characters
  *   (Unicode codepoints), can only contain lowercase letters, numeric
  *   characters, underscores and dashes. International characters are allowed.
- *   Label values are optional. Label keys must start with a letter. 
+ *   Label values are optional. Label keys must start with a letter.
  *
  *   See https://cloud.google.com/translate/docs/labels for more information.
  * @param {object} [options]
@@ -980,7 +980,7 @@ export class TranslationServiceClient {
       'parent': request.parent || '',
     });
     return this._innerApiCalls.listGlossaries(request, options, callback);
-  } 
+  }
 
 /**
  * Equivalent to {@link listGlossaries}, but returns a NodeJS Stream object.
@@ -1020,7 +1020,7 @@ export class TranslationServiceClient {
       request?: protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest,
       options?: gax.CallOptions | {}):
     Transform{
-    request = request || {}; 
+    request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listGlossaries.createStream(
       this._innerApiCalls.listGlossaries as gax.GaxCall,


### PR DESCRIPTION
For all trailing whitespace haters (looking at you @JustinBeckwith and @schmidt-sebastian :) ), here we go :) A little bit of `find templates typescript README.md -type f | xargs perl -pi -e 's/[\s\r]+\n/\n/g'` plus a small change in the templates to make sure the generated comments also have no trailing whitespace. Enjoy!