### PR TITLE
fix: resource ids can contain underscores and trailing characters

### DIFF
--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -66,9 +66,9 @@ export class ResourceDatabase {
       }
       return;
     }
-    const params = pattern[0].match(/{[a-zA-Z]+}/g) || [];
+    const params = pattern[0].match(/{[a-zA-Z_]+(?:=.*?)?}/g) || [];
     for (let i = 0; i < params.length; i++) {
-      params[i] = params[i].replace('{', '').replace('}', '');
+      params[i] = params[i].replace(/{([a-zA-Z_]+).*/, '$1');
     }
 
     const resourceDescriptor: ResourceDescriptor = Object.assign(

--- a/typescript/test/unit/resourceDatabase.ts
+++ b/typescript/test/unit/resourceDatabase.ts
@@ -165,4 +165,23 @@ describe('ResourceDatabase', () => {
     assert.strictEqual(parentResources[1].name, resourceName);
     assert.strictEqual(warnings.length, 0);
   });
+
+  it('can parse different patterns into parameters', () => {
+    const rdb = new ResourceDatabase();
+    const resource: plugin.google.api.IResourceDescriptor = {
+      type: resourceType,
+      pattern: [
+        'lettersdigits/{abc123}/underscores/{snake_case}/trailing/{trailing=**}',
+      ],
+    };
+
+    rdb.registerResource(resource, errorLocation);
+    const registeredResource = rdb.getResourceByType(resourceType);
+    assert(registeredResource);
+    assert.deepStrictEqual(registeredResource!.params, [
+      'snake_case',
+      'trailing',
+    ]);
+    assert.strictEqual(warnings.length, 0);
+  });
 });


### PR DESCRIPTION
Fixes #204. We should allow underscores and possible trailing `=**`, but not digits.