### PR TITLE
chore: more fixes to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,18 @@
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,
+  "upgradeInRange": true,
   "gitAuthor": null,
   "packageRules": [
     {
       "extends": "packages:linters",
       "groupName": "linters"
     }
+  ],
+  "assignees": [
+    "alexander-fenster",
+    "bcoe",
+    "summer-ji-eng",
+    "xiaozhenliu-gg5"
   ]
 }


### PR DESCRIPTION
1. `"upgradeInRange": true` will ask Renovate to send PRs for updates that are covered by a range. I.e. `google-gax` dependency is currently set to `^1.12.0` and since the latest version `1.14.1` is within that range, we don't get a PR. We want the generated libraries to have the very latest dependencies listed, so we actually want to see PRs for these updates.

2. Set assignees for Renovate PRs.