### PR TITLE
feat: support additional_bindings in google.api.http option

### DIFF
--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -185,15 +185,32 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {{- arr[arr.length - 1] -}}
 {%- endmacro -%}
 
+{%- macro buildHeaderRequestParam(method) -%}
+    options = options || {};
+{%- if method.headerRequestParams.length > 0 %}
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+{%- for requestParam in method.headerRequestParams %}
+      '{{ requestParam.toString().toSnakeCase() }}': request.{{ requestParam.toCamelCaseString("!.") }} || '',
+{%- endfor %}
+    });
+{%- endif %}
+{%- endmacro -%}
+
 {%- macro initRequestWithHeaderParam(method) -%}
             const request: {{ toInterface(method.inputInterface) }} = {};
-{%- if method.headerRequestParams.length > 1 %}
+{%- if method.headerRequestParams.length > 0 %}
+{%- for requestParam in method.headerRequestParams %}
 {%- set chain = "request" -%}
-{%- for field in method.headerRequestParams.slice(0, -1) %}
+{%- for field in requestParam.slice(0, -1) %}
             {{ chain }}.{{ field.toCamelCase() }} = {};
 {%- set chain = chain + "." + field.toCamelCase() -%}
 {%- endfor %}
-            {{ chain }}.{{ method.headerRequestParams.slice(-1)[0].toCamelCase() }} = '';
+            {{ chain }}.{{ requestParam.slice(-1)[0].toCamelCase() }} = '';
+{%- endfor %}
 {%- endif %}
 {%- endmacro -%}
 

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -194,7 +194,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
 {%- for requestParam in method.headerRequestParams %}
-      '{{ requestParam.toString().toSnakeCase() }}': request.{{ requestParam.toCamelCaseString("!.") }} || '',
+      '{{ requestParam.toSnakeCaseString(".") }}': request.{{ requestParam.toCamelCaseString("!.") }} || '',
 {%- endfor %}
     });
 {%- endif %}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -372,16 +372,7 @@ export class {{ service.name }}Client {
     else {
       options = optionsOrCallback as gax.CallOptions;
     }
-    options = options || {};
-{%- if method.headerRequestParams.length > 0 %}
-    options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers[
-      'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toSnakeCaseString(".") }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
-    });
-{%- endif %}
+    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 {%- endfor %}
@@ -480,16 +471,7 @@ export class {{ service.name }}Client {
     else {
       options = optionsOrCallback as gax.CallOptions;
     }
-    options = options || {};
-{%- if method.headerRequestParams.length > 0 %}
-    options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers[
-      'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
-    });
-{%- endif %}
+    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 {%- endfor %}
@@ -536,16 +518,7 @@ export class {{ service.name }}Client {
     else {
       options = optionsOrCallback as gax.CallOptions;
     }
-    options = options || {};
-{%- if method.headerRequestParams.length > 0 %}
-    options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers[
-      'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
-      '{{ method.headerRequestParams.toString().toSnakeCase() }}': request.{{ method.headerRequestParams.toCamelCaseString("!.") }} || '',
-    });
-{%- endif %}
+    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 

--- a/templates/typescript_gapic/test/gapic-$service-$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic-$service-$version.ts.njk
@@ -368,7 +368,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             // Mock request
             {{ util.initRequestWithHeaderParam(method) }}
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.{{ method.name.toCamelCase() }} = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -380,7 +380,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 {%- endfor %}

--- a/typescript/test/testdata/dlp/test/gapic-dlp_service-v2.ts.baseline
+++ b/typescript/test/testdata/dlp/test/gapic-dlp_service-v2.ts.baseline
@@ -86,6 +86,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IInspectContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -108,6 +109,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IInspectContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -132,6 +134,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IRedactImageRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -154,6 +157,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IRedactImageRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -178,6 +182,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeidentifyContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -200,6 +205,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeidentifyContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -224,6 +230,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IReidentifyContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -246,6 +253,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IReidentifyContentRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -316,6 +324,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateInspectTemplateRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -338,6 +347,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateInspectTemplateRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -362,6 +372,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -384,6 +395,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -408,6 +420,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -430,6 +443,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -454,6 +468,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -476,6 +491,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteInspectTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -500,6 +516,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -522,6 +539,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -546,6 +564,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -568,6 +587,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -592,6 +612,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -614,6 +635,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -638,6 +660,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -660,6 +683,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -684,6 +708,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateJobTriggerRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -706,6 +731,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateJobTriggerRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -730,6 +756,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -752,6 +779,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -776,6 +804,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -798,6 +827,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -822,6 +852,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -844,6 +875,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -868,6 +900,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IActivateJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -890,6 +923,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IActivateJobTriggerRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -914,6 +948,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateDlpJobRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -936,6 +971,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateDlpJobRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -960,6 +996,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -982,6 +1019,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1006,6 +1044,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1028,6 +1067,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1052,6 +1092,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICancelDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1074,6 +1115,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICancelDlpJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1098,6 +1140,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1120,6 +1163,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1144,6 +1188,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1166,6 +1211,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1190,6 +1236,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1212,6 +1259,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IGetStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1236,6 +1284,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1258,6 +1307,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -1282,6 +1332,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListInspectTemplatesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1304,8 +1355,9 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListInspectTemplatesRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listInspectTemplates = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1317,7 +1369,7 @@ describe('v2.DlpServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listDeidentifyTemplates', () => {
@@ -1328,6 +1380,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1350,8 +1403,9 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listDeidentifyTemplates = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1363,7 +1417,7 @@ describe('v2.DlpServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listJobTriggers', () => {
@@ -1374,6 +1428,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListJobTriggersRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1396,8 +1451,9 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListJobTriggersRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listJobTriggers = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1409,7 +1465,7 @@ describe('v2.DlpServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listDlpJobs', () => {
@@ -1420,6 +1476,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListDlpJobsRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1442,8 +1499,9 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListDlpJobsRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listDlpJobs = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1455,7 +1513,7 @@ describe('v2.DlpServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listStoredInfoTypes', () => {
@@ -1466,6 +1524,7 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListStoredInfoTypesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1488,8 +1547,9 @@ describe('v2.DlpServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.privacy.dlp.v2.IListStoredInfoTypesRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listStoredInfoTypes = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1501,7 +1561,7 @@ describe('v2.DlpServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 });

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -977,7 +977,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key_name': request.cryptoKey!.name || '',
+      'crypto_key.name': request.cryptoKey!.name || '',
     });
     return this._innerApiCalls.updateCryptoKey(request, options, callback);
   }
@@ -1044,7 +1044,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key_version_name': request.cryptoKeyVersion!.name || '',
+      'crypto_key_version.name': request.cryptoKeyVersion!.name || '',
     });
     return this._innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -977,7 +977,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key.name': request.cryptoKey!.name || '',
+      'crypto_key_name': request.cryptoKey!.name || '',
     });
     return this._innerApiCalls.updateCryptoKey(request, options, callback);
   }
@@ -1044,7 +1044,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'crypto_key_version.name': request.cryptoKeyVersion!.name || '',
+      'crypto_key_version_name': request.cryptoKeyVersion!.name || '',
     });
     return this._innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }

--- a/typescript/test/testdata/keymanager/test/gapic-key_management_service-v1.ts.baseline
+++ b/typescript/test/testdata/keymanager/test/gapic-key_management_service-v1.ts.baseline
@@ -86,6 +86,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetKeyRingRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -108,6 +109,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetKeyRingRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -132,6 +134,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -154,6 +157,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -178,6 +182,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -200,6 +205,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -224,6 +230,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetPublicKeyRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -246,6 +253,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetPublicKeyRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -270,6 +278,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetImportJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -292,6 +301,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IGetImportJobRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -316,6 +326,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateKeyRingRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -338,6 +349,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateKeyRingRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -362,6 +374,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -384,6 +397,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -408,6 +422,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -430,6 +445,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -454,6 +470,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IImportCryptoKeyVersionRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -476,6 +493,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IImportCryptoKeyVersionRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -500,6 +518,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateImportJobRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -522,6 +541,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.ICreateImportJobRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -646,6 +666,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IEncryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -668,6 +689,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IEncryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -692,6 +714,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IDecryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -714,6 +737,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IDecryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -738,6 +762,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IAsymmetricSignRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -760,6 +785,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IAsymmetricSignRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -784,6 +810,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IAsymmetricDecryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -806,6 +833,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IAsymmetricDecryptRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -830,6 +858,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -852,6 +881,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -876,6 +906,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -898,6 +929,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -922,6 +954,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -944,6 +977,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -968,6 +1002,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -990,8 +1025,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listKeyRings = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1003,7 +1039,7 @@ describe('v1.KeyManagementServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listCryptoKeys', () => {
@@ -1014,6 +1050,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1036,8 +1073,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listCryptoKeys = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1049,7 +1087,7 @@ describe('v1.KeyManagementServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listCryptoKeyVersions', () => {
@@ -1060,6 +1098,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1082,8 +1121,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listCryptoKeyVersions = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1095,7 +1135,7 @@ describe('v1.KeyManagementServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
     describe('listImportJobs', () => {
@@ -1106,6 +1146,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListImportJobsRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -1128,8 +1169,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.kms.v1.IListImportJobsRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listImportJobs = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -1141,7 +1183,7 @@ describe('v1.KeyManagementServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 });

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -544,7 +544,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
-      'instance_name': request.instance!.name || '',
+      'instance.name': request.instance!.name || '',
     });
     return this._innerApiCalls.updateInstance(request, options, callback);
   }

--- a/typescript/test/testdata/redis/test/gapic-cloud_redis-v1beta1.ts.baseline
+++ b/typescript/test/testdata/redis/test/gapic-cloud_redis-v1beta1.ts.baseline
@@ -104,6 +104,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IGetInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -126,6 +127,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IGetInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -150,6 +152,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.ICreateInstanceRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -175,6 +178,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.ICreateInstanceRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -260,6 +264,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IImportInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -285,6 +290,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IImportInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -313,6 +319,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IExportInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -338,6 +345,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IExportInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -366,6 +374,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IFailoverInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -391,6 +400,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IFailoverInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -419,6 +429,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IDeleteInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -444,6 +455,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IDeleteInstanceRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -472,6 +484,7 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -494,8 +507,9 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listInstances = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -507,7 +521,7 @@ describe('v1beta1.CloudRedisClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 });

--- a/typescript/test/testdata/showcase/test/gapic-echo-v1beta1.ts.baseline
+++ b/typescript/test/testdata/showcase/test/gapic-echo-v1beta1.ts.baseline
@@ -348,7 +348,7 @@ describe('v1beta1.EchoClient', () => {
             // Mock request
             const request: protosTypes.google.showcase.v1beta1.IPagedExpandRequest = {};
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.pagedExpand = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -360,7 +360,7 @@ describe('v1beta1.EchoClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 });

--- a/typescript/test/testdata/translate/test/gapic-translation_service-v3beta1.ts.baseline
+++ b/typescript/test/testdata/translate/test/gapic-translation_service-v3beta1.ts.baseline
@@ -104,6 +104,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.ITranslateTextRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -126,6 +127,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.ITranslateTextRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -150,6 +152,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IDetectLanguageRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -172,6 +175,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IDetectLanguageRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -196,6 +200,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -218,6 +223,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -242,6 +248,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IGetGlossaryRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -264,6 +271,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IGetGlossaryRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -288,6 +296,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IBatchTranslateTextRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -313,6 +322,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IBatchTranslateTextRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -341,6 +351,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.ICreateGlossaryRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -366,6 +377,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.ICreateGlossaryRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -394,6 +406,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IDeleteGlossaryRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -419,6 +432,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IDeleteGlossaryRequest = {};
+            request.name = '';
             // Mock response
             const expectedResponse = {};
             // Mock gRPC layer
@@ -447,6 +461,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest = {};
+            request.parent = '';
             // Mock response
             const expectedResponse = {};
             // Mock Grpc layer
@@ -469,8 +484,9 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             // Mock request
             const request: protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest = {};
+            request.parent = '';
             // Mock response
-            const expectedResponse = {};
+            const expectedResponse = {response: 'data'};
             // Mock Grpc layer
             client._innerApiCalls.listGlossaries = (actualRequest: {}, options: {}, callback: Callback) => {
                 assert.deepStrictEqual(actualRequest, request);
@@ -482,7 +498,7 @@ describe('v3beta1.TranslationServiceClient', () => {
             }).on('error', (err: FakeError) => {
                 done(err);
             });
-            stream.write(request);
+            stream.write(expectedResponse);
         });
     });
 });


### PR DESCRIPTION
BigQuery Storage API has this fun annotation:

```proto
  rpc CreateReadSession(CreateReadSessionRequest) returns (ReadSession) {
    option (google.api.http) = {
      post: "/v1beta1/{table_reference.project_id=projects/*}"
      body: "*"
      additional_bindings {
        post: "/v1beta1/{table_reference.dataset_id=projects/*/datasets/*}"
        body: "*"
      }
    };
    ...
  }
```

Both `table_reference.project_id` and `table_reference.dataset_id` must go into `x-goog-request-params` header, otherwise the server returns an error.

Fixing this problem. Also, the fix exposed a small problem in the page streaming test, fixing it as well.

@steffnay This, when released, will finally unblock you!