### PR TITLE
fix: parameters should be camelcase in path template function

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -587,7 +587,7 @@ export class {{ service.name }}Client {
   ) {
     return this._pathTemplates.{{ template.name.toLowerCase() }}PathTemplate.render({
 {%- for param in template.params %}
-      {{ param.toCamelCase() }}: {{ param.toCamelCase() }},
+      {{ param }}: {{ param.toCamelCase() }},
 {%- endfor %}
     });
   }

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -582,12 +582,12 @@ export class {{ service.name }}Client {
   {{ template.name.toCamelCase() }}Path(
 {%- set paramJoiner = joiner() %}
 {%- for param in template.params %}
-{{-paramJoiner()-}}{{ param }}:string
+{{-paramJoiner()-}}{{ param.toCamelCase() }}:string
 {%- endfor -%}
   ) {
     return this._pathTemplates.{{ template.name.toLowerCase() }}PathTemplate.render({
 {%- for param in template.params %}
-      {{ param }}: {{ param }},
+      {{ param.toCamelCase() }}: {{ param.toCamelCase() }},
 {%- endfor %}
     });
   }


### PR DESCRIPTION
```
  incidentRoleAssignmentPath(
    project_id_or_number: string,
    incident_id: string,
    role_id: string
  ) {
    return this._pathTemplates.incidentroleassignmentPathTemplate.render({
      project_id_or_number,
      incident_id,
      role_id,
    });
  }
```
tslint fail for `variable name must be in lowerCamelCase or UPPER_CASE` 