### PR TITLE
fix: fix docker image with symlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "lint": "gts check",
     "prepare": "npm run compile-protos && npm run compile",
     "pretest": "npm run compile-protos && npm run compile",
-    "test": "c8 --reporter=lcov mocha build/test/unit"
+    "test": "c8 --reporter=lcov mocha build/test/unit",
+    "prepack": "cd templates/typescript_gapic && rm -f package.json.njk && mv package.json package.json.njk",
+    "postpack": "cd templates/typescript_gapic && mv package.json.njk package.json && ln -s package.json package.json.njk"
   },
   "dependencies": {
     "file-system": "^2.2.2",


### PR DESCRIPTION
Fixing docker image that I broke with #240 :)

Just before packing, remove the symlink (not supported by `npm`). Right after packing, put it back.