### PR TITLE
chore: remove renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,
-  "schedule": [
-    "after 9am and before 3pm"
-  ],
   "gitAuthor": null,
   "packageRules": [
     {


### PR DESCRIPTION
We don't mind running renovate 24x7 here. The schedule was important for client libraries so renovate won't spam the CI during the work day, but it's OK for this one repo to remove the schedule.