### PR TITLE
fix: pass x-goog-request-params to streaming methods

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -527,7 +527,7 @@ export class {{ service.name }}Client {
  */
   {{ method.name.toCamelCase() }}Stream(
       request?: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -384,7 +384,7 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       options?: gax.CallOptions):
     gax.CancellableStream{
-    options = options || {};
+    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(options);
   }
 {%- elif method.serverStreaming %}
@@ -396,18 +396,18 @@ export class {{ service.name }}Client {
       options?: gax.CallOptions):
     gax.CancellableStream{
     request = request || {};
-    options = options || {};
+    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(request, options);
   }
 {%- elif method.clientStreaming %}
   {{ method.name.toCamelCase() }}(
-      options: gax.CallOptions,
-      callback: Callback<
+      options?: gax.CallOptions,
+      callback?: Callback<
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
   {{ method.name.toCamelCase() }}(
-      callback: Callback<
+      callback?: Callback<
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>):
     gax.CancellableStream;
@@ -415,7 +415,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      optionsOrCallback: gax.CallOptions|Callback<
+      optionsOrCallback?: gax.CallOptions|Callback<
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined>,
       callback?: Callback<
@@ -426,8 +426,9 @@ export class {{ service.name }}Client {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    optionsOrCallback = optionsOrCallback || {};
-    return this._innerApiCalls.{{ method.name.toCamelCase() }}(null, optionsOrCallback, callback);
+    let options = optionsOrCallback as gax.CallOptions;
+    {{ util.buildHeaderRequestParam(method) }}
+    return this._innerApiCalls.{{ method.name.toCamelCase() }}(null, options, callback);
   }
 {%- endif %}
 {% endfor %}
@@ -530,6 +531,7 @@ export class {{ service.name }}Client {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    {{ util.buildHeaderRequestParam(method) }}
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.{{ method.name.toCamelCase() }}.createStream(
       this._innerApiCalls.{{ method.name.toCamelCase() }} as gax.GaxCall,

--- a/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
@@ -2225,7 +2225,7 @@ export class DlpServiceClient {
  */
   listInspectTemplatesStream(
       request?: protosTypes.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -2384,7 +2384,7 @@ export class DlpServiceClient {
  */
   listDeidentifyTemplatesStream(
       request?: protosTypes.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -2594,7 +2594,7 @@ export class DlpServiceClient {
  */
   listJobTriggersStream(
       request?: protosTypes.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -2809,7 +2809,7 @@ export class DlpServiceClient {
  */
   listDlpJobsStream(
       request?: protosTypes.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -2970,7 +2970,7 @@ export class DlpServiceClient {
  */
   listStoredInfoTypesStream(
       request?: protosTypes.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/typescript/test/testdata/dlp/src/v2/dlp_service_client.ts.baseline
@@ -2228,6 +2228,14 @@ export class DlpServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listInspectTemplates.createStream(
       this._innerApiCalls.listInspectTemplates as gax.GaxCall,
@@ -2387,6 +2395,14 @@ export class DlpServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listDeidentifyTemplates.createStream(
       this._innerApiCalls.listDeidentifyTemplates as gax.GaxCall,
@@ -2597,6 +2613,14 @@ export class DlpServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listJobTriggers.createStream(
       this._innerApiCalls.listJobTriggers as gax.GaxCall,
@@ -2812,6 +2836,14 @@ export class DlpServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listDlpJobs.createStream(
       this._innerApiCalls.listDlpJobs as gax.GaxCall,
@@ -2973,6 +3005,14 @@ export class DlpServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listStoredInfoTypes.createStream(
       this._innerApiCalls.listStoredInfoTypes as gax.GaxCall,

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -1655,7 +1655,7 @@ export class KeyManagementServiceClient {
  */
   listKeyRingsStream(
       request?: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -1796,7 +1796,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeysStream(
       request?: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -1939,7 +1939,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeyVersionsStream(
       request?: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -2076,7 +2076,7 @@ export class KeyManagementServiceClient {
  */
   listImportJobsStream(
       request?: protosTypes.google.cloud.kms.v1.IListImportJobsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
+++ b/typescript/test/testdata/keymanager/src/v1/key_management_service_client.ts.baseline
@@ -1658,6 +1658,14 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listKeyRings.createStream(
       this._innerApiCalls.listKeyRings as gax.GaxCall,
@@ -1799,6 +1807,14 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listCryptoKeys.createStream(
       this._innerApiCalls.listCryptoKeys as gax.GaxCall,
@@ -1942,6 +1958,14 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listCryptoKeyVersions.createStream(
       this._innerApiCalls.listCryptoKeyVersions as gax.GaxCall,
@@ -2079,6 +2103,14 @@ export class KeyManagementServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listImportJobs.createStream(
       this._innerApiCalls.listImportJobs as gax.GaxCall,

--- a/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -932,7 +932,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServicesStream(
       request?: protosTypes.google.monitoring.v3.IListServicesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -1071,7 +1071,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServiceLevelObjectivesStream(
       request?: protosTypes.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -935,6 +935,14 @@ export class ServiceMonitoringServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listServices.createStream(
       this._innerApiCalls.listServices as gax.GaxCall,
@@ -1074,6 +1082,14 @@ export class ServiceMonitoringServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listServiceLevelObjectives.createStream(
       this._innerApiCalls.listServiceLevelObjectives as gax.GaxCall,

--- a/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -666,7 +666,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckConfigsStream(
       request?: protosTypes.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);
@@ -786,7 +786,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckIpsStream(
       request?: protosTypes.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/typescript/test/testdata/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -669,6 +669,14 @@ export class UptimeCheckServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listUptimeCheckConfigs.createStream(
       this._innerApiCalls.listUptimeCheckConfigs as gax.GaxCall,
@@ -789,6 +797,7 @@ export class UptimeCheckServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listUptimeCheckIps.createStream(
       this._innerApiCalls.listUptimeCheckIps as gax.GaxCall,

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -948,6 +948,14 @@ export class CloudRedisClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listInstances.createStream(
       this._innerApiCalls.listInstances as gax.GaxCall,

--- a/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/typescript/test/testdata/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -945,7 +945,7 @@ export class CloudRedisClient {
  */
   listInstancesStream(
       request?: protosTypes.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -566,7 +566,7 @@ export class EchoClient {
  */
   pagedExpandStream(
       request?: protosTypes.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -350,13 +350,13 @@ export class EchoClient {
   }
 
   collect(
-      options: gax.CallOptions,
-      callback: Callback<
+      options?: gax.CallOptions,
+      callback?: Callback<
         protosTypes.google.showcase.v1beta1.IEchoResponse,
         protosTypes.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined>):
     gax.CancellableStream;
   collect(
-      callback: Callback<
+      callback?: Callback<
         protosTypes.google.showcase.v1beta1.IEchoResponse,
         protosTypes.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined>):
     gax.CancellableStream;
@@ -371,7 +371,7 @@ export class EchoClient {
  * [EchoRequest]{@link google.showcase.v1beta1.EchoRequest}.
  */
   collect(
-      optionsOrCallback: gax.CallOptions|Callback<
+      optionsOrCallback?: gax.CallOptions|Callback<
         protosTypes.google.showcase.v1beta1.IEchoResponse,
         protosTypes.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined>,
       callback?: Callback<
@@ -382,8 +382,9 @@ export class EchoClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    optionsOrCallback = optionsOrCallback || {};
-    return this._innerApiCalls.collect(null, optionsOrCallback, callback);
+    let options = optionsOrCallback as gax.CallOptions;
+    options = options || {};
+    return this._innerApiCalls.collect(null, options, callback);
   }
 
 /**
@@ -569,6 +570,7 @@ export class EchoClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.pagedExpand.createStream(
       this._innerApiCalls.pagedExpand as gax.GaxCall,

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1018,7 +1018,7 @@ export class TranslationServiceClient {
  */
   listGlossariesStream(
       request?: protosTypes.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options?: gax.CallOptions | {}):
+      options?: gax.CallOptions):
     Transform{
     request = request || {};
     const callSettings = new gax.CallSettings(options);

--- a/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/typescript/test/testdata/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1021,6 +1021,14 @@ export class TranslationServiceClient {
       options?: gax.CallOptions):
     Transform{
     request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.listGlossaries.createStream(
       this._innerApiCalls.listGlossaries as gax.GaxCall,


### PR DESCRIPTION
Turns out BigQuery Storage API actually cares about the `x-goog-request-params` being passed for all methods, including streaming.

Cc: @steffnay 