### PR TITLE
fix: throw err when fail to get service name list

### DIFF
--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import * as yargs from 'yargs';
-import { Generator } from './generator';
+import {Generator} from './generator';
 
 async function main() {
   const argv = yargs.argv;
@@ -32,4 +32,5 @@ async function main() {
 
 main().catch(err => {
   console.error(err);
+  process.exit(1);
 });

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import * as yargs from 'yargs';
-import {Generator} from './generator';
+import { Generator } from './generator';
 
 async function main() {
   const argv = yargs.argv;

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -93,6 +93,11 @@ export class API {
         this.port = port ?? this.port ?? '443';
         serviceNamesList.push(service.name || this.naming.name);
       });
+    if (serviceNamesList.length === 0) {
+      throw new Error(
+        `Can't find ${this.naming.name}'s service names, please make sure that service names are defined in the proto file.`
+      );
+    }
     this.mainServiceName = options.mainServiceName || serviceNamesList[0];
   }
 

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -95,7 +95,7 @@ export class API {
       });
     if (serviceNamesList.length === 0) {
       throw new Error(
-        `Can't find ${this.naming.name}'s service names, please make sure that service names are defined in the proto file.`
+        `Can't find ${this.naming.name}'s service names, please make sure that services are defined in the proto file.`
       );
     }
     this.mainServiceName = options.mainServiceName || serviceNamesList[0];

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -23,6 +23,10 @@ describe('schema/api.ts', () => {
     fd.name = 'google/cloud/test/v1/test.proto';
     fd.package = 'google.cloud.test.v1';
     fd.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    fd.service[0].name = 'ZService';
+    fd.service[0].options = {
+      '.google.api.defaultHost': 'hostname.example.com:443',
+    };
     const api = new API([fd], 'google.cloud.test.v1', {
       grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
     });
@@ -36,6 +40,10 @@ describe('schema/api.ts', () => {
     fd1.name = 'google/cloud/test/v1/test.proto';
     fd1.package = 'google.cloud.test.v1';
     fd1.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    fd1.service[0].name = 'ZService';
+    fd1.service[0].options = {
+      '.google.api.defaultHost': 'hostname.example.com:443',
+    };
     const fd2 = new plugin.google.protobuf.FileDescriptorProto();
     fd2.name = 'google/longrunning/operation.proto';
     fd2.package = 'google.longrunning';
@@ -131,5 +139,17 @@ describe('schema/api.ts', () => {
       '../../protos/google/cloud/example/v1/example.proto',
       '../../protos/google/cloud/example/v1/test.proto',
     ]);
+  });
+
+  it('should throw error when the service name is not found', () => {
+    assert.throws(() => {
+      const fd = new plugin.google.protobuf.FileDescriptorProto();
+      fd.name = 'google/cloud/test/v1/test.proto';
+      fd.package = 'google.cloud.test.v1';
+      fd.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+      const api = new API([fd], 'google.cloud.test.v1', {
+        grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
+      });
+    });
   });
 });

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -142,11 +142,11 @@ describe('schema/api.ts', () => {
   });
 
   it('should throw error when the service name is not found', () => {
+    const fd = new plugin.google.protobuf.FileDescriptorProto();
+    fd.name = 'google/cloud/test/v1/test.proto';
+    fd.package = 'google.cloud.test.v1';
+    fd.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
     assert.throws(() => {
-      const fd = new plugin.google.protobuf.FileDescriptorProto();
-      fd.name = 'google/cloud/test/v1/test.proto';
-      fd.package = 'google.cloud.test.v1';
-      fd.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
       const api = new API([fd], 'google.cloud.test.v1', {
         grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
       });


### PR DESCRIPTION
We should throw error if generated client library is empty.

Need feedback of error message @alexander-fenster @xiaozhenliu-gg5 🙏