### PR TITLE
fix: make sure the order of protos is fixed

### DIFF
--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -120,9 +120,11 @@ export class API {
 
   get protoFilesToGenerateJSON() {
     return JSON.stringify(
-      this.filesToGenerate.map(file => {
-        return `../../protos/${file}`;
-      }),
+      this.filesToGenerate
+        .map(file => {
+          return `../../protos/${file}`;
+        })
+        .sort(),
       null,
       '  '
     );

--- a/typescript/test/testdata/dlp/src/v2/dlp_service_proto_list.json.baseline
+++ b/typescript/test/testdata/dlp/src/v2/dlp_service_proto_list.json.baseline
@@ -1,4 +1,4 @@
 [
-  "../../protos/google/privacy/dlp/v2/storage.proto",
-  "../../protos/google/privacy/dlp/v2/dlp.proto"
+  "../../protos/google/privacy/dlp/v2/dlp.proto",
+  "../../protos/google/privacy/dlp/v2/storage.proto"
 ]

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -109,4 +109,27 @@ describe('schema/api.ts', () => {
     });
     assert.deepStrictEqual(api.mainServiceName, 'OverriddenName');
   });
+
+  it('should return list of protos in lexicographical order', () => {
+    const fd1 = new plugin.google.protobuf.FileDescriptorProto();
+    fd1.name = 'google/cloud/example/v1/test.proto';
+    fd1.package = 'google.cloud.example.v1';
+
+    fd1.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    fd1.service[0].name = 'Service';
+    fd1.service[0].options = {
+      '.google.api.defaultHost': 'hostname.example.com:443',
+    };
+    const fd2 = new plugin.google.protobuf.FileDescriptorProto();
+    fd2.name = 'google/cloud/example/v1/example.proto';
+    fd2.package = 'google.cloud.example.v1';
+    fd2.service = [];
+    const api = new API([fd1, fd2], 'google.cloud.example.v1', {
+      grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
+    });
+    assert.deepStrictEqual(JSON.parse(api.protoFilesToGenerateJSON), [
+      '../../protos/google/cloud/example/v1/example.proto',
+      '../../protos/google/cloud/example/v1/test.proto',
+    ]);
+  });
 });


### PR DESCRIPTION
We got some PRs that changed only the order of protos after proto update (maybe because the file update time was somehow used in the default ordering). I think it's a good time to make the order fixed.

Example PRs: https://github.com/googleapis/nodejs-monitoring/pull/353, https://github.com/googleapis/nodejs-datacatalog/pull/101, https://github.com/googleapis/nodejs-datalabeling/pull/119

@bcoe This will likely cause some autosynth PRs with reordering, I will take care of those, and then it should reduce the amount of proto-rearranging PRs.