### PR TITLE
fix: copy protos in common google gax and googleapis

### DIFF
--- a/typescript/src/start_script.ts
+++ b/typescript/src/start_script.ts
@@ -18,7 +18,6 @@ import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
-import { Z_FIXED } from 'zlib';
 const fileSystem = require('file-system');
 
 const googleGaxPath = path.dirname(require.resolve('google-gax')); // ...../google-gax/build/src
@@ -105,9 +104,7 @@ try {
   }
   // copy proto file to generated folder
   const protoList = path.join(outputDir, 'proto.list');
-  const protoFilesMap = new Map<string, string>(
-    protoFiles.map(proto => [proto, proto])
-  );
+  const protoFilesSet = new Set(protoFiles);
   fs.readFileSync(protoList)
     .toString()
     .split('\n')
@@ -115,7 +112,7 @@ try {
       protoDirs.forEach(dir => {
         const protoFile = path.join(dir, proto);
         if (
-          (protoFilesMap.has(protoFile) ||
+          (protoFilesSet.has(protoFile) ||
             !fs.existsSync(path.join(GOOGLE_GAX_PROTOS_DIR, proto))) &&
           fs.existsSync(protoFile)
         ) {

--- a/typescript/src/start_script.ts
+++ b/typescript/src/start_script.ts
@@ -14,11 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {execFileSync} from 'child_process';
+import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
-import {Z_FIXED} from 'zlib';
+import { Z_FIXED } from 'zlib';
 const fileSystem = require('file-system');
 
 const googleGaxPath = path.dirname(require.resolve('google-gax')); // ...../google-gax/build/src
@@ -91,7 +91,7 @@ protocCommand.push(...protoDirsArg);
 protocCommand.push(...protoFiles);
 protocCommand.push(`-I${commonProtoPath}`);
 try {
-  execFileSync(`protoc`, protocCommand, {stdio: 'inherit'});
+  execFileSync(`protoc`, protocCommand, { stdio: 'inherit' });
 } catch (err) {
   console.error(err.toString());
   process.exit(1);
@@ -114,7 +114,11 @@ try {
     .forEach(proto => {
       protoDirs.forEach(dir => {
         const protoFile = path.join(dir, proto);
-        if ((protoFilesMap.has(protoFile) || !fs.existsSync(path.join(GOOGLE_GAX_PROTOS_DIR, proto))) && fs.existsSync(protoFile)) {
+        if (
+          (protoFilesMap.has(protoFile) ||
+            !fs.existsSync(path.join(GOOGLE_GAX_PROTOS_DIR, proto))) &&
+          fs.existsSync(protoFile)
+        ) {
           fileSystem.copyFileSync(protoFile, path.join(copyProtoDir, proto));
         }
       });

--- a/typescript/src/start_script.ts
+++ b/typescript/src/start_script.ts
@@ -14,10 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execFileSync } from 'child_process';
+import {execFileSync} from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
+import {Z_FIXED} from 'zlib';
 const fileSystem = require('file-system');
 
 const googleGaxPath = path.dirname(require.resolve('google-gax')); // ...../google-gax/build/src
@@ -90,7 +91,7 @@ protocCommand.push(...protoDirsArg);
 protocCommand.push(...protoFiles);
 protocCommand.push(`-I${commonProtoPath}`);
 try {
-  execFileSync(`protoc`, protocCommand, { stdio: 'inherit' });
+  execFileSync(`protoc`, protocCommand, {stdio: 'inherit'});
 } catch (err) {
   console.error(err.toString());
   process.exit(1);
@@ -104,14 +105,16 @@ try {
   }
   // copy proto file to generated folder
   const protoList = path.join(outputDir, 'proto.list');
+  const protoFilesMap = new Map<string, string>(
+    protoFiles.map(proto => [proto, proto])
+  );
   fs.readFileSync(protoList)
     .toString()
     .split('\n')
-    .filter(proto => !fs.existsSync(path.join(GOOGLE_GAX_PROTOS_DIR, proto)))
     .forEach(proto => {
       protoDirs.forEach(dir => {
         const protoFile = path.join(dir, proto);
-        if (fs.existsSync(protoFile)) {
+        if ((protoFilesMap.has(protoFile) || !fs.existsSync(path.join(GOOGLE_GAX_PROTOS_DIR, proto))) && fs.existsSync(protoFile)) {
           fileSystem.copyFileSync(protoFile, path.join(copyProtoDir, proto));
         }
       });

--- a/typescript/test/testdata/monitoring/protos/google/monitoring/v3/service_service.proto.baseline
+++ b/typescript/test/testdata/monitoring/protos/google/monitoring/v3/service_service.proto.baseline
@@ -1,0 +1,337 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.monitoring.v3;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/monitored_resource.proto";
+import "google/api/resource.proto";
+import "google/monitoring/v3/service.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.Monitoring.V3";
+option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
+option java_multiple_files = true;
+option java_outer_classname = "ServiceMonitoringServiceProto";
+option java_package = "com.google.monitoring.v3";
+option php_namespace = "Google\\Cloud\\Monitoring\\V3";
+
+// The Stackdriver Monitoring Service-Oriented Monitoring API has endpoints for
+// managing and querying aspects of a workspace's services. These include the
+// `Service`'s monitored resources, its Service-Level Objectives, and a taxonomy
+// of categorized Health Metrics.
+service ServiceMonitoringService {
+  option (google.api.default_host) = "monitoring.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/monitoring,"
+      "https://www.googleapis.com/auth/monitoring.read";
+
+  // Create a `Service`.
+  rpc CreateService(CreateServiceRequest) returns (Service) {
+    option (google.api.http) = {
+      post: "/v3/{parent=*/*}/services"
+      body: "service"
+    };
+    option (google.api.method_signature) = "parent,service";
+  }
+
+  // Get the named `Service`.
+  rpc GetService(GetServiceRequest) returns (Service) {
+    option (google.api.http) = {
+      get: "/v3/{name=*/*/services/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // List `Service`s for this workspace.
+  rpc ListServices(ListServicesRequest) returns (ListServicesResponse) {
+    option (google.api.http) = {
+      get: "/v3/{parent=*/*}/services"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Update this `Service`.
+  rpc UpdateService(UpdateServiceRequest) returns (Service) {
+    option (google.api.http) = {
+      patch: "/v3/{service.name=*/*/services/*}"
+      body: "service"
+    };
+    option (google.api.method_signature) = "service";
+  }
+
+  // Soft delete this `Service`.
+  rpc DeleteService(DeleteServiceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v3/{name=*/*/services/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Create a `ServiceLevelObjective` for the given `Service`.
+  rpc CreateServiceLevelObjective(CreateServiceLevelObjectiveRequest) returns (ServiceLevelObjective) {
+    option (google.api.http) = {
+      post: "/v3/{parent=*/*/services/*}/serviceLevelObjectives"
+      body: "service_level_objective"
+    };
+    option (google.api.method_signature) = "parent,service_level_objective";
+  }
+
+  // Get a `ServiceLevelObjective` by name.
+  rpc GetServiceLevelObjective(GetServiceLevelObjectiveRequest) returns (ServiceLevelObjective) {
+    option (google.api.http) = {
+      get: "/v3/{name=*/*/services/*/serviceLevelObjectives/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // List the `ServiceLevelObjective`s for the given `Service`.
+  rpc ListServiceLevelObjectives(ListServiceLevelObjectivesRequest) returns (ListServiceLevelObjectivesResponse) {
+    option (google.api.http) = {
+      get: "/v3/{parent=*/*/services/*}/serviceLevelObjectives"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Update the given `ServiceLevelObjective`.
+  rpc UpdateServiceLevelObjective(UpdateServiceLevelObjectiveRequest) returns (ServiceLevelObjective) {
+    option (google.api.http) = {
+      patch: "/v3/{service_level_objective.name=*/*/services/*/serviceLevelObjectives/*}"
+      body: "service_level_objective"
+    };
+    option (google.api.method_signature) = "service_level_objective";
+  }
+
+  // Delete the given `ServiceLevelObjective`.
+  rpc DeleteServiceLevelObjective(DeleteServiceLevelObjectiveRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v3/{name=*/*/services/*/serviceLevelObjectives/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+}
+
+// The `CreateService` request.
+message CreateServiceRequest {
+  // Required. Resource name of the parent workspace.
+  // Of the form `projects/{project_id}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "monitoring.googleapis.com/Service"
+    }
+  ];
+
+  // Optional. The Service id to use for this Service. If omitted, an id will be
+  // generated instead. Must match the pattern [a-z0-9\-]+
+  string service_id = 3;
+
+  // Required. The `Service` to create.
+  Service service = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The `GetService` request.
+message GetServiceRequest {
+  // Required. Resource name of the `Service`.
+  // Of the form `projects/{project_id}/services/{service_id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/Service"
+    }
+  ];
+}
+
+// The `ListServices` request.
+message ListServicesRequest {
+  // Required. Resource name of the parent `Workspace`.
+  // Of the form `projects/{project_id}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "monitoring.googleapis.com/Service"
+    }
+  ];
+
+  // A filter specifying what `Service`s to return. The filter currently
+  // supports the following fields:
+  //
+  //     - `identifier_case`
+  //     - `app_engine.module_id`
+  //     - `cloud_endpoints.service`
+  //     - `cluster_istio.location`
+  //     - `cluster_istio.cluster_name`
+  //     - `cluster_istio.service_namespace`
+  //     - `cluster_istio.service_name`
+  //
+  // `identifier_case` refers to which option in the identifier oneof is
+  // populated. For example, the filter `identifier_case = "CUSTOM"` would match
+  // all services with a value for the `custom` field. Valid options are
+  // "CUSTOM", "APP_ENGINE", "CLOUD_ENDPOINTS", and "CLUSTER_ISTIO".
+  string filter = 2;
+
+  // A non-negative number that is the maximum number of results to return.
+  // When 0, use default page size.
+  int32 page_size = 3;
+
+  // If this field is not empty then it must contain the `nextPageToken` value
+  // returned by a previous call to this method.  Using this field causes the
+  // method to return additional results from the previous method call.
+  string page_token = 4;
+}
+
+// The `ListServices` response.
+message ListServicesResponse {
+  // The `Service`s matching the specified filter.
+  repeated Service services = 1;
+
+  // If there are more results than have been returned, then this field is set
+  // to a non-empty value.  To see the additional results,
+  // use that value as `pageToken` in the next call to this method.
+  string next_page_token = 2;
+}
+
+// The `UpdateService` request.
+message UpdateServiceRequest {
+  // Required. The `Service` to draw updates from.
+  // The given `name` specifies the resource to update.
+  Service service = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // A set of field paths defining which fields to use for the update.
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// The `DeleteService` request.
+message DeleteServiceRequest {
+  // Required. Resource name of the `Service` to delete.
+  // Of the form `projects/{project_id}/services/{service_id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/Service"
+    }
+  ];
+}
+
+// The `CreateServiceLevelObjective` request.
+message CreateServiceLevelObjectiveRequest {
+  // Required. Resource name of the parent `Service`.
+  // Of the form `projects/{project_id}/services/{service_id}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/Service"
+    }
+  ];
+
+  // Optional. The ServiceLevelObjective id to use for this
+  // ServiceLevelObjective. If omitted, an id will be generated instead. Must
+  // match the pattern [a-z0-9\-]+
+  string service_level_objective_id = 3;
+
+  // Required. The `ServiceLevelObjective` to create.
+  // The provided `name` will be respected if no `ServiceLevelObjective` exists
+  // with this name.
+  ServiceLevelObjective service_level_objective = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The `GetServiceLevelObjective` request.
+message GetServiceLevelObjectiveRequest {
+  // Required. Resource name of the `ServiceLevelObjective` to get.
+  // Of the form
+  // `projects/{project_id}/services/{service_id}/serviceLevelObjectives/{slo_name}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/ServiceLevelObjective"
+    }
+  ];
+
+  // View of the `ServiceLevelObjective` to return. If `DEFAULT`, return the
+  // `ServiceLevelObjective` as originally defined. If `EXPLICIT` and the
+  // `ServiceLevelObjective` is defined in terms of a `BasicSli`, replace the
+  // `BasicSli` with a `RequestBasedSli` spelling out how the SLI is computed.
+  ServiceLevelObjective.View view = 2;
+}
+
+// The `ListServiceLevelObjectives` request.
+message ListServiceLevelObjectivesRequest {
+  // Required. Resource name of the parent `Service`.
+  // Of the form `projects/{project_id}/services/{service_id}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/Service"
+    }
+  ];
+
+  // A filter specifying what `ServiceLevelObjective`s to return.
+  string filter = 2;
+
+  // A non-negative number that is the maximum number of results to return.
+  // When 0, use default page size.
+  int32 page_size = 3;
+
+  // If this field is not empty then it must contain the `nextPageToken` value
+  // returned by a previous call to this method.  Using this field causes the
+  // method to return additional results from the previous method call.
+  string page_token = 4;
+
+  // View of the `ServiceLevelObjective`s to return. If `DEFAULT`, return each
+  // `ServiceLevelObjective` as originally defined. If `EXPLICIT` and the
+  // `ServiceLevelObjective` is defined in terms of a `BasicSli`, replace the
+  // `BasicSli` with a `RequestBasedSli` spelling out how the SLI is computed.
+  ServiceLevelObjective.View view = 5;
+}
+
+// The `ListServiceLevelObjectives` response.
+message ListServiceLevelObjectivesResponse {
+  // The `ServiceLevelObjective`s matching the specified filter.
+  repeated ServiceLevelObjective service_level_objectives = 1;
+
+  // If there are more results than have been returned, then this field is set
+  // to a non-empty value.  To see the additional results,
+  // use that value as `pageToken` in the next call to this method.
+  string next_page_token = 2;
+}
+
+// The `UpdateServiceLevelObjective` request.
+message UpdateServiceLevelObjectiveRequest {
+  // Required. The `ServiceLevelObjective` to draw updates from.
+  // The given `name` specifies the resource to update.
+  ServiceLevelObjective service_level_objective = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // A set of field paths defining which fields to use for the update.
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// The `DeleteServiceLevelObjective` request.
+message DeleteServiceLevelObjectiveRequest {
+  // Required. Resource name of the `ServiceLevelObjective` to delete.
+  // Of the form
+  // `projects/{project_id}/services/{service_id}/serviceLevelObjectives/{slo_name}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/ServiceLevelObjective"
+    }
+  ];
+}

--- a/typescript/test/testdata/monitoring/protos/google/monitoring/v3/uptime_service.proto.baseline
+++ b/typescript/test/testdata/monitoring/protos/google/monitoring/v3/uptime_service.proto.baseline
@@ -1,0 +1,237 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.monitoring.v3;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/monitoring/v3/uptime.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.Monitoring.V3";
+option go_package = "google.golang.org/genproto/googleapis/monitoring/v3;monitoring";
+option java_multiple_files = true;
+option java_outer_classname = "UptimeServiceProto";
+option java_package = "com.google.monitoring.v3";
+option php_namespace = "Google\\Cloud\\Monitoring\\V3";
+
+// The UptimeCheckService API is used to manage (list, create, delete, edit)
+// Uptime check configurations in the Stackdriver Monitoring product. An Uptime
+// check is a piece of configuration that determines which resources and
+// services to monitor for availability. These configurations can also be
+// configured interactively by navigating to the [Cloud Console]
+// (http://console.cloud.google.com), selecting the appropriate project,
+// clicking on "Monitoring" on the left-hand side to navigate to Stackdriver,
+// and then clicking on "Uptime".
+service UptimeCheckService {
+  option (google.api.default_host) = "monitoring.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/monitoring,"
+      "https://www.googleapis.com/auth/monitoring.read";
+
+  // Lists the existing valid Uptime check configurations for the project
+  // (leaving out any invalid configurations).
+  rpc ListUptimeCheckConfigs(ListUptimeCheckConfigsRequest) returns (ListUptimeCheckConfigsResponse) {
+    option (google.api.http) = {
+      get: "/v3/{parent=projects/*}/uptimeCheckConfigs"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Gets a single Uptime check configuration.
+  rpc GetUptimeCheckConfig(GetUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+    option (google.api.http) = {
+      get: "/v3/{name=projects/*/uptimeCheckConfigs/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a new Uptime check configuration.
+  rpc CreateUptimeCheckConfig(CreateUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+    option (google.api.http) = {
+      post: "/v3/{parent=projects/*}/uptimeCheckConfigs"
+      body: "uptime_check_config"
+    };
+    option (google.api.method_signature) = "parent,uptime_check_config";
+  }
+
+  // Updates an Uptime check configuration. You can either replace the entire
+  // configuration with a new one or replace only certain fields in the current
+  // configuration by specifying the fields to be updated via `updateMask`.
+  // Returns the updated configuration.
+  rpc UpdateUptimeCheckConfig(UpdateUptimeCheckConfigRequest) returns (UptimeCheckConfig) {
+    option (google.api.http) = {
+      patch: "/v3/{uptime_check_config.name=projects/*/uptimeCheckConfigs/*}"
+      body: "uptime_check_config"
+    };
+    option (google.api.method_signature) = "uptime_check_config";
+  }
+
+  // Deletes an Uptime check configuration. Note that this method will fail
+  // if the Uptime check configuration is referenced by an alert policy or
+  // other dependent configs that would be rendered invalid by the deletion.
+  rpc DeleteUptimeCheckConfig(DeleteUptimeCheckConfigRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v3/{name=projects/*/uptimeCheckConfigs/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns the list of IP addresses that checkers run from
+  rpc ListUptimeCheckIps(ListUptimeCheckIpsRequest) returns (ListUptimeCheckIpsResponse) {
+    option (google.api.http) = {
+      get: "/v3/uptimeCheckIps"
+    };
+  }
+}
+
+// The protocol for the `ListUptimeCheckConfigs` request.
+message ListUptimeCheckConfigsRequest {
+  // Required. The project whose Uptime check configurations are listed. The format
+  //   is `projects/[PROJECT_ID]`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "monitoring.googleapis.com/UptimeCheckConfig"
+    }
+  ];
+
+  // The maximum number of results to return in a single response. The server
+  // may further constrain the maximum number of results returned in a single
+  // page. If the page_size is <=0, the server will decide the number of results
+  // to be returned.
+  int32 page_size = 3;
+
+  // If this field is not empty then it must contain the `nextPageToken` value
+  // returned by a previous call to this method.  Using this field causes the
+  // method to return more results from the previous method call.
+  string page_token = 4;
+}
+
+// The protocol for the `ListUptimeCheckConfigs` response.
+message ListUptimeCheckConfigsResponse {
+  // The returned Uptime check configurations.
+  repeated UptimeCheckConfig uptime_check_configs = 1;
+
+  // This field represents the pagination token to retrieve the next page of
+  // results. If the value is empty, it means no further results for the
+  // request. To retrieve the next page of results, the value of the
+  // next_page_token is passed to the subsequent List method call (in the
+  // request message's page_token field).
+  string next_page_token = 2;
+
+  // The total number of Uptime check configurations for the project,
+  // irrespective of any pagination.
+  int32 total_size = 3;
+}
+
+// The protocol for the `GetUptimeCheckConfig` request.
+message GetUptimeCheckConfigRequest {
+  // Required. The Uptime check configuration to retrieve. The format
+  //   is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/UptimeCheckConfig"
+    }
+  ];
+}
+
+// The protocol for the `CreateUptimeCheckConfig` request.
+message CreateUptimeCheckConfigRequest {
+  // Required. The project in which to create the Uptime check. The format
+  //   is `projects/[PROJECT_ID]`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "monitoring.googleapis.com/UptimeCheckConfig"
+    }
+  ];
+
+  // Required. The new Uptime check configuration.
+  UptimeCheckConfig uptime_check_config = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The protocol for the `UpdateUptimeCheckConfig` request.
+message UpdateUptimeCheckConfigRequest {
+  // Optional. If present, only the listed fields in the current Uptime check
+  // configuration are updated with values from the new configuration. If this
+  // field is empty, then the current configuration is completely replaced with
+  // the new configuration.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // Required. If an `updateMask` has been specified, this field gives
+  // the values for the set of fields mentioned in the `updateMask`. If an
+  // `updateMask` has not been given, this Uptime check configuration replaces
+  // the current configuration. If a field is mentioned in `updateMask` but
+  // the corresonding field is omitted in this partial Uptime check
+  // configuration, it has the effect of deleting/clearing the field from the
+  // configuration on the server.
+  //
+  // The following fields can be updated: `display_name`,
+  // `http_check`, `tcp_check`, `timeout`, `content_matchers`, and
+  // `selected_regions`.
+  UptimeCheckConfig uptime_check_config = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The protocol for the `DeleteUptimeCheckConfig` request.
+message DeleteUptimeCheckConfigRequest {
+  // Required. The Uptime check configuration to delete. The format
+  //   is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "monitoring.googleapis.com/UptimeCheckConfig"
+    }
+  ];
+}
+
+// The protocol for the `ListUptimeCheckIps` request.
+message ListUptimeCheckIpsRequest {
+  // The maximum number of results to return in a single response. The server
+  // may further constrain the maximum number of results returned in a single
+  // page. If the page_size is <=0, the server will decide the number of results
+  // to be returned.
+  // NOTE: this field is not yet implemented
+  int32 page_size = 2;
+
+  // If this field is not empty then it must contain the `nextPageToken` value
+  // returned by a previous call to this method.  Using this field causes the
+  // method to return more results from the previous method call.
+  // NOTE: this field is not yet implemented
+  string page_token = 3;
+}
+
+// The protocol for the `ListUptimeCheckIps` response.
+message ListUptimeCheckIpsResponse {
+  // The returned list of IP addresses (including region and location) that the
+  // checkers run from.
+  repeated UptimeCheckIp uptime_check_ips = 1;
+
+  // This field represents the pagination token to retrieve the next page of
+  // results. If the value is empty, it means no further results for the
+  // request. To retrieve the next page of results, the value of the
+  // next_page_token is passed to the subsequent List method call (in the
+  // request message's page_token field).
+  // NOTE: this field is not yet implemented
+  string next_page_token = 2;
+}


### PR DESCRIPTION
Problem: fail to copy proto files from proto.list because the duplicate in common google-gax and input proto files.

The original logic is to copy the proto files which are **not** in google-gax.

Fixed logic is to copy the proto file **either** from input proto files from cmd **or** not in google-gax, which also means that skip the proto file in gax common protos **and** not in cmd input proto files

 I didn't add extra unit test for this case, because monitoring library cover this case as well. Let me know if you have concern.
----------------------------|---------|----------|---------|---------|------------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s            
----------------------------|---------|----------|---------|---------|------------------------------              
  start_script.ts    |    93.6      |       80     |     100      |    93.6 .   | 66,67,96-98,123-125          
                   
@alexander-fenster @xiaozhenliu-gg5 @JustinBeckwith Appreciate any comment on the coding style, since I am still new to typescript. Thanks🙏