### PR TITLE
fix: no double quotes in .jsdoc.js

### DIFF
--- a/baselines/dlp/.jsdoc.js.baseline
+++ b/baselines/dlp/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'dlp',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/kms/.jsdoc.js.baseline
+++ b/baselines/kms/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'kms',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/monitoring/.jsdoc.js.baseline
+++ b/baselines/monitoring/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'monitoring',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/redis/.jsdoc.js.baseline
+++ b/baselines/redis/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'redis',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/showcase/.jsdoc.js.baseline
+++ b/baselines/showcase/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'showcase',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/texttospeech/.jsdoc.js.baseline
+++ b/baselines/texttospeech/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: '@google-cloud/text-to-speech',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/baselines/translate/.jsdoc.js.baseline
+++ b/baselines/translate/.jsdoc.js.baseline
@@ -44,7 +44,7 @@ module.exports = {
     systemName: 'translation',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {

--- a/templates/typescript_gapic/.jsdoc.js.njk
+++ b/templates/typescript_gapic/.jsdoc.js.njk
@@ -44,7 +44,7 @@ module.exports = {
     systemName: '{{ api.publishName }}',
     theme: 'lumen',
     default: {
-      "outputSourceFiles": false
+      outputSourceFiles: false
     }
   },
   markdown: {


### PR DESCRIPTION
@summer-ji-eng will send one more mass PR (for a different reason - to add `protos` folder everywhere), so it's also a good time to fix formatting here :)