### PR TITLE
fix: ignore img.shields.io in linkinator

### DIFF
--- a/templates/typescript_gapic/linkinator.config.json.njk
+++ b/templates/typescript_gapic/linkinator.config.json.njk
@@ -1,7 +1,8 @@
 {
-    "recurse": true,
-    "skip": [
-      "https://codecov.io/gh/googleapis/",
-      "www.googleapis.com"
-    ]
-  }
+  "recurse": true,
+  "skip": [
+    "https://codecov.io/gh/googleapis/",
+    "www.googleapis.com",
+    "img.shields.io"
+  ]
+}

--- a/typescript/test/testdata/dlp/linkinator.config.json.baseline
+++ b/typescript/test/testdata/dlp/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }

--- a/typescript/test/testdata/keymanager/linkinator.config.json.baseline
+++ b/typescript/test/testdata/keymanager/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }

--- a/typescript/test/testdata/redis/linkinator.config.json.baseline
+++ b/typescript/test/testdata/redis/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }

--- a/typescript/test/testdata/showcase/linkinator.config.json.baseline
+++ b/typescript/test/testdata/showcase/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }

--- a/typescript/test/testdata/texttospeech/linkinator.config.json.baseline
+++ b/typescript/test/testdata/texttospeech/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }

--- a/typescript/test/testdata/translate/linkinator.config.json.baseline
+++ b/typescript/test/testdata/translate/linkinator.config.json.baseline
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "img.shields.io"
   ]
 }


### PR DESCRIPTION
I had to close out a bunch of the autosynth PRs because we had landed this everywhere without updating the generator :)