### PR TITLE
fix: make npm run baseline behave properly with symlinks

### DIFF
--- a/typescript/tools/update-baselines.ts
+++ b/typescript/tools/update-baselines.ts
@@ -30,6 +30,7 @@ import * as ncp from 'ncp';
 const rmrf = promisify(rimraf);
 const readdirp = promisify(readdir);
 const fsstat = util.promisify(fs.stat);
+const fssymlink = util.promisify(fs.symlink);
 const mkdirp = promisify(mkdir);
 const execp = promisify(exec);
 const ncpp = promisify(ncp);
@@ -61,9 +62,11 @@ async function copyBaseline(library: string, root: string, directory = '.') {
     } else if (stat.isFile()) {
       const baseline = getBaselineFilename(library, relativePath);
       // In baselines/, update `package.json` instead of `package.json.baseline`
+      // (package.json.baseline is a symlink to package.json to make renovate bot happy)
       if (relativePath.endsWith(`${path.sep}package.json`)) {
         const packageJson = baseline.substring(0, baseline.lastIndexOf('.'));
         await ncpp(absolutePath, packageJson);
+        await fssymlink(packageJson, baseline);
       } else {
         await ncpp(absolutePath, baseline);
       }


### PR DESCRIPTION
We just want `npm run baseline` to create the `package.json.baseline` symlinks properly.

Background: #240 - to make renovate bot update our baselines, we renamed `package.json.baseline` to `package.json` there in baselines folder, and created a symlink to have the baseline test logic work.