### PR TITLE
fix: use ubuntu-based image instead of alpine-based, update protoc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12
 
 # Create folder structure
 RUN mkdir -p /in
@@ -11,11 +11,9 @@ COPY ./package.tgz /root/files/
 RUN npm install -g /root/files/package.tgz
 
 # Download and install protoc
-RUN apk update && apk add libc6-compat && rm -f /var/cache/apk/*
-ENV LD_LIBRARY_PATH /lib64:$LD_LIBRARY_PATH
 RUN cd /root/files && \
-    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip
-RUN cd /usr/local && unzip /root/files/protoc-3.10.0-linux-x86_64.zip
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip
+RUN cd /usr/local && unzip /root/files/protoc-3.11.2-linux-x86_64.zip
 
 # Download a copy of API common protos
 RUN cd /root/files && \


### PR DESCRIPTION
Alpine got broken :)  They removed `__strftime_l` from `/lib64/ld-linux-x86-64.so.2` (it existed in `libc6-compat-1.1.20-r5` but is missing in `libc6-compat-1.1.24-r0`, I'm guessing it's [this commit](https://gitlab.alpinelinux.org/alpine/aports/commit/f6baa2aad98a418cd21b857f825e772a987b7c93#0b6ead39bf26fd40f7e2f862e39d543f2821fca3_0_19) that causes it.

`protoc` binary needs this symbol:

```
# ldd /usr/local/bin/protoc
	/lib64/ld-linux-x86-64.so.2 (0x7f7a983cf000)
	libm.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f7a983cf000)
	libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f7a983cf000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f7a983cf000)
Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /usr/local/bin/protoc)
Error relocating /usr/local/bin/protoc: __strftime_l: symbol not found
```

I don't want to build `protoc` from source in our image, so... let's drop alpine and switch to ubuntu :)

Also, updating `protoc` to the latest available version (3.11.2).