### PR TITLE
feat: support proto packages in different namespace

### DIFF
--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -16,9 +16,10 @@ import * as plugin from '../../../pbjs-genfiles/plugin';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { Naming } from './naming';
+import { Naming, Options as namingOptions } from './naming';
 import { Proto, MessagesMap } from './proto';
 import { ResourceDatabase, ResourceDescriptor } from './resourceDatabase';
+import { Options } from 'yargs-parser';
 
 const googleGaxLocation = path.dirname(require.resolve('google-gax'));
 const gaxProtosLocation = path.join(googleGaxLocation, '..', '..', 'protos');
@@ -41,11 +42,7 @@ export class API {
   constructor(
     fileDescriptors: plugin.google.protobuf.IFileDescriptorProto[],
     packageName: string,
-    options: {
-      grpcServiceConfig: plugin.grpc.service_config.ServiceConfig;
-      publishName?: string;
-      mainServiceName?: string;
-    }
+    options: namingOptions
   ) {
     this.naming = new Naming(
       fileDescriptors.filter(

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -50,7 +50,8 @@ export class API {
     this.naming = new Naming(
       fileDescriptors.filter(
         fd => fd.package && fd.package.startsWith(packageName)
-      ), options
+      ),
+      options
     );
     // users specify the actual package name, if not, set it to product name.
     this.publishName =

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -50,7 +50,7 @@ export class API {
     this.naming = new Naming(
       fileDescriptors.filter(
         fd => fd.package && fd.package.startsWith(packageName)
-      )
+      ), options
     );
     // users specify the actual package name, if not, set it to product name.
     this.publishName =

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -27,8 +27,11 @@ export class Naming {
   productName: string;
   protoPackage: string;
 
-  constructor(fileDescriptors: plugin.google.protobuf.IFileDescriptorProto[], options?: Options) {
-    let rootPackage: string = '';
+  constructor(
+    fileDescriptors: plugin.google.protobuf.IFileDescriptorProto[],
+    options?: Options
+  ) {
+    let rootPackage = '';
     const mainServiceName = options ? options.mainServiceName : '';
     const protoPackages = fileDescriptors
       .filter(fd => fd.service && fd.service.length > 0)
@@ -39,10 +42,13 @@ export class Naming {
     // common prefix must either end with `.`, or be equal to at least one of
     // the packages' prefix
     if (!prefix.endsWith('.') && !protoPackages.some(pkg => pkg === prefix)) {
-      if(mainServiceName) rootPackage = this.checkServiceInPackage(protoPackages, mainServiceName);
+      if (mainServiceName)
+        rootPackage = this.checkServiceInPackage(
+          protoPackages,
+          mainServiceName
+        );
       else throw new Error('Protos provided have different proto packages.');
-    }
-    else rootPackage = prefix.replace(/\.$/, '');
+    } else rootPackage = prefix.replace(/\.$/, '');
     const segments = rootPackage.split('.');
     if (!segments || segments.length < 2) {
       throw new Error(`Cannot parse package name ${rootPackage}.`);
@@ -70,10 +76,14 @@ export class Naming {
     }
   }
 
-  private checkServiceInPackage(protoPackages: string[], mainServiceName: string){
-    for(const packageName of protoPackages){
-      if(packageName.indexOf(mainServiceName.toLowerCase()) !== -1)
+  private checkServiceInPackage(
+    protoPackages: string[],
+    mainServiceName: string
+  ) {
+    for (const packageName of protoPackages) {
+      if (packageName.indexOf(mainServiceName.toLowerCase()) !== -1) {
         return packageName;
+      }
     }
     return '';
   }

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -41,14 +41,15 @@ export class Naming {
     const prefix = commonPrefix(protoPackages);
     // common prefix must either end with `.`, or be equal to at least one of
     // the packages' prefix
-    if (!prefix.endsWith('.') && !protoPackages.some(pkg => pkg === prefix)) {
-      if (mainServiceName) {
-        rootPackage = this.checkServiceInPackage(
-          protoPackages,
-          mainServiceName
-        );
-      } else throw new Error('Protos provided have different proto packages.');
-    } else rootPackage = prefix.replace(/\.$/, '');
+    const invalidPrefix =
+      !prefix.endsWith('.') && !protoPackages.some(pkg => pkg === prefix);
+    if (invalidPrefix && mainServiceName) {
+      rootPackage = this.checkServiceInPackage(protoPackages, mainServiceName);
+    } else if (invalidPrefix && !mainServiceName) {
+      throw new Error('Protos provided have different proto packages.');
+    } else {
+      rootPackage = prefix.replace(/\.$/, '');
+    }
     const segments = rootPackage.split('.');
     if (!segments || segments.length < 2) {
       throw new Error(`Cannot parse package name ${rootPackage}.`);

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -45,9 +45,11 @@ export class Naming {
       !prefix.endsWith('.') && !protoPackages.some(pkg => pkg === prefix);
     if (invalidPrefix && mainServiceName) {
       rootPackage = this.checkServiceInPackage(protoPackages, mainServiceName);
-    } else if (invalidPrefix && !mainServiceName) {
+    }
+    if (invalidPrefix && !mainServiceName) {
       throw new Error('Protos provided have different proto packages.');
-    } else {
+    }
+    if (!invalidPrefix) {
       rootPackage = prefix.replace(/\.$/, '');
     }
     const segments = rootPackage.split('.');

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -42,12 +42,12 @@ export class Naming {
     // common prefix must either end with `.`, or be equal to at least one of
     // the packages' prefix
     if (!prefix.endsWith('.') && !protoPackages.some(pkg => pkg === prefix)) {
-      if (mainServiceName)
+      if (mainServiceName) {
         rootPackage = this.checkServiceInPackage(
           protoPackages,
           mainServiceName
         );
-      else throw new Error('Protos provided have different proto packages.');
+      } else throw new Error('Protos provided have different proto packages.');
     } else rootPackage = prefix.replace(/\.$/, '');
     const segments = rootPackage.split('.');
     if (!segments || segments.length < 2) {

--- a/typescript/test/unit/naming.ts
+++ b/typescript/test/unit/naming.ts
@@ -125,7 +125,7 @@ describe('schema/naming.ts', () => {
     });
   });
 
-    it('parse name correctly if no common package, but service-name specified', () => {
+  it('parse name correctly if no common package, but service-name specified', () => {
     const descriptor1 = new plugin.google.protobuf.FileDescriptorProto();
     const descriptor2 = new plugin.google.protobuf.FileDescriptorProto();
     descriptor1.package = 'namespace1.service1.v1beta1';
@@ -133,7 +133,10 @@ describe('schema/naming.ts', () => {
     descriptor2.package = 'namespace2.service2.v1beta1';
     descriptor2.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
     const serviceConfig = new plugin.grpc.service_config.ServiceConfig();
-    const options : Options= {grpcServiceConfig: serviceConfig, mainServiceName:'service1'};
+    const options: Options = {
+      grpcServiceConfig: serviceConfig,
+      mainServiceName: 'service1',
+    };
     assert.throws(() => {
       const naming = new Naming([descriptor1, descriptor2], options);
       assert.strictEqual(naming.name, 'service1');

--- a/typescript/test/unit/naming.ts
+++ b/typescript/test/unit/naming.ts
@@ -15,7 +15,7 @@
 import * as assert from 'assert';
 import { describe, it } from 'mocha';
 import * as plugin from '../../../pbjs-genfiles/plugin';
-import { Naming } from '../../src/schema/naming';
+import { Naming, Options } from '../../src/schema/naming';
 
 describe('schema/naming.ts', () => {
   it('parses name correctly', () => {
@@ -113,7 +113,7 @@ describe('schema/naming.ts', () => {
     });
   });
 
-  it('fails if no common package', () => {
+  it('fails if no common package, no service-name', () => {
     const descriptor1 = new plugin.google.protobuf.FileDescriptorProto();
     const descriptor2 = new plugin.google.protobuf.FileDescriptorProto();
     descriptor1.package = 'namespace1.service.v1beta1';
@@ -122,6 +122,25 @@ describe('schema/naming.ts', () => {
     descriptor2.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
     assert.throws(() => {
       const naming = new Naming([descriptor1, descriptor2]);
+    });
+  });
+
+    it('parse name correctly if no common package, but service-name specified', () => {
+    const descriptor1 = new plugin.google.protobuf.FileDescriptorProto();
+    const descriptor2 = new plugin.google.protobuf.FileDescriptorProto();
+    descriptor1.package = 'namespace1.service1.v1beta1';
+    descriptor1.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    descriptor2.package = 'namespace2.service2.v1beta1';
+    descriptor2.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    const serviceConfig = new plugin.grpc.service_config.ServiceConfig();
+    const options : Options= {grpcServiceConfig: serviceConfig, mainServiceName:'service1'};
+    assert.throws(() => {
+      const naming = new Naming([descriptor1, descriptor2], options);
+      assert.strictEqual(naming.name, 'service1');
+      assert.strictEqual(naming.productName, 'service1');
+      assert.strictEqual(naming.version, 'v1beta1');
+      assert.strictEqual(naming.namespace, 'namespace1');
+      assert.strictEqual(naming.protoPackage, 'namespace1.service1.v1beta1');
     });
   });
 


### PR DESCRIPTION
fix #214 

If no common prefix package name is found, but users specify `main-service` option, we will take the package with the `main-service` name as root package. If `main-service` is not set, error will be thrown.