### PR TITLE
fix: sort path templates, ignore useless templates

### DIFF
--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -611,7 +611,21 @@ function augmentService(
       }
     }
   }
-  augmentedService.pathTemplates = Object.values(uniqueResources).sort();
+  augmentedService.pathTemplates = Object.values(uniqueResources).sort(
+    (resourceA, resourceB) => {
+      // Path templates names can be cased differently
+      // (e.g. 'Project' and 'project_deidentify_template'),
+      // so we use camel case for comparison.
+      if (resourceA.name.toCamelCase() < resourceB.name.toCamelCase()) {
+        return -1;
+      }
+      if (resourceA.name.toCamelCase() > resourceB.name.toCamelCase()) {
+        return 1;
+      }
+      return 0;
+    }
+  );
+  console.warn(augmentedService.pathTemplates);
   return augmentedService;
 }
 

--- a/typescript/src/schema/resourceDatabase.ts
+++ b/typescript/src/schema/resourceDatabase.ts
@@ -74,8 +74,11 @@ export class ResourceDatabase {
         params,
         resource
       );
-      this.patterns[patterns?.[0]] = resourceDescriptor;
-      this.types[resourceDescriptor.type!] = resourceDescriptor;
+      // We ignore resources with no parameters (e.g. pattern = '*').
+      if (params.length > 0) {
+        this.patterns[patterns?.[0]] = resourceDescriptor;
+        this.types[resourceDescriptor.type!] = resourceDescriptor;
+      }
     }
     // resource: {name, type, pattern: [p1, p2]}
     // register resource does: in type map {type: { name, type, pattern: [p1, p2]} }
@@ -83,6 +86,10 @@ export class ResourceDatabase {
     else {
       for (const pattern of patterns!) {
         const params = this.getParams(pattern);
+        // We ignore resources with no parameters (e.g. pattern = '*').
+        if (params.length === 0) {
+          continue;
+        }
         const name = params.join('_');
         let resourceDescriptor: ResourceDescriptor = {
           name,
@@ -177,6 +184,7 @@ export class ResourceDatabase {
     params = params.map(p => p.replace(/{([a-zA-Z_]+).*/, '$1'));
     return params;
   }
+
   private getResourceDescriptor(
     name: string,
     params: string[],

--- a/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
@@ -139,35 +139,35 @@ export class DlpServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      organizationInspectTemplatePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/inspectTemplates/{inspect_template}'
-      ),
-      projectInspectTemplatePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/inspectTemplates/{inspect_template}'
-      ),
-      organizationDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/deidentifyTemplates/{deidentify_template}'
-      ),
-      projectDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/deidentifyTemplates/{deidentify_template}'
+      dlpJobPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/dlpJobs/{dlp_job}'
       ),
       jobTriggerPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}/jobTriggers/{job_trigger}'
       ),
-      dlpJobPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/dlpJobs/{dlp_job}'
+      organizationPathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}'
+      ),
+      organizationDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/deidentifyTemplates/{deidentify_template}'
+      ),
+      organizationInspectTemplatePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/inspectTemplates/{inspect_template}'
       ),
       organizationStoredInfoTypePathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/storedInfoTypes/{stored_info_type}'
       ),
-      projectStoredInfoTypePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/storedInfoTypes/{stored_info_type}'
-      ),
       projectPathTemplate: new gaxModule.PathTemplate(
         'projects/{project}'
       ),
-      organizationPathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}'
+      projectDeidentifyTemplatePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/deidentifyTemplates/{deidentify_template}'
+      ),
+      projectInspectTemplatePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/inspectTemplates/{inspect_template}'
+      ),
+      projectStoredInfoTypePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/storedInfoTypes/{stored_info_type}'
       ),
     };
 
@@ -2985,147 +2985,39 @@ export class DlpServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified organizationInspectTemplate resource name string.
-   *
-   * @param {string} organization
-   * @param {string} inspect_template
-   * @returns {string} Resource name string.
-   */
-  organizationInspectTemplatePath(organization:string,inspectTemplate:string) {
-    return this._pathTemplates.organizationInspectTemplatePathTemplate.render({
-      organization: organization,
-      inspect_template: inspectTemplate,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationInspectTemplate resource.
-   *
-   * @param {string} organizationInspectTemplateName
-   *   A fully-qualified path representing organization_inspect_template resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationInspectTemplateName(organizationInspectTemplateName: string) {
-    return this._pathTemplates.organizationInspectTemplatePathTemplate.match(organizationInspectTemplateName).organization;
-  }
-
-  /**
-   * Parse the inspect_template from OrganizationInspectTemplate resource.
-   *
-   * @param {string} organizationInspectTemplateName
-   *   A fully-qualified path representing organization_inspect_template resource.
-   * @returns {string} A string representing the inspect_template.
-   */
-  matchInspectTemplateFromOrganizationInspectTemplateName(organizationInspectTemplateName: string) {
-    return this._pathTemplates.organizationInspectTemplatePathTemplate.match(organizationInspectTemplateName).inspect_template;
-  }
-
-  /**
-   * Return a fully-qualified projectInspectTemplate resource name string.
+   * Return a fully-qualified dlpJob resource name string.
    *
    * @param {string} project
-   * @param {string} inspect_template
+   * @param {string} dlp_job
    * @returns {string} Resource name string.
    */
-  projectInspectTemplatePath(project:string,inspectTemplate:string) {
-    return this._pathTemplates.projectInspectTemplatePathTemplate.render({
+  dlpJobPath(project:string,dlpJob:string) {
+    return this._pathTemplates.dlpJobPathTemplate.render({
       project: project,
-      inspect_template: inspectTemplate,
+      dlp_job: dlpJob,
     });
   }
 
   /**
-   * Parse the project from ProjectInspectTemplate resource.
+   * Parse the project from DlpJob resource.
    *
-   * @param {string} projectInspectTemplateName
-   *   A fully-qualified path representing project_inspect_template resource.
+   * @param {string} dlpJobName
+   *   A fully-qualified path representing DlpJob resource.
    * @returns {string} A string representing the project.
    */
-  matchProjectFromProjectInspectTemplateName(projectInspectTemplateName: string) {
-    return this._pathTemplates.projectInspectTemplatePathTemplate.match(projectInspectTemplateName).project;
+  matchProjectFromDlpJobName(dlpJobName: string) {
+    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).project;
   }
 
   /**
-   * Parse the inspect_template from ProjectInspectTemplate resource.
+   * Parse the dlp_job from DlpJob resource.
    *
-   * @param {string} projectInspectTemplateName
-   *   A fully-qualified path representing project_inspect_template resource.
-   * @returns {string} A string representing the inspect_template.
+   * @param {string} dlpJobName
+   *   A fully-qualified path representing DlpJob resource.
+   * @returns {string} A string representing the dlp_job.
    */
-  matchInspectTemplateFromProjectInspectTemplateName(projectInspectTemplateName: string) {
-    return this._pathTemplates.projectInspectTemplatePathTemplate.match(projectInspectTemplateName).inspect_template;
-  }
-
-  /**
-   * Return a fully-qualified organizationDeidentifyTemplate resource name string.
-   *
-   * @param {string} organization
-   * @param {string} deidentify_template
-   * @returns {string} Resource name string.
-   */
-  organizationDeidentifyTemplatePath(organization:string,deidentifyTemplate:string) {
-    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.render({
-      organization: organization,
-      deidentify_template: deidentifyTemplate,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationDeidentifyTemplate resource.
-   *
-   * @param {string} organizationDeidentifyTemplateName
-   *   A fully-qualified path representing organization_deidentify_template resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationDeidentifyTemplateName(organizationDeidentifyTemplateName: string) {
-    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.match(organizationDeidentifyTemplateName).organization;
-  }
-
-  /**
-   * Parse the deidentify_template from OrganizationDeidentifyTemplate resource.
-   *
-   * @param {string} organizationDeidentifyTemplateName
-   *   A fully-qualified path representing organization_deidentify_template resource.
-   * @returns {string} A string representing the deidentify_template.
-   */
-  matchDeidentifyTemplateFromOrganizationDeidentifyTemplateName(organizationDeidentifyTemplateName: string) {
-    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.match(organizationDeidentifyTemplateName).deidentify_template;
-  }
-
-  /**
-   * Return a fully-qualified projectDeidentifyTemplate resource name string.
-   *
-   * @param {string} project
-   * @param {string} deidentify_template
-   * @returns {string} Resource name string.
-   */
-  projectDeidentifyTemplatePath(project:string,deidentifyTemplate:string) {
-    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.render({
-      project: project,
-      deidentify_template: deidentifyTemplate,
-    });
-  }
-
-  /**
-   * Parse the project from ProjectDeidentifyTemplate resource.
-   *
-   * @param {string} projectDeidentifyTemplateName
-   *   A fully-qualified path representing project_deidentify_template resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectDeidentifyTemplateName(projectDeidentifyTemplateName: string) {
-    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.match(projectDeidentifyTemplateName).project;
-  }
-
-  /**
-   * Parse the deidentify_template from ProjectDeidentifyTemplate resource.
-   *
-   * @param {string} projectDeidentifyTemplateName
-   *   A fully-qualified path representing project_deidentify_template resource.
-   * @returns {string} A string representing the deidentify_template.
-   */
-  matchDeidentifyTemplateFromProjectDeidentifyTemplateName(projectDeidentifyTemplateName: string) {
-    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.match(projectDeidentifyTemplateName).deidentify_template;
+  matchDlpJobFromDlpJobName(dlpJobName: string) {
+    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).dlp_job;
   }
 
   /**
@@ -3165,39 +3057,98 @@ export class DlpServiceClient {
   }
 
   /**
-   * Return a fully-qualified dlpJob resource name string.
+   * Return a fully-qualified organization resource name string.
    *
-   * @param {string} project
-   * @param {string} dlp_job
+   * @param {string} organization
    * @returns {string} Resource name string.
    */
-  dlpJobPath(project:string,dlpJob:string) {
-    return this._pathTemplates.dlpJobPathTemplate.render({
-      project: project,
-      dlp_job: dlpJob,
+  organizationPath(organization:string) {
+    return this._pathTemplates.organizationPathTemplate.render({
+      organization: organization,
     });
   }
 
   /**
-   * Parse the project from DlpJob resource.
+   * Parse the organization from Organization resource.
    *
-   * @param {string} dlpJobName
-   *   A fully-qualified path representing DlpJob resource.
-   * @returns {string} A string representing the project.
+   * @param {string} organizationName
+   *   A fully-qualified path representing Organization resource.
+   * @returns {string} A string representing the organization.
    */
-  matchProjectFromDlpJobName(dlpJobName: string) {
-    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).project;
+  matchOrganizationFromOrganizationName(organizationName: string) {
+    return this._pathTemplates.organizationPathTemplate.match(organizationName).organization;
   }
 
   /**
-   * Parse the dlp_job from DlpJob resource.
+   * Return a fully-qualified organizationDeidentifyTemplate resource name string.
    *
-   * @param {string} dlpJobName
-   *   A fully-qualified path representing DlpJob resource.
-   * @returns {string} A string representing the dlp_job.
+   * @param {string} organization
+   * @param {string} deidentify_template
+   * @returns {string} Resource name string.
    */
-  matchDlpJobFromDlpJobName(dlpJobName: string) {
-    return this._pathTemplates.dlpJobPathTemplate.match(dlpJobName).dlp_job;
+  organizationDeidentifyTemplatePath(organization:string,deidentifyTemplate:string) {
+    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.render({
+      organization: organization,
+      deidentify_template: deidentifyTemplate,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationDeidentifyTemplate resource.
+   *
+   * @param {string} organizationDeidentifyTemplateName
+   *   A fully-qualified path representing organization_deidentify_template resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationDeidentifyTemplateName(organizationDeidentifyTemplateName: string) {
+    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.match(organizationDeidentifyTemplateName).organization;
+  }
+
+  /**
+   * Parse the deidentify_template from OrganizationDeidentifyTemplate resource.
+   *
+   * @param {string} organizationDeidentifyTemplateName
+   *   A fully-qualified path representing organization_deidentify_template resource.
+   * @returns {string} A string representing the deidentify_template.
+   */
+  matchDeidentifyTemplateFromOrganizationDeidentifyTemplateName(organizationDeidentifyTemplateName: string) {
+    return this._pathTemplates.organizationDeidentifyTemplatePathTemplate.match(organizationDeidentifyTemplateName).deidentify_template;
+  }
+
+  /**
+   * Return a fully-qualified organizationInspectTemplate resource name string.
+   *
+   * @param {string} organization
+   * @param {string} inspect_template
+   * @returns {string} Resource name string.
+   */
+  organizationInspectTemplatePath(organization:string,inspectTemplate:string) {
+    return this._pathTemplates.organizationInspectTemplatePathTemplate.render({
+      organization: organization,
+      inspect_template: inspectTemplate,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationInspectTemplate resource.
+   *
+   * @param {string} organizationInspectTemplateName
+   *   A fully-qualified path representing organization_inspect_template resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationInspectTemplateName(organizationInspectTemplateName: string) {
+    return this._pathTemplates.organizationInspectTemplatePathTemplate.match(organizationInspectTemplateName).organization;
+  }
+
+  /**
+   * Parse the inspect_template from OrganizationInspectTemplate resource.
+   *
+   * @param {string} organizationInspectTemplateName
+   *   A fully-qualified path representing organization_inspect_template resource.
+   * @returns {string} A string representing the inspect_template.
+   */
+  matchInspectTemplateFromOrganizationInspectTemplateName(organizationInspectTemplateName: string) {
+    return this._pathTemplates.organizationInspectTemplatePathTemplate.match(organizationInspectTemplateName).inspect_template;
   }
 
   /**
@@ -3237,6 +3188,101 @@ export class DlpServiceClient {
   }
 
   /**
+   * Return a fully-qualified project resource name string.
+   *
+   * @param {string} project
+   * @returns {string} Resource name string.
+   */
+  projectPath(project:string) {
+    return this._pathTemplates.projectPathTemplate.render({
+      project: project,
+    });
+  }
+
+  /**
+   * Parse the project from Project resource.
+   *
+   * @param {string} projectName
+   *   A fully-qualified path representing Project resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectName(projectName: string) {
+    return this._pathTemplates.projectPathTemplate.match(projectName).project;
+  }
+
+  /**
+   * Return a fully-qualified projectDeidentifyTemplate resource name string.
+   *
+   * @param {string} project
+   * @param {string} deidentify_template
+   * @returns {string} Resource name string.
+   */
+  projectDeidentifyTemplatePath(project:string,deidentifyTemplate:string) {
+    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.render({
+      project: project,
+      deidentify_template: deidentifyTemplate,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectDeidentifyTemplate resource.
+   *
+   * @param {string} projectDeidentifyTemplateName
+   *   A fully-qualified path representing project_deidentify_template resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectDeidentifyTemplateName(projectDeidentifyTemplateName: string) {
+    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.match(projectDeidentifyTemplateName).project;
+  }
+
+  /**
+   * Parse the deidentify_template from ProjectDeidentifyTemplate resource.
+   *
+   * @param {string} projectDeidentifyTemplateName
+   *   A fully-qualified path representing project_deidentify_template resource.
+   * @returns {string} A string representing the deidentify_template.
+   */
+  matchDeidentifyTemplateFromProjectDeidentifyTemplateName(projectDeidentifyTemplateName: string) {
+    return this._pathTemplates.projectDeidentifyTemplatePathTemplate.match(projectDeidentifyTemplateName).deidentify_template;
+  }
+
+  /**
+   * Return a fully-qualified projectInspectTemplate resource name string.
+   *
+   * @param {string} project
+   * @param {string} inspect_template
+   * @returns {string} Resource name string.
+   */
+  projectInspectTemplatePath(project:string,inspectTemplate:string) {
+    return this._pathTemplates.projectInspectTemplatePathTemplate.render({
+      project: project,
+      inspect_template: inspectTemplate,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectInspectTemplate resource.
+   *
+   * @param {string} projectInspectTemplateName
+   *   A fully-qualified path representing project_inspect_template resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectInspectTemplateName(projectInspectTemplateName: string) {
+    return this._pathTemplates.projectInspectTemplatePathTemplate.match(projectInspectTemplateName).project;
+  }
+
+  /**
+   * Parse the inspect_template from ProjectInspectTemplate resource.
+   *
+   * @param {string} projectInspectTemplateName
+   *   A fully-qualified path representing project_inspect_template resource.
+   * @returns {string} A string representing the inspect_template.
+   */
+  matchInspectTemplateFromProjectInspectTemplateName(projectInspectTemplateName: string) {
+    return this._pathTemplates.projectInspectTemplatePathTemplate.match(projectInspectTemplateName).inspect_template;
+  }
+
+  /**
    * Return a fully-qualified projectStoredInfoType resource name string.
    *
    * @param {string} project
@@ -3270,52 +3316,6 @@ export class DlpServiceClient {
    */
   matchStoredInfoTypeFromProjectStoredInfoTypeName(projectStoredInfoTypeName: string) {
     return this._pathTemplates.projectStoredInfoTypePathTemplate.match(projectStoredInfoTypeName).stored_info_type;
-  }
-
-  /**
-   * Return a fully-qualified project resource name string.
-   *
-   * @param {string} project
-   * @returns {string} Resource name string.
-   */
-  projectPath(project:string) {
-    return this._pathTemplates.projectPathTemplate.render({
-      project: project,
-    });
-  }
-
-  /**
-   * Parse the project from Project resource.
-   *
-   * @param {string} projectName
-   *   A fully-qualified path representing Project resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectName(projectName: string) {
-    return this._pathTemplates.projectPathTemplate.match(projectName).project;
-  }
-
-  /**
-   * Return a fully-qualified organization resource name string.
-   *
-   * @param {string} organization
-   * @returns {string} Resource name string.
-   */
-  organizationPath(organization:string) {
-    return this._pathTemplates.organizationPathTemplate.render({
-      organization: organization,
-    });
-  }
-
-  /**
-   * Parse the organization from Organization resource.
-   *
-   * @param {string} organizationName
-   *   A fully-qualified path representing Organization resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationName(organizationName: string) {
-    return this._pathTemplates.organizationPathTemplate.match(organizationName).organization;
   }
 
   /**

--- a/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -134,35 +134,32 @@ export class ServiceMonitoringServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectServicePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/services/{service}'
-      ),
-      organizationServicePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/services/{service}'
-      ),
       folderServicePathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}/services/{service}'
-      ),
-      PathTemplate: new gaxModule.PathTemplate(
-        '*'
-      ),
-      projectServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/services/{service}/serviceLevelObjectives/{service_level_objective}'
-      ),
-      organizationServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
       folderServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
-      projectUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/uptimeCheckConfigs/{uptime_check_config}'
+      folderUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
+        'folders/{folder}/uptimeCheckConfigs/{uptime_check_config}'
+      ),
+      organizationServicePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/services/{service}'
+      ),
+      organizationServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
       organizationUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/uptimeCheckConfigs/{uptime_check_config}'
       ),
-      folderUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
-        'folders/{folder}/uptimeCheckConfigs/{uptime_check_config}'
+      projectServicePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/services/{service}'
+      ),
+      projectServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/services/{service}/serviceLevelObjectives/{service_level_objective}'
+      ),
+      projectUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/uptimeCheckConfigs/{uptime_check_config}'
       ),
     };
 
@@ -1089,78 +1086,6 @@ export class ServiceMonitoringServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified projectService resource name string.
-   *
-   * @param {string} project
-   * @param {string} service
-   * @returns {string} Resource name string.
-   */
-  projectServicePath(project:string,service:string) {
-    return this._pathTemplates.projectServicePathTemplate.render({
-      project: project,
-      service: service,
-    });
-  }
-
-  /**
-   * Parse the project from ProjectService resource.
-   *
-   * @param {string} projectServiceName
-   *   A fully-qualified path representing project_service resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectServiceName(projectServiceName: string) {
-    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).project;
-  }
-
-  /**
-   * Parse the service from ProjectService resource.
-   *
-   * @param {string} projectServiceName
-   *   A fully-qualified path representing project_service resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromProjectServiceName(projectServiceName: string) {
-    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).service;
-  }
-
-  /**
-   * Return a fully-qualified organizationService resource name string.
-   *
-   * @param {string} organization
-   * @param {string} service
-   * @returns {string} Resource name string.
-   */
-  organizationServicePath(organization:string,service:string) {
-    return this._pathTemplates.organizationServicePathTemplate.render({
-      organization: organization,
-      service: service,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationService resource.
-   *
-   * @param {string} organizationServiceName
-   *   A fully-qualified path representing organization_service resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationServiceName(organizationServiceName: string) {
-    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).organization;
-  }
-
-  /**
-   * Parse the service from OrganizationService resource.
-   *
-   * @param {string} organizationServiceName
-   *   A fully-qualified path representing organization_service resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromOrganizationServiceName(organizationServiceName: string) {
-    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).service;
-  }
-
-  /**
    * Return a fully-qualified folderService resource name string.
    *
    * @param {string} folder
@@ -1194,114 +1119,6 @@ export class ServiceMonitoringServiceClient {
    */
   matchServiceFromFolderServiceName(folderServiceName: string) {
     return this._pathTemplates.folderServicePathTemplate.match(folderServiceName).service;
-  }
-
-  /**
-   * Return a fully-qualified  resource name string.
-   *
-   * @returns {string} Resource name string.
-   */
-  Path() {
-    return this._pathTemplates.PathTemplate.render({
-    });
-  }
-
-  /**
-   * Return a fully-qualified projectServiceServiceLevelObjective resource name string.
-   *
-   * @param {string} project
-   * @param {string} service
-   * @param {string} service_level_objective
-   * @returns {string} Resource name string.
-   */
-  projectServiceServiceLevelObjectivePath(project:string,service:string,serviceLevelObjective:string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.render({
-      project: project,
-      service: service,
-      service_level_objective: serviceLevelObjective,
-    });
-  }
-
-  /**
-   * Parse the project from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).project;
-  }
-
-  /**
-   * Parse the service from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service;
-  }
-
-  /**
-   * Parse the service_level_objective from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the service_level_objective.
-   */
-  matchServiceLevelObjectiveFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service_level_objective;
-  }
-
-  /**
-   * Return a fully-qualified organizationServiceServiceLevelObjective resource name string.
-   *
-   * @param {string} organization
-   * @param {string} service
-   * @param {string} service_level_objective
-   * @returns {string} Resource name string.
-   */
-  organizationServiceServiceLevelObjectivePath(organization:string,service:string,serviceLevelObjective:string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.render({
-      organization: organization,
-      service: service,
-      service_level_objective: serviceLevelObjective,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).organization;
-  }
-
-  /**
-   * Parse the service from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service;
-  }
-
-  /**
-   * Parse the service_level_objective from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the service_level_objective.
-   */
-  matchServiceLevelObjectiveFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service_level_objective;
   }
 
   /**
@@ -1354,39 +1171,124 @@ export class ServiceMonitoringServiceClient {
   }
 
   /**
-   * Return a fully-qualified projectUptimeCheckConfig resource name string.
+   * Return a fully-qualified folderUptimeCheckConfig resource name string.
    *
-   * @param {string} project
+   * @param {string} folder
    * @param {string} uptime_check_config
    * @returns {string} Resource name string.
    */
-  projectUptimeCheckConfigPath(project:string,uptimeCheckConfig:string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.render({
-      project: project,
+  folderUptimeCheckConfigPath(folder:string,uptimeCheckConfig:string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.render({
+      folder: folder,
       uptime_check_config: uptimeCheckConfig,
     });
   }
 
   /**
-   * Parse the project from ProjectUptimeCheckConfig resource.
+   * Parse the folder from FolderUptimeCheckConfig resource.
    *
-   * @param {string} projectUptimeCheckConfigName
-   *   A fully-qualified path representing project_uptime_check_config resource.
-   * @returns {string} A string representing the project.
+   * @param {string} folderUptimeCheckConfigName
+   *   A fully-qualified path representing folder_uptime_check_config resource.
+   * @returns {string} A string representing the folder.
    */
-  matchProjectFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).project;
+  matchFolderFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).folder;
   }
 
   /**
-   * Parse the uptime_check_config from ProjectUptimeCheckConfig resource.
+   * Parse the uptime_check_config from FolderUptimeCheckConfig resource.
    *
-   * @param {string} projectUptimeCheckConfigName
-   *   A fully-qualified path representing project_uptime_check_config resource.
+   * @param {string} folderUptimeCheckConfigName
+   *   A fully-qualified path representing folder_uptime_check_config resource.
    * @returns {string} A string representing the uptime_check_config.
    */
-  matchUptimeCheckConfigFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).uptime_check_config;
+  matchUptimeCheckConfigFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).uptime_check_config;
+  }
+
+  /**
+   * Return a fully-qualified organizationService resource name string.
+   *
+   * @param {string} organization
+   * @param {string} service
+   * @returns {string} Resource name string.
+   */
+  organizationServicePath(organization:string,service:string) {
+    return this._pathTemplates.organizationServicePathTemplate.render({
+      organization: organization,
+      service: service,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationService resource.
+   *
+   * @param {string} organizationServiceName
+   *   A fully-qualified path representing organization_service resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationServiceName(organizationServiceName: string) {
+    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).organization;
+  }
+
+  /**
+   * Parse the service from OrganizationService resource.
+   *
+   * @param {string} organizationServiceName
+   *   A fully-qualified path representing organization_service resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromOrganizationServiceName(organizationServiceName: string) {
+    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).service;
+  }
+
+  /**
+   * Return a fully-qualified organizationServiceServiceLevelObjective resource name string.
+   *
+   * @param {string} organization
+   * @param {string} service
+   * @param {string} service_level_objective
+   * @returns {string} Resource name string.
+   */
+  organizationServiceServiceLevelObjectivePath(organization:string,service:string,serviceLevelObjective:string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.render({
+      organization: organization,
+      service: service,
+      service_level_objective: serviceLevelObjective,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).organization;
+  }
+
+  /**
+   * Parse the service from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service;
+  }
+
+  /**
+   * Parse the service_level_objective from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the service_level_objective.
+   */
+  matchServiceLevelObjectiveFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service_level_objective;
   }
 
   /**
@@ -1426,39 +1328,124 @@ export class ServiceMonitoringServiceClient {
   }
 
   /**
-   * Return a fully-qualified folderUptimeCheckConfig resource name string.
+   * Return a fully-qualified projectService resource name string.
    *
-   * @param {string} folder
+   * @param {string} project
+   * @param {string} service
+   * @returns {string} Resource name string.
+   */
+  projectServicePath(project:string,service:string) {
+    return this._pathTemplates.projectServicePathTemplate.render({
+      project: project,
+      service: service,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectService resource.
+   *
+   * @param {string} projectServiceName
+   *   A fully-qualified path representing project_service resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectServiceName(projectServiceName: string) {
+    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).project;
+  }
+
+  /**
+   * Parse the service from ProjectService resource.
+   *
+   * @param {string} projectServiceName
+   *   A fully-qualified path representing project_service resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromProjectServiceName(projectServiceName: string) {
+    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).service;
+  }
+
+  /**
+   * Return a fully-qualified projectServiceServiceLevelObjective resource name string.
+   *
+   * @param {string} project
+   * @param {string} service
+   * @param {string} service_level_objective
+   * @returns {string} Resource name string.
+   */
+  projectServiceServiceLevelObjectivePath(project:string,service:string,serviceLevelObjective:string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.render({
+      project: project,
+      service: service,
+      service_level_objective: serviceLevelObjective,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).project;
+  }
+
+  /**
+   * Parse the service from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service;
+  }
+
+  /**
+   * Parse the service_level_objective from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the service_level_objective.
+   */
+  matchServiceLevelObjectiveFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service_level_objective;
+  }
+
+  /**
+   * Return a fully-qualified projectUptimeCheckConfig resource name string.
+   *
+   * @param {string} project
    * @param {string} uptime_check_config
    * @returns {string} Resource name string.
    */
-  folderUptimeCheckConfigPath(folder:string,uptimeCheckConfig:string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.render({
-      folder: folder,
+  projectUptimeCheckConfigPath(project:string,uptimeCheckConfig:string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.render({
+      project: project,
       uptime_check_config: uptimeCheckConfig,
     });
   }
 
   /**
-   * Parse the folder from FolderUptimeCheckConfig resource.
+   * Parse the project from ProjectUptimeCheckConfig resource.
    *
-   * @param {string} folderUptimeCheckConfigName
-   *   A fully-qualified path representing folder_uptime_check_config resource.
-   * @returns {string} A string representing the folder.
+   * @param {string} projectUptimeCheckConfigName
+   *   A fully-qualified path representing project_uptime_check_config resource.
+   * @returns {string} A string representing the project.
    */
-  matchFolderFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).folder;
+  matchProjectFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).project;
   }
 
   /**
-   * Parse the uptime_check_config from FolderUptimeCheckConfig resource.
+   * Parse the uptime_check_config from ProjectUptimeCheckConfig resource.
    *
-   * @param {string} folderUptimeCheckConfigName
-   *   A fully-qualified path representing folder_uptime_check_config resource.
+   * @param {string} projectUptimeCheckConfigName
+   *   A fully-qualified path representing project_uptime_check_config resource.
    * @returns {string} A string representing the uptime_check_config.
    */
-  matchUptimeCheckConfigFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).uptime_check_config;
+  matchUptimeCheckConfigFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).uptime_check_config;
   }
 
   /**

--- a/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -138,35 +138,32 @@ export class UptimeCheckServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectServicePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/services/{service}'
-      ),
-      organizationServicePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/services/{service}'
-      ),
       folderServicePathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}/services/{service}'
-      ),
-      PathTemplate: new gaxModule.PathTemplate(
-        '*'
-      ),
-      projectServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/services/{service}/serviceLevelObjectives/{service_level_objective}'
-      ),
-      organizationServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
-        'organizations/{organization}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
       folderServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
         'folders/{folder}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
-      projectUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
-        'projects/{project}/uptimeCheckConfigs/{uptime_check_config}'
+      folderUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
+        'folders/{folder}/uptimeCheckConfigs/{uptime_check_config}'
+      ),
+      organizationServicePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/services/{service}'
+      ),
+      organizationServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
+        'organizations/{organization}/services/{service}/serviceLevelObjectives/{service_level_objective}'
       ),
       organizationUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
         'organizations/{organization}/uptimeCheckConfigs/{uptime_check_config}'
       ),
-      folderUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
-        'folders/{folder}/uptimeCheckConfigs/{uptime_check_config}'
+      projectServicePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/services/{service}'
+      ),
+      projectServiceServiceLevelObjectivePathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/services/{service}/serviceLevelObjectives/{service_level_objective}'
+      ),
+      projectUptimeCheckConfigPathTemplate: new gaxModule.PathTemplate(
+        'projects/{project}/uptimeCheckConfigs/{uptime_check_config}'
       ),
     };
 
@@ -804,78 +801,6 @@ export class UptimeCheckServiceClient {
   // --------------------
 
   /**
-   * Return a fully-qualified projectService resource name string.
-   *
-   * @param {string} project
-   * @param {string} service
-   * @returns {string} Resource name string.
-   */
-  projectServicePath(project:string,service:string) {
-    return this._pathTemplates.projectServicePathTemplate.render({
-      project: project,
-      service: service,
-    });
-  }
-
-  /**
-   * Parse the project from ProjectService resource.
-   *
-   * @param {string} projectServiceName
-   *   A fully-qualified path representing project_service resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectServiceName(projectServiceName: string) {
-    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).project;
-  }
-
-  /**
-   * Parse the service from ProjectService resource.
-   *
-   * @param {string} projectServiceName
-   *   A fully-qualified path representing project_service resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromProjectServiceName(projectServiceName: string) {
-    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).service;
-  }
-
-  /**
-   * Return a fully-qualified organizationService resource name string.
-   *
-   * @param {string} organization
-   * @param {string} service
-   * @returns {string} Resource name string.
-   */
-  organizationServicePath(organization:string,service:string) {
-    return this._pathTemplates.organizationServicePathTemplate.render({
-      organization: organization,
-      service: service,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationService resource.
-   *
-   * @param {string} organizationServiceName
-   *   A fully-qualified path representing organization_service resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationServiceName(organizationServiceName: string) {
-    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).organization;
-  }
-
-  /**
-   * Parse the service from OrganizationService resource.
-   *
-   * @param {string} organizationServiceName
-   *   A fully-qualified path representing organization_service resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromOrganizationServiceName(organizationServiceName: string) {
-    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).service;
-  }
-
-  /**
    * Return a fully-qualified folderService resource name string.
    *
    * @param {string} folder
@@ -909,114 +834,6 @@ export class UptimeCheckServiceClient {
    */
   matchServiceFromFolderServiceName(folderServiceName: string) {
     return this._pathTemplates.folderServicePathTemplate.match(folderServiceName).service;
-  }
-
-  /**
-   * Return a fully-qualified  resource name string.
-   *
-   * @returns {string} Resource name string.
-   */
-  Path() {
-    return this._pathTemplates.PathTemplate.render({
-    });
-  }
-
-  /**
-   * Return a fully-qualified projectServiceServiceLevelObjective resource name string.
-   *
-   * @param {string} project
-   * @param {string} service
-   * @param {string} service_level_objective
-   * @returns {string} Resource name string.
-   */
-  projectServiceServiceLevelObjectivePath(project:string,service:string,serviceLevelObjective:string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.render({
-      project: project,
-      service: service,
-      service_level_objective: serviceLevelObjective,
-    });
-  }
-
-  /**
-   * Parse the project from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the project.
-   */
-  matchProjectFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).project;
-  }
-
-  /**
-   * Parse the service from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service;
-  }
-
-  /**
-   * Parse the service_level_objective from ProjectServiceServiceLevelObjective resource.
-   *
-   * @param {string} projectServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing project_service_service_level_objective resource.
-   * @returns {string} A string representing the service_level_objective.
-   */
-  matchServiceLevelObjectiveFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service_level_objective;
-  }
-
-  /**
-   * Return a fully-qualified organizationServiceServiceLevelObjective resource name string.
-   *
-   * @param {string} organization
-   * @param {string} service
-   * @param {string} service_level_objective
-   * @returns {string} Resource name string.
-   */
-  organizationServiceServiceLevelObjectivePath(organization:string,service:string,serviceLevelObjective:string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.render({
-      organization: organization,
-      service: service,
-      service_level_objective: serviceLevelObjective,
-    });
-  }
-
-  /**
-   * Parse the organization from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the organization.
-   */
-  matchOrganizationFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).organization;
-  }
-
-  /**
-   * Parse the service from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the service.
-   */
-  matchServiceFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service;
-  }
-
-  /**
-   * Parse the service_level_objective from OrganizationServiceServiceLevelObjective resource.
-   *
-   * @param {string} organizationServiceServiceLevelObjectiveName
-   *   A fully-qualified path representing organization_service_service_level_objective resource.
-   * @returns {string} A string representing the service_level_objective.
-   */
-  matchServiceLevelObjectiveFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
-    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service_level_objective;
   }
 
   /**
@@ -1069,39 +886,124 @@ export class UptimeCheckServiceClient {
   }
 
   /**
-   * Return a fully-qualified projectUptimeCheckConfig resource name string.
+   * Return a fully-qualified folderUptimeCheckConfig resource name string.
    *
-   * @param {string} project
+   * @param {string} folder
    * @param {string} uptime_check_config
    * @returns {string} Resource name string.
    */
-  projectUptimeCheckConfigPath(project:string,uptimeCheckConfig:string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.render({
-      project: project,
+  folderUptimeCheckConfigPath(folder:string,uptimeCheckConfig:string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.render({
+      folder: folder,
       uptime_check_config: uptimeCheckConfig,
     });
   }
 
   /**
-   * Parse the project from ProjectUptimeCheckConfig resource.
+   * Parse the folder from FolderUptimeCheckConfig resource.
    *
-   * @param {string} projectUptimeCheckConfigName
-   *   A fully-qualified path representing project_uptime_check_config resource.
-   * @returns {string} A string representing the project.
+   * @param {string} folderUptimeCheckConfigName
+   *   A fully-qualified path representing folder_uptime_check_config resource.
+   * @returns {string} A string representing the folder.
    */
-  matchProjectFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).project;
+  matchFolderFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).folder;
   }
 
   /**
-   * Parse the uptime_check_config from ProjectUptimeCheckConfig resource.
+   * Parse the uptime_check_config from FolderUptimeCheckConfig resource.
    *
-   * @param {string} projectUptimeCheckConfigName
-   *   A fully-qualified path representing project_uptime_check_config resource.
+   * @param {string} folderUptimeCheckConfigName
+   *   A fully-qualified path representing folder_uptime_check_config resource.
    * @returns {string} A string representing the uptime_check_config.
    */
-  matchUptimeCheckConfigFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
-    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).uptime_check_config;
+  matchUptimeCheckConfigFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
+    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).uptime_check_config;
+  }
+
+  /**
+   * Return a fully-qualified organizationService resource name string.
+   *
+   * @param {string} organization
+   * @param {string} service
+   * @returns {string} Resource name string.
+   */
+  organizationServicePath(organization:string,service:string) {
+    return this._pathTemplates.organizationServicePathTemplate.render({
+      organization: organization,
+      service: service,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationService resource.
+   *
+   * @param {string} organizationServiceName
+   *   A fully-qualified path representing organization_service resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationServiceName(organizationServiceName: string) {
+    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).organization;
+  }
+
+  /**
+   * Parse the service from OrganizationService resource.
+   *
+   * @param {string} organizationServiceName
+   *   A fully-qualified path representing organization_service resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromOrganizationServiceName(organizationServiceName: string) {
+    return this._pathTemplates.organizationServicePathTemplate.match(organizationServiceName).service;
+  }
+
+  /**
+   * Return a fully-qualified organizationServiceServiceLevelObjective resource name string.
+   *
+   * @param {string} organization
+   * @param {string} service
+   * @param {string} service_level_objective
+   * @returns {string} Resource name string.
+   */
+  organizationServiceServiceLevelObjectivePath(organization:string,service:string,serviceLevelObjective:string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.render({
+      organization: organization,
+      service: service,
+      service_level_objective: serviceLevelObjective,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).organization;
+  }
+
+  /**
+   * Parse the service from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service;
+  }
+
+  /**
+   * Parse the service_level_objective from OrganizationServiceServiceLevelObjective resource.
+   *
+   * @param {string} organizationServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing organization_service_service_level_objective resource.
+   * @returns {string} A string representing the service_level_objective.
+   */
+  matchServiceLevelObjectiveFromOrganizationServiceServiceLevelObjectiveName(organizationServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.organizationServiceServiceLevelObjectivePathTemplate.match(organizationServiceServiceLevelObjectiveName).service_level_objective;
   }
 
   /**
@@ -1141,39 +1043,124 @@ export class UptimeCheckServiceClient {
   }
 
   /**
-   * Return a fully-qualified folderUptimeCheckConfig resource name string.
+   * Return a fully-qualified projectService resource name string.
    *
-   * @param {string} folder
+   * @param {string} project
+   * @param {string} service
+   * @returns {string} Resource name string.
+   */
+  projectServicePath(project:string,service:string) {
+    return this._pathTemplates.projectServicePathTemplate.render({
+      project: project,
+      service: service,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectService resource.
+   *
+   * @param {string} projectServiceName
+   *   A fully-qualified path representing project_service resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectServiceName(projectServiceName: string) {
+    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).project;
+  }
+
+  /**
+   * Parse the service from ProjectService resource.
+   *
+   * @param {string} projectServiceName
+   *   A fully-qualified path representing project_service resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromProjectServiceName(projectServiceName: string) {
+    return this._pathTemplates.projectServicePathTemplate.match(projectServiceName).service;
+  }
+
+  /**
+   * Return a fully-qualified projectServiceServiceLevelObjective resource name string.
+   *
+   * @param {string} project
+   * @param {string} service
+   * @param {string} service_level_objective
+   * @returns {string} Resource name string.
+   */
+  projectServiceServiceLevelObjectivePath(project:string,service:string,serviceLevelObjective:string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.render({
+      project: project,
+      service: service,
+      service_level_objective: serviceLevelObjective,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).project;
+  }
+
+  /**
+   * Parse the service from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the service.
+   */
+  matchServiceFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service;
+  }
+
+  /**
+   * Parse the service_level_objective from ProjectServiceServiceLevelObjective resource.
+   *
+   * @param {string} projectServiceServiceLevelObjectiveName
+   *   A fully-qualified path representing project_service_service_level_objective resource.
+   * @returns {string} A string representing the service_level_objective.
+   */
+  matchServiceLevelObjectiveFromProjectServiceServiceLevelObjectiveName(projectServiceServiceLevelObjectiveName: string) {
+    return this._pathTemplates.projectServiceServiceLevelObjectivePathTemplate.match(projectServiceServiceLevelObjectiveName).service_level_objective;
+  }
+
+  /**
+   * Return a fully-qualified projectUptimeCheckConfig resource name string.
+   *
+   * @param {string} project
    * @param {string} uptime_check_config
    * @returns {string} Resource name string.
    */
-  folderUptimeCheckConfigPath(folder:string,uptimeCheckConfig:string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.render({
-      folder: folder,
+  projectUptimeCheckConfigPath(project:string,uptimeCheckConfig:string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.render({
+      project: project,
       uptime_check_config: uptimeCheckConfig,
     });
   }
 
   /**
-   * Parse the folder from FolderUptimeCheckConfig resource.
+   * Parse the project from ProjectUptimeCheckConfig resource.
    *
-   * @param {string} folderUptimeCheckConfigName
-   *   A fully-qualified path representing folder_uptime_check_config resource.
-   * @returns {string} A string representing the folder.
+   * @param {string} projectUptimeCheckConfigName
+   *   A fully-qualified path representing project_uptime_check_config resource.
+   * @returns {string} A string representing the project.
    */
-  matchFolderFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).folder;
+  matchProjectFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).project;
   }
 
   /**
-   * Parse the uptime_check_config from FolderUptimeCheckConfig resource.
+   * Parse the uptime_check_config from ProjectUptimeCheckConfig resource.
    *
-   * @param {string} folderUptimeCheckConfigName
-   *   A fully-qualified path representing folder_uptime_check_config resource.
+   * @param {string} projectUptimeCheckConfigName
+   *   A fully-qualified path representing project_uptime_check_config resource.
    * @returns {string} A string representing the uptime_check_config.
    */
-  matchUptimeCheckConfigFromFolderUptimeCheckConfigName(folderUptimeCheckConfigName: string) {
-    return this._pathTemplates.folderUptimeCheckConfigPathTemplate.match(folderUptimeCheckConfigName).uptime_check_config;
+  matchUptimeCheckConfigFromProjectUptimeCheckConfigName(projectUptimeCheckConfigName: string) {
+    return this._pathTemplates.projectUptimeCheckConfigPathTemplate.match(projectUptimeCheckConfigName).uptime_check_config;
   }
 
   /**


### PR DESCRIPTION
As @JustinBeckwith pointed out [here](https://github.com/googleapis/nodejs-tasks/pull/350#discussion_r375907862), the path templates are not really sorted (well, they are, but nobody knows how exactly).

Fixing that, and also removing path templates with no parameters (such as `*`) from the database, since we cannot possibly generate any useful helper function for them.