### PR TITLE
fix: camelCase more proto identifiers

### DIFF
--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -193,7 +193,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
             {{ chain }}.{{ field.toCamelCase() }} = {};
 {%- set chain = chain + "." + field.toCamelCase() -%}
 {%- endfor %}
-            {{ chain }}.{{ method.headerRequestParams.slice(-1)[0] }} = '';
+            {{ chain }}.{{ method.headerRequestParams.slice(-1)[0].toCamelCase() }} = '';
 {%- endif %}
 {%- endmacro -%}
 

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -379,7 +379,7 @@ export class {{ service.name }}Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.camelCaseBeforeDot("!.") }} || '',
+      '{{ method.headerRequestParams.toSnakeCaseString(".") }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
@@ -487,7 +487,7 @@ export class {{ service.name }}Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.camelCaseBeforeDot("!.") }} || '',
+      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
@@ -543,7 +543,7 @@ export class {{ service.name }}Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.camelCaseBeforeDot("!.") }} || '',
+      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
     });
 {%- endif %}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -23,5 +23,6 @@ interface String {
 }
 
 interface Array<T> {
-  camelCaseBeforeDot(this: string[], joiner: string): string;
+  toCamelCaseString(this: string[], joiner: string): string;
+  toSnakeCaseString(this: string[], joiner: string): string;
 }

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -128,13 +128,16 @@ String.prototype.replaceAll = function(
   return this.split(search).join(replacement);
 };
 
-Array.prototype.camelCaseBeforeDot = function(
+Array.prototype.toCamelCaseString = function(
   this: string[],
   joiner: string
 ): string {
-  if (this.length <= 1) {
-    return this.toString().toCamelCase();
-  }
-  const res = this.slice(0, -1).map(w => w.toCamelCase());
-  return res.join(joiner) + joiner + this[this.length - 1];
+  return this.map(part => part.toCamelCase()).join(joiner);
+};
+
+Array.prototype.toSnakeCaseString = function(
+  this: string[],
+  joiner: string
+): string {
+  return this.map(part => part.toSnakeCase()).join(joiner);
 };

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -977,7 +977,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key_name': request.cryptoKey!.name || '',
+      'crypto_key.name': request.cryptoKey!.name || '',
     });
     return this._innerApiCalls.updateCryptoKey(request, options, callback);
   }
@@ -1044,7 +1044,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key_version_name': request.cryptoKeyVersion!.name || '',
+      'crypto_key_version.name': request.cryptoKeyVersion!.name || '',
     });
     return this._innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -311,43 +311,86 @@ describe('util.ts', () => {
   });
 
   describe('array manipulation', () => {
-    it('should convert to camel case except last element', () => {
-      it('should convert to camelCase before dot', () => {
-        assert.deepStrictEqual([''].camelCaseBeforeDot('!.'), '');
-        assert.deepStrictEqual(['test'].camelCaseBeforeDot('!.'), 'test');
-        assert.deepStrictEqual(
-          ['camelCaseString'].camelCaseBeforeDot('!.'),
-          'camelCaseString'
-        );
-        assert.deepStrictEqual(
-          ['PascalCaseString'].camelCaseBeforeDot('!.'),
-          'pascalCaseString'
-        );
-        assert.deepStrictEqual(
-          ['snake_case_string'].camelCaseBeforeDot('!.'),
-          'snakeCaseString'
-        );
-        assert.deepStrictEqual(
-          ['kebab-case-string'].camelCaseBeforeDot('!.'),
-          'kebabCaseString'
-        );
-        assert.deepStrictEqual(
-          ['random/separators-string'].camelCaseBeforeDot('!.'),
-          'randomSeparatorsString'
-        );
-        assert.deepStrictEqual(
-          ['mixedType-string', 'SomewhatWeird'].camelCaseBeforeDot('!.'),
-          'mixedTypeString!.SomewhatWeird'
-        );
-        assert.deepStrictEqual(
-          ['productName', 'v1p1beta1'].camelCaseBeforeDot('!.'),
-          'productName!.v1p1beta1'
-        );
-        assert.deepStrictEqual(
-          ['product_key', 'lower_name', 'v1p1beta1'].camelCaseBeforeDot('!.'),
-          'productKey!.lowerName!.v1p1beta1'
-        );
-      });
+    it('should convert array to camel case string using the joiner', () => {
+      assert.deepStrictEqual([''].toCamelCaseString('!.'), '');
+      assert.deepStrictEqual(['test'].toCamelCaseString('!.'), 'test');
+      assert.deepStrictEqual(
+        ['camelCaseString'].toCamelCaseString('!.'),
+        'camelCaseString'
+      );
+      assert.deepStrictEqual(
+        ['PascalCaseString'].toCamelCaseString('!.'),
+        'pascalCaseString'
+      );
+      assert.deepStrictEqual(
+        ['snake_case_string'].toCamelCaseString('!.'),
+        'snakeCaseString'
+      );
+      assert.deepStrictEqual(
+        ['kebab-case-string'].toCamelCaseString('!.'),
+        'kebabCaseString'
+      );
+      assert.deepStrictEqual(
+        ['random/separators-string'].toCamelCaseString('!.'),
+        'randomSeparatorsString'
+      );
+      assert.deepStrictEqual(
+        ['mixedType-string', 'SomewhatWeird'].toCamelCaseString('!.'),
+        'mixedTypeString!.somewhatWeird'
+      );
+      assert.deepStrictEqual(
+        ['productName', 'v1p1beta1'].toCamelCaseString('!.'),
+        'productName!.v1p1beta1'
+      );
+      assert.deepStrictEqual(
+        ['product_key', 'lower_name', 'v1p1beta1'].toCamelCaseString('!.'),
+        'productKey!.lowerName!.v1p1beta1'
+      );
+      assert.deepStrictEqual(
+        ['tableReference', 'project_id'].toCamelCaseString('!.'),
+        'tableReference!.projectId'
+      );
+    });
+
+    it('should convert array to snake case string using the joiner', () => {
+      assert.deepStrictEqual([''].toSnakeCaseString('!.'), '');
+      assert.deepStrictEqual(['test'].toSnakeCaseString('!.'), 'test');
+      assert.deepStrictEqual(
+        ['camelCaseString'].toSnakeCaseString('!.'),
+        'camel_case_string'
+      );
+      assert.deepStrictEqual(
+        ['PascalCaseString'].toSnakeCaseString('!.'),
+        'pascal_case_string'
+      );
+      assert.deepStrictEqual(
+        ['snake_case_string'].toSnakeCaseString('!.'),
+        'snake_case_string'
+      );
+      assert.deepStrictEqual(
+        ['kebab-case-string'].toSnakeCaseString('!.'),
+        'kebab_case_string'
+      );
+      assert.deepStrictEqual(
+        ['random/separators-string'].toSnakeCaseString('!.'),
+        'random_separators_string'
+      );
+      assert.deepStrictEqual(
+        ['mixedType-string', 'SomewhatWeird'].toSnakeCaseString('!.'),
+        'mixed_type_string!.somewhat_weird'
+      );
+      assert.deepStrictEqual(
+        ['productName', 'v1p1beta1'].toSnakeCaseString('!.'),
+        'product_name!.v1p1beta1'
+      );
+      assert.deepStrictEqual(
+        ['product_key', 'lower_name', 'v1p1beta1'].toSnakeCaseString('!.'),
+        'product_key!.lower_name!.v1p1beta1'
+      );
+      assert.deepStrictEqual(
+        ['tableReference', 'project_id'].toSnakeCaseString('!.'),
+        'table_reference!.project_id'
+      );
     });
   });
 });


### PR DESCRIPTION
In https://github.com/googleapis/nodejs-bigquery-storage/pull/1 we see that the last element of `request.tableReference.project_id` should also be in the camel case (`request.tableReference.projectId`), otherwise it won't match the TypeScript type.

Fixing this in both client and unit test templates.

Also, the headers should still contain `table_reference.project_id` (snake case, joined with a dot), not just one snake cased line as now.