### PR TITLE
fix: client streaming do not have request

### DIFF
--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -384,7 +384,6 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       options?: gax.CallOptions):
     gax.CancellableStream{
-    {{ util.buildHeaderRequestParam(method) }}
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(options);
   }
 {%- elif method.serverStreaming %}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -426,8 +426,7 @@ export class {{ service.name }}Client {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    let options = optionsOrCallback as gax.CallOptions;
-    {{ util.buildHeaderRequestParam(method) }}
+    const options = optionsOrCallback as gax.CallOptions;
     return this._innerApiCalls.{{ method.name.toCamelCase() }}(null, options, callback);
   }
 {%- endif %}

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -401,7 +401,6 @@ export class EchoClient {
   chat(
       options?: gax.CallOptions):
     gax.CancellableStream{
-    options = options || {};
     return this._innerApiCalls.chat(options);
   }
 

--- a/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/typescript/test/testdata/showcase/src/v1beta1/echo_client.ts.baseline
@@ -382,8 +382,7 @@ export class EchoClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    let options = optionsOrCallback as gax.CallOptions;
-    options = options || {};
+    const options = optionsOrCallback as gax.CallOptions;
     return this._innerApiCalls.collect(null, options, callback);
   }
 


### PR DESCRIPTION
This fixes the problem @hkdevandla just found with the Showcase Messaging API. The problem is not shown by our existing tests but in Messaging API we had a client streaming method that had a request parameter (which did not make any sense because client streaming methods have no request object).

@xiaozhenliu-gg5 Maybe we can add Messaging API to the Showcase tests as well?  If we add those protos to our Showcase folder it will give us better coverage almost for free.

Introduced today by me in #234 :)