### PR TITLE
feat!: generate all api resources and resource definition which is referenced.

### DIFF
--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -159,7 +159,5 @@ function getResourceDatabase(
       );
     }
   }
-  console.warn('======= resource dtabase: ', resourceDatabase);
-  console.warn('======= resource definition database: ', resourceDefinitionDatabase);
   return [resourceDatabase, resourceDefinitionDatabase];
 }

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -53,7 +53,9 @@ export class API {
     this.publishName =
       options.publishName || this.naming.productName.toKebabCase();
     // construct resource map
-    const [resourceDatabase, resourceDefinitionDatabase] = getResourceDatabase(fileDescriptors);
+    const [resourceDatabase, resourceDefinitionDatabase] = getResourceDatabase(
+      fileDescriptors
+    );
     // parse resource map to Proto constructor
     this.protos = fileDescriptors
       .filter(fd => fd.name)
@@ -138,7 +140,7 @@ function getResourceDatabase(
     // process file-level options
     for (const resource of fd.options?.['.google.api.resourceDefinition'] ??
       []) {
-        resourceDefinitionDatabase.registerResource(
+      resourceDefinitionDatabase.registerResource(
         resource as ResourceDescriptor,
         `file ${fd.name} resource_definition option`
       );

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -554,12 +554,12 @@ function augmentService(
       let resourceByType = resourceDefinitionDatabase.getResourceByType(
         resourceReference?.type
       );
-      resourceByType = resourceByType
-        ? resourceByType
-        : resourceDatabase.getResourceByType(
-            resourceReference?.type,
-            errorLocation
-          );
+      resourceByType =
+        resourceByType ??
+        resourceDatabase.getResourceByType(
+          resourceReference?.type,
+          errorLocation
+        );
       if (!resourceByType || !resourceByType.pattern) continue;
       // For multi pattern resources, we look up the type first, and get the [pattern] from resource,
       // look up pattern map for all resources.

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -529,12 +529,12 @@ function augmentService(
   const uniqueResources: { [name: string]: ResourceDescriptor } = {};
   // Copy all resources in resourceDatabase to uniqueResources
   const allPatterns = resourceDatabase.patterns;
-  for(const pattern of Object.keys(allPatterns)){
+  for (const pattern of Object.keys(allPatterns)) {
     const resource = allPatterns[pattern];
     uniqueResources[resource.name] = resource;
   }
 
-  // Copy all resources definination which are referenced into unique resources map. 
+  // Copy all resources definination which are referenced into unique resources map.
   for (const property of Object.keys(messages)) {
     const errorLocation = `service ${service.name} message ${property}`;
     for (const fieldDescriptor of messages[property].field ?? []) {
@@ -542,7 +542,7 @@ function augmentService(
       const resourceReference =
         fieldDescriptor.options?.['.google.api.resourceReference'];
       // 1. If this resource reference has .child_type, figure out if we have any known parent resources.
-      let parentResources = resourceDefinitionDatabase.getParentResourcesByChildType(
+      const parentResources = resourceDefinitionDatabase.getParentResourcesByChildType(
         resourceReference?.childType,
         errorLocation
       );
@@ -551,8 +551,15 @@ function augmentService(
       );
 
       // 2. If this resource reference has .type, we should have a known resource with this type, check two maps.
-      let resourceByType = resourceDefinitionDatabase.getResourceByType(resourceReference?.type);
-      resourceByType = resourceByType ? resourceByType : resourceDatabase.getResourceByType(resourceReference?.type, errorLocation);
+      let resourceByType = resourceDefinitionDatabase.getResourceByType(
+        resourceReference?.type
+      );
+      resourceByType = resourceByType
+        ? resourceByType
+        : resourceDatabase.getResourceByType(
+            resourceReference?.type,
+            errorLocation
+          );
       if (!resourceByType || !resourceByType.pattern) continue;
       // For multi pattern resources, we look up the type first, and get the [pattern] from resource,
       // look up pattern map for all resources.
@@ -581,8 +588,8 @@ export class Proto {
     fd: plugin.google.protobuf.IFileDescriptorProto,
     packageName: string,
     grpcServiceConfig: plugin.grpc.service_config.ServiceConfig,
-    resourceDatabase: ResourceDatabase, 
-    resourceDefinitionDatabase: ResourceDatabase,
+    resourceDatabase: ResourceDatabase,
+    resourceDefinitionDatabase: ResourceDatabase
   ) {
     fd.enumType = fd.enumType || [];
     fd.messageType = fd.messageType || [];

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -21,14 +21,12 @@ export interface ResourceDescriptor
 }
 
 export class ResourceDatabase {
-  private patterns: { [pattern: string]: ResourceDescriptor };
-  private types: { [type: string]: ResourceDescriptor };
-  public names: {[name: string]: ResourceDescriptor}
+  public patterns: { [pattern: string]: ResourceDescriptor };
+  public types: { [type: string]: ResourceDescriptor };
 
   constructor() {
     this.patterns = {};
     this.types = {};
-    this.names = {};
   }
 
   registerResource(
@@ -78,7 +76,6 @@ export class ResourceDatabase {
       );
       this.patterns[patterns?.[0]] = resourceDescriptor;
       this.types[resourceDescriptor.type!] = resourceDescriptor;
-      this.names[name] = resourceDescriptor;
     }
     // resource: {name, type, pattern: [p1, p2]}
     // register resource does: in type map {type: { name, type, pattern: [p1, p2]} }
@@ -98,7 +95,6 @@ export class ResourceDatabase {
         if (!this.types[resource.type]) {
           this.types[resource.type] = resourceDescriptor;
         }
-        this.names[name] = resourceDescriptor;        
       }
     }
   }

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -21,8 +21,8 @@ export interface ResourceDescriptor
 }
 
 export class ResourceDatabase {
-  public patterns: { [pattern: string]: ResourceDescriptor };
-  public types: { [type: string]: ResourceDescriptor };
+  patterns: { [pattern: string]: ResourceDescriptor };
+  types: { [type: string]: ResourceDescriptor };
 
   constructor() {
     this.patterns = {};

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -23,10 +23,12 @@ export interface ResourceDescriptor
 export class ResourceDatabase {
   private patterns: { [pattern: string]: ResourceDescriptor };
   private types: { [type: string]: ResourceDescriptor };
+  public names: {[name: string]: ResourceDescriptor}
 
   constructor() {
     this.patterns = {};
     this.types = {};
+    this.names = {};
   }
 
   registerResource(
@@ -76,6 +78,7 @@ export class ResourceDatabase {
       );
       this.patterns[patterns?.[0]] = resourceDescriptor;
       this.types[resourceDescriptor.type!] = resourceDescriptor;
+      this.names[name] = resourceDescriptor;
     }
     // resource: {name, type, pattern: [p1, p2]}
     // register resource does: in type map {type: { name, type, pattern: [p1, p2]} }
@@ -92,8 +95,10 @@ export class ResourceDatabase {
         };
         this.patterns[pattern] = resourceDescriptor;
         resourceDescriptor = this.getResourceDescriptor(name, params, resource);
-        if (this.types[resource.type]) continue;
-        this.types[resource.type] = resourceDescriptor;
+        if (!this.types[resource.type]) {
+          this.types[resource.type] = resourceDescriptor;
+        }
+        this.names[name] = resourceDescriptor;        
       }
     }
   }

--- a/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
@@ -139,23 +139,11 @@ export class DlpServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}'
-      ),
-      organizationPathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}'
-      ),
       organizationInspectTemplatePathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/inspectTemplates/{inspect_template}'
       ),
       projectInspectTemplatePathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/inspectTemplates/{inspect_template}'
-      ),
-      jobTriggerPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/jobTriggers/{job_trigger}'
-      ),
-      dlpJobPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/dlpJobs/{dlp_job}'
       ),
       organizationDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/deidentifyTemplates/{deidentify_template}'
@@ -163,11 +151,20 @@ export class DlpServiceClient {
       projectDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/deidentifyTemplates/{deidentify_template}'
       ),
+      jobTriggerPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/jobTriggers/{job_trigger}'
+      ),
+      dlpJobPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/dlpJobs/{dlp_job}'
+      ),
       organizationStoredInfoTypePathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/storedInfoTypes/{stored_info_type}'
       ),
       projectStoredInfoTypePathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/storedInfoTypes/{stored_info_type}'
+      ),
+      projectPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}'
       ),
     };
 
@@ -2985,52 +2982,6 @@ export class DlpServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified project resource name string.
-   *
-   * @param {string} project
-   * @returns {string} Resource name string.
-   */
-  projectPath(project:string) {
-    return this._pathTemplates.projectPathTemplate.render({
-      project: project,
-    });
-  }
-
-  /**
-   * Parse the project from Project resource.
-   *
-   * @param {string} projectName
-   *   A fully-qualified path representing Project resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectName(projectName: string) {
-    return this._pathTemplates.projectPathTemplate.match(projectName).project;
-  }
-
-  /**
-   * Return a fully-qualified organization resource name string.
-   *
-   * @param {string} organization
-   * @returns {string} Resource name string.
-   */
-  organizationPath(organization:string) {
-    return this._pathTemplates.organizationPathTemplate.render({
-      organization: organization,
-    });
-  }
-
-  /**
-   * Parse the organization from Organization resource.
-   *
-   * @param {string} organizationName
-   *   A fully-qualified path representing Organization resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationName(organizationName: string) {
-    return this._pathTemplates.organizationPathTemplate.match(organizationName).organization;
-  }
-
-  /**
    * Return a fully-qualified organizationInspectTemplate resource name string.
    *
    * @param {string} organization
@@ -3100,78 +3051,6 @@ export class DlpServiceClient {
    */
   matchInspectTemplateFromProjectInspectTemplateName(projectInspectTemplateName: string) {
     return this._pathTemplates.projectInspectTemplatePathTemplate.match(projectInspectTemplateName).inspect_template;
-  }
-
-  /**
-   * Return a fully-qualified jobTrigger resource name string.
-   *
-   * @param {string} project
-   * @param {string} job_trigger
-   * @returns {string} Resource name string.
-   */
-  jobTriggerPath(project:string,jobTrigger:string) {
-    return this._pathTemplates.jobTriggerPathTemplate.render({
-      project: project,
-      job_trigger: jobTrigger,
-    });
-  }
-
-  /**
-   * Parse the project from JobTrigger resource.
-   *
-   * @param {string} jobTriggerName
-   *   A fully-qualified path representing JobTrigger resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromJobTriggerName(jobTriggerName: string) {
-    return this._pathTemplates.jobTriggerPathTemplate.match(jobTriggerName).project;
-  }
-
-  /**
-   * Parse the job_trigger from JobTrigger resource.
-   *
-   * @param {string} jobTriggerName
-   *   A fully-qualified path representing JobTrigger resource.
-   * @returns {string} A string representing the job_trigger.
-   */
-  matchJobTriggerFromJobTriggerName(jobTriggerName: string) {
-    return this._pathTemplates.jobTriggerPathTemplate.match(jobTriggerName).job_trigger;
-  }
-
-  /**
-   * Return a fully-qualified dlpJob resource name string.
-   *
-   * @param {string} project
-   * @param {string} dlp_job
-   * @returns {string} Resource name string.
-   */
-  dlpJobPath(project:string,dlpJob:string) {
-    return this._pathTemplates.dlpJobPathTemplate.render({
-      project: project,
-      dlp_job: dlpJob,
-    });
-  }
-
-  /**
-   * Parse the project from DlpJob resource.
-   *
-   * @param {string} dlpJobName
-   *   A fully-qualified path representing DlpJob resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromDlpJobName(dlpJobName: string) {
-    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).project;
-  }
-
-  /**
-   * Parse the dlp_job from DlpJob resource.
-   *
-   * @param {string} dlpJobName
-   *   A fully-qualified path representing DlpJob resource.
-   * @returns {string} A string representing the dlp_job.
-   */
-  matchDlpJobFromDlpJobName(dlpJobName: string) {
-    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).dlp_job;
   }
 
   /**
@@ -3247,6 +3126,78 @@ export class DlpServiceClient {
   }
 
   /**
+   * Return a fully-qualified jobTrigger resource name string.
+   *
+   * @param {string} project
+   * @param {string} job_trigger
+   * @returns {string} Resource name string.
+   */
+  jobTriggerPath(project:string,jobTrigger:string) {
+    return this._pathTemplates.jobTriggerPathTemplate.render({
+      project: project,
+      job_trigger: jobTrigger,
+    });
+  }
+
+  /**
+   * Parse the project from JobTrigger resource.
+   *
+   * @param {string} jobTriggerName
+   *   A fully-qualified path representing JobTrigger resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromJobTriggerName(jobTriggerName: string) {
+    return this._pathTemplates.jobTriggerPathTemplate.match(jobTriggerName).project;
+  }
+
+  /**
+   * Parse the job_trigger from JobTrigger resource.
+   *
+   * @param {string} jobTriggerName
+   *   A fully-qualified path representing JobTrigger resource.
+   * @returns {string} A string representing the job_trigger.
+   */
+  matchJobTriggerFromJobTriggerName(jobTriggerName: string) {
+    return this._pathTemplates.jobTriggerPathTemplate.match(jobTriggerName).job_trigger;
+  }
+
+  /**
+   * Return a fully-qualified dlpJob resource name string.
+   *
+   * @param {string} project
+   * @param {string} dlp_job
+   * @returns {string} Resource name string.
+   */
+  dlpJobPath(project:string,dlpJob:string) {
+    return this._pathTemplates.dlpJobPathTemplate.render({
+      project: project,
+      dlp_job: dlpJob,
+    });
+  }
+
+  /**
+   * Parse the project from DlpJob resource.
+   *
+   * @param {string} dlpJobName
+   *   A fully-qualified path representing DlpJob resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromDlpJobName(dlpJobName: string) {
+    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).project;
+  }
+
+  /**
+   * Parse the dlp_job from DlpJob resource.
+   *
+   * @param {string} dlpJobName
+   *   A fully-qualified path representing DlpJob resource.
+   * @returns {string} A string representing the dlp_job.
+   */
+  matchDlpJobFromDlpJobName(dlpJobName: string) {
+    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).dlp_job;
+  }
+
+  /**
    * Return a fully-qualified organizationStoredInfoType resource name string.
    *
    * @param {string} organization
@@ -3316,6 +3267,29 @@ export class DlpServiceClient {
    */
   matchStoredInfoTypeFromProjectStoredInfoTypeName(projectStoredInfoTypeName: string) {
     return this._pathTemplates.projectStoredInfoTypePathTemplate.match(projectStoredInfoTypeName).stored_info_type;
+  }
+
+  /**
+   * Return a fully-qualified project resource name string.
+   *
+   * @param {string} project
+   * @returns {string} Resource name string.
+   */
+  projectPath(project:string) {
+    return this._pathTemplates.projectPathTemplate.render({
+      project: project,
+    });
+  }
+
+  /**
+   * Parse the project from Project resource.
+   *
+   * @param {string} projectName
+   *   A fully-qualified path representing Project resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectName(projectName: string) {
+    return this._pathTemplates.projectPathTemplate.match(projectName).project;
   }
 
   /**

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -146,11 +146,11 @@ export class CloudRedisClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      locationPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}'
-      ),
       instancePathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/instances/{instance}'
+      ),
+      locationPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}'
       ),
     };
 
@@ -960,42 +960,6 @@ export class CloudRedisClient {
   // --------------------
 
   /**
-   * Return a fully-qualified location resource name string.
-   *
-   * @param {string} project
-   * @param {string} location
-   * @returns {string} Resource name string.
-   */
-  locationPath(project:string,location:string) {
-    return this._pathTemplates.locationPathTemplate.render({
-      project: project,
-      location: location,
-    });
-  }
-
-  /**
-   * Parse the project from Location resource.
-   *
-   * @param {string} locationName
-   *   A fully-qualified path representing Location resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromLocationName(locationName: string) {
-    return this._pathTemplates.locationPathTemplate.match(locationName).project;
-  }
-
-  /**
-   * Parse the location from Location resource.
-   *
-   * @param {string} locationName
-   *   A fully-qualified path representing Location resource.
-   * @returns {string} A string representing the location.
-   */
-  matchLocationFromLocationName(locationName: string) {
-    return this._pathTemplates.locationPathTemplate.match(locationName).location;
-  }
-
-  /**
    * Return a fully-qualified instance resource name string.
    *
    * @param {string} project
@@ -1042,6 +1006,42 @@ export class CloudRedisClient {
    */
   matchInstanceFromInstanceName(instanceName: string) {
     return this._pathTemplates.instancePathTemplate.match(instanceName).instance;
+  }
+
+  /**
+   * Return a fully-qualified location resource name string.
+   *
+   * @param {string} project
+   * @param {string} location
+   * @returns {string} Resource name string.
+   */
+  locationPath(project:string,location:string) {
+    return this._pathTemplates.locationPathTemplate.render({
+      project: project,
+      location: location,
+    });
+  }
+
+  /**
+   * Parse the project from Location resource.
+   *
+   * @param {string} locationName
+   *   A fully-qualified path representing Location resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromLocationName(locationName: string) {
+    return this._pathTemplates.locationPathTemplate.match(locationName).project;
+  }
+
+  /**
+   * Parse the location from Location resource.
+   *
+   * @param {string} locationName
+   *   A fully-qualified path representing Location resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromLocationName(locationName: string) {
+    return this._pathTemplates.locationPathTemplate.match(locationName).location;
   }
 
   /**

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -132,11 +132,11 @@ export class TranslationServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      locationPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/locations/{location}'
-      ),
       glossaryPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/glossaries/{glossary}'
+      ),
+      locationPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}'
       ),
     };
 
@@ -1033,42 +1033,6 @@ export class TranslationServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified location resource name string.
-   *
-   * @param {string} project
-   * @param {string} location
-   * @returns {string} Resource name string.
-   */
-  locationPath(project:string,location:string) {
-    return this._pathTemplates.locationPathTemplate.render({
-      project: project,
-      location: location,
-    });
-  }
-
-  /**
-   * Parse the project from Location resource.
-   *
-   * @param {string} locationName
-   *   A fully-qualified path representing Location resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromLocationName(locationName: string) {
-    return this._pathTemplates.locationPathTemplate.match(locationName).project;
-  }
-
-  /**
-   * Parse the location from Location resource.
-   *
-   * @param {string} locationName
-   *   A fully-qualified path representing Location resource.
-   * @returns {string} A string representing the location.
-   */
-  matchLocationFromLocationName(locationName: string) {
-    return this._pathTemplates.locationPathTemplate.match(locationName).location;
-  }
-
-  /**
    * Return a fully-qualified glossary resource name string.
    *
    * @param {string} project
@@ -1115,6 +1079,42 @@ export class TranslationServiceClient {
    */
   matchGlossaryFromGlossaryName(glossaryName: string) {
     return this._pathTemplates.glossaryPathTemplate.match(glossaryName).glossary;
+  }
+
+  /**
+   * Return a fully-qualified location resource name string.
+   *
+   * @param {string} project
+   * @param {string} location
+   * @returns {string} Resource name string.
+   */
+  locationPath(project:string,location:string) {
+    return this._pathTemplates.locationPathTemplate.render({
+      project: project,
+      location: location,
+    });
+  }
+
+  /**
+   * Parse the project from Location resource.
+   *
+   * @param {string} locationName
+   *   A fully-qualified path representing Location resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromLocationName(locationName: string) {
+    return this._pathTemplates.locationPathTemplate.match(locationName).project;
+  }
+
+  /**
+   * Parse the location from Location resource.
+   *
+   * @param {string} locationName
+   *   A fully-qualified path representing Location resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromLocationName(locationName: string) {
+    return this._pathTemplates.locationPathTemplate.match(locationName).location;
   }
 
   /**


### PR DESCRIPTION
We generated all resources into pathTemplates only if:
 1. Message or fields with `google.api.resource` option
 2. Options that have `google.api.resource_definition` and are referenced by some messages or fields.

Also, sort pathTemplate to avoid random test failure.

For dlp baseline test, `organization` is not referenced in proto, so get removed by logic.
This should unblock `securitycenter` API conversion to typescript: https://github.com/googleapis/nodejs-security-center/pull/198#event-2998450223