### PR TITLE
fix: include IAM into common services to ignore, refactor the code

### DIFF
--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -141,9 +141,7 @@ export class Generator {
       pf =>
         pf.name &&
         this.request.fileToGenerate.includes(pf.name) &&
-        // ignoring some common package names
-        pf.package !== 'google.longrunning' &&
-        pf.package !== 'google.cloud'
+        !API.isIgnoredService(pf)
     );
     const packageNamesToGenerate = protoFilesToGenerate.map(
       pf => pf.package || ''

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -38,6 +38,18 @@ export class API {
   // Sometimes it's hard to figure out automatically, so making this an option.
   mainServiceName: string;
 
+  static isIgnoredService(
+    fd: plugin.google.protobuf.IFileDescriptorProto
+  ): boolean {
+    // Some common proto files define common services which we don't want to generate.
+    // List them here.
+    return (
+      fd.package === 'google.longrunning' ||
+      fd.package === 'google.iam.v1' ||
+      fd.package === 'google.cloud'
+    );
+  }
+
   constructor(
     fileDescriptors: plugin.google.protobuf.IFileDescriptorProto[],
     packageName: string,
@@ -59,6 +71,7 @@ export class API {
     // parse resource map to Proto constructor
     this.protos = fileDescriptors
       .filter(fd => fd.name)
+      .filter(fd => !API.isIgnoredService(fd))
       .reduce((map, fd) => {
         map[fd.name!] = new Proto(
           fd,
@@ -72,6 +85,7 @@ export class API {
 
     const serviceNamesList: string[] = [];
     fileDescriptors
+      .filter(fd => !API.isIgnoredService(fd))
       .filter(fd => fd.service)
       .reduce((servicesList, fd) => {
         servicesList.push(...fd.service!);

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -14,12 +14,14 @@
 
 import * as plugin from '../../../pbjs-genfiles/plugin';
 import { commonPrefix } from '../util';
+import { API } from './api';
 
 export interface Options {
   grpcServiceConfig: plugin.grpc.service_config.ServiceConfig;
   publishName?: string;
   mainServiceName?: string;
 }
+
 export class Naming {
   name: string;
   namespace: string[];
@@ -35,8 +37,7 @@ export class Naming {
     const mainServiceName = options ? options.mainServiceName : '';
     const protoPackages = fileDescriptors
       .filter(fd => fd.service && fd.service.length > 0)
-      // LRO is an exception: it's a service but we don't generate any code for it
-      .filter(fd => fd.package !== 'google.longrunning')
+      .filter(fd => !API.isIgnoredService(fd))
       .map(fd => fd.package || '');
     const prefix = commonPrefix(protoPackages);
     // common prefix must either end with `.`, or be equal to at least one of

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -48,7 +48,11 @@ describe('schema/api.ts', () => {
     fd2.name = 'google/longrunning/operation.proto';
     fd2.package = 'google.longrunning';
     fd2.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
-    const api = new API([fd1, fd2], 'google.cloud.test.v1', {
+    const fd3 = new plugin.google.protobuf.FileDescriptorProto();
+    fd3.name = 'google/iam/v1/iam_policy.proto';
+    fd3.package = 'google.iam.v1';
+    fd2.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    const api = new API([fd1, fd2, fd3], 'google.cloud.test.v1', {
       grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
     });
     assert.deepStrictEqual(api.filesToGenerate, [


### PR DESCRIPTION
One more attempt to fix the common services problem properly. This time, let's move all the similar checks into one place (a public static method of the `API` class).