### PR TITLE
feat: export API JSON

### DIFF
--- a/baselines/showcase/api.json.baseline
+++ b/baselines/showcase/api.json.baseline
@@ -1,0 +1,5030 @@
+{
+  "publishName": "showcase",
+  "naming": {
+    "name": "Showcase",
+    "productName": "Showcase",
+    "namespace": [
+      "google"
+    ],
+    "version": "v1beta1",
+    "protoPackage": "google.showcase.v1beta1"
+  },
+  "hostname": "localhost",
+  "port": "7469",
+  "services": [
+    {
+      "method": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Echo",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:echo",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ExpandRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method split the given content into words and will pass each word back",
+            " through the stream. This method showcases server-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Expand",
+          "inputType": ".google.showcase.v1beta1.ExpandRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.methodSignature": [
+              "content,error"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/echo:expand",
+              "body": "*"
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content that will be split into words and returned on the stream."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that is thrown after all words are sent on the stream."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method will collect the words given to it. When the stream is closed",
+            " by the client, this method will return the a concatenation of the strings",
+            " passed to it. This method showcases client-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Collect",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:collect",
+              "body": "*"
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method, upon receiving a request on the stream, the same content will",
+            " be passed  back on the stream. This method showcases bidirectional",
+            " streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Chat",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "pagingFieldName": "responses",
+          "pagingResponseType": ".google.showcase.v1beta1.EchoResponse",
+          "inputInterface": ".google.showcase.v1beta1.PagedExpandRequest",
+          "outputInterface": ".google.showcase.v1beta1.PagedExpandResponse",
+          "comments": [
+            " This is similar to the Expand method but instead of returning a stream of",
+            " expanded words, this method returns a paged list of expanded words.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "PagedExpand",
+          "inputType": ".google.showcase.v1beta1.PagedExpandRequest",
+          "outputType": ".google.showcase.v1beta1.PagedExpandResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:pagedExpand",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The string to expand."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The amount of words to returned in each page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The position of the page to be returned."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "longRunning": {
+            "responseType": "WaitResponse",
+            "metadataType": "WaitMetadata"
+          },
+          "longRunningResponseType": ".google.showcase.v1beta1.WaitResponse",
+          "longRunningMetadataType": ".google.showcase.v1beta1.WaitMetadata",
+          "inputInterface": ".google.showcase.v1beta1.WaitRequest",
+          "outputInterface": ".google.longrunning.Operation",
+          "comments": [
+            " This method will wait the requested amount of and then return.",
+            " This method showcases how a client handles a request timing out.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Wait",
+          "inputType": ".google.showcase.v1beta1.WaitRequest",
+          "outputType": ".google.longrunning.Operation",
+          "options": {
+            ".google.longrunning.operationInfo": {
+              "responseType": "WaitResponse",
+              "metadataType": "WaitMetadata"
+            },
+            ".google.api.http": {
+              "post": "/v1beta1/echo:wait",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "end_time",
+              "paramType": ".google.protobuf.Timestamp",
+              "comments": [
+                " The time that this operation will complete."
+              ]
+            },
+            {
+              "paramName": "ttl",
+              "paramType": ".google.protobuf.Duration",
+              "comments": [
+                " The duration of this operation."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that will be returned by the server. If this code is specified",
+                " to be the OK rpc code, an empty response will be returned."
+              ]
+            },
+            {
+              "paramName": "success",
+              "paramType": ".google.showcase.v1beta1.WaitResponse",
+              "comments": [
+                " The response to be returned on operation completion."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.BlockRequest",
+          "outputInterface": ".google.showcase.v1beta1.BlockResponse",
+          "comments": [
+            " This method will block (wait) for the requested amount of time ",
+            " and then return the response or error.",
+            " This method showcases how a client handles delays or retries.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Block",
+          "inputType": ".google.showcase.v1beta1.BlockRequest",
+          "outputType": ".google.showcase.v1beta1.BlockResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:block",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "response_delay",
+              "paramType": ".google.protobuf.Duration",
+              "comments": [
+                " The amount of time to block before returning a response."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that will be returned by the server. If this code is specified",
+                " to be the OK rpc code, an empty response will be returned."
+              ]
+            },
+            {
+              "paramName": "success",
+              "paramType": ".google.showcase.v1beta1.BlockResponse",
+              "comments": [
+                " The response to be returned that will signify successful method call."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "name": "Echo",
+      "options": {
+        ".google.api.defaultHost": "localhost:7469"
+      },
+      "packageName": "google.showcase.v1beta1",
+      "comments": [
+        " This service is used showcase the four main types of rpcs - unary, server",
+        " side streaming, client side streaming, and bidirectional streaming. This",
+        " service also exposes methods that explicitly implement server delay, and",
+        " paginated calls. Set the 'showcase-trailer' metadata key on any method",
+        " to have the values echoed in the response trailers."
+      ],
+      "commentsMap": {
+        "comments": {
+          "Echo": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This service is used showcase the four main types of rpcs - unary, server",
+              " side streaming, client side streaming, and bidirectional streaming. This",
+              " service also exposes methods that explicitly implement server delay, and",
+              " paginated calls. Set the 'showcase-trailer' metadata key on any method",
+              " to have the values echoed in the response trailers."
+            ]
+          },
+          "Echo:Expand": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method split the given content into words and will pass each word back",
+              " through the stream. This method showcases server-side streaming rpcs.",
+              ""
+            ]
+          },
+          "Echo:Collect": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method will collect the words given to it. When the stream is closed",
+              " by the client, this method will return the a concatenation of the strings",
+              " passed to it. This method showcases client-side streaming rpcs.",
+              ""
+            ]
+          },
+          "Echo:Chat": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method, upon receiving a request on the stream, the same content will",
+              " be passed  back on the stream. This method showcases bidirectional",
+              " streaming rpcs.",
+              ""
+            ]
+          },
+          "Echo:PagedExpand": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This is similar to the Expand method but instead of returning a stream of",
+              " expanded words, this method returns a paged list of expanded words.",
+              ""
+            ]
+          },
+          "Echo:Wait": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method will wait the requested amount of and then return.",
+              " This method showcases how a client handles a request timing out.",
+              ""
+            ]
+          },
+          "Echo:Block": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method will block (wait) for the requested amount of time ",
+              " and then return the response or error.",
+              " This method showcases how a client handles delays or retries.",
+              ""
+            ]
+          },
+          "EchoRequest:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The content to be echoed by the server."
+            ]
+          },
+          "EchoRequest:error": {
+            "paramName": "error",
+            "paramType": ".google.rpc.Status",
+            "comments": [
+              " The error to be thrown by the server."
+            ]
+          },
+          "EchoResponse:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The content specified in the request."
+            ]
+          },
+          "ExpandRequest:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The content that will be split into words and returned on the stream."
+            ]
+          },
+          "ExpandRequest:error": {
+            "paramName": "error",
+            "paramType": ".google.rpc.Status",
+            "comments": [
+              " The error that is thrown after all words are sent on the stream."
+            ]
+          },
+          "PagedExpandRequest:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The string to expand."
+            ],
+            "fieldBehavior": 2
+          },
+          "PagedExpandRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The amount of words to returned in each page."
+            ]
+          },
+          "PagedExpandRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The position of the page to be returned."
+            ]
+          },
+          "PagedExpandResponse:responses": {
+            "paramName": "responses",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The words that were expanded."
+            ]
+          },
+          "PagedExpandResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The next page token."
+            ]
+          },
+          "WaitRequest:end_time": {
+            "paramName": "end_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The time that this operation will complete."
+            ]
+          },
+          "WaitRequest:ttl": {
+            "paramName": "ttl",
+            "paramType": ".google.protobuf.Duration",
+            "comments": [
+              " The duration of this operation."
+            ]
+          },
+          "WaitRequest:error": {
+            "paramName": "error",
+            "paramType": ".google.rpc.Status",
+            "comments": [
+              " The error that will be returned by the server. If this code is specified",
+              " to be the OK rpc code, an empty response will be returned."
+            ]
+          },
+          "WaitRequest:success": {
+            "paramName": "success",
+            "paramType": ".google.showcase.v1beta1.WaitResponse",
+            "comments": [
+              " The response to be returned on operation completion."
+            ]
+          },
+          "WaitResponse:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " This content of the result."
+            ]
+          },
+          "WaitMetadata:end_time": {
+            "paramName": "end_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The time that this operation will complete."
+            ]
+          },
+          "BlockRequest:response_delay": {
+            "paramName": "response_delay",
+            "paramType": ".google.protobuf.Duration",
+            "comments": [
+              " The amount of time to block before returning a response."
+            ]
+          },
+          "BlockRequest:error": {
+            "paramName": "error",
+            "paramType": ".google.rpc.Status",
+            "comments": [
+              " The error that will be returned by the server. If this code is specified",
+              " to be the OK rpc code, an empty response will be returned."
+            ]
+          },
+          "BlockRequest:success": {
+            "paramName": "success",
+            "paramType": ".google.showcase.v1beta1.BlockResponse",
+            "comments": [
+              " The response to be returned that will signify successful method call."
+            ]
+          },
+          "BlockResponse:content": {
+            "paramName": "content",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " This content can contain anything, the server will not depend on a value",
+              " here."
+            ]
+          }
+        }
+      },
+      "retryableCodeMap": {
+        "uniqueCodesNamesMap": {
+          "": "non_idempotent",
+          "deadline_exceeded_unavailable": "idempotent"
+        },
+        "prettyCodesNamesMap": {
+          "non_idempotent": [],
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ]
+        },
+        "uniqueParamsNamesMap": {
+          "94312e9926796a52a8fcbbedaac41972e07ccd1c": "default"
+        },
+        "prettyParamNamesMap": {
+          "default": {
+            "initial_retry_delay_millis": 100,
+            "retry_delay_multiplier": 1.3,
+            "max_retry_delay_millis": 60000,
+            "initial_rpc_timeout_millis": 60000,
+            "rpc_timeout_multiplier": 1,
+            "max_rpc_timeout_millis": 60000,
+            "total_timeout_millis": 600000
+          }
+        },
+        "codeEnumMapping": {
+          "0": "OK",
+          "1": "CANCELLED",
+          "2": "UNKNOWN",
+          "3": "INVALID_ARGUMENT",
+          "4": "DEADLINE_EXCEEDED",
+          "5": "NOT_FOUND",
+          "6": "ALREADY_EXISTS",
+          "7": "PERMISSION_DENIED",
+          "8": "RESOURCE_EXHAUSTED",
+          "9": "FAILED_PRECONDITION",
+          "10": "ABORTED",
+          "11": "OUT_OF_RANGE",
+          "12": "UNIMPLEMENTED",
+          "13": "INTERNAL",
+          "14": "UNAVAILABLE",
+          "15": "DATA_LOSS",
+          "16": "UNAUTHENTICATED"
+        }
+      },
+      "grpcServiceConfig": {},
+      "simpleMethods": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Echo",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:echo",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.BlockRequest",
+          "outputInterface": ".google.showcase.v1beta1.BlockResponse",
+          "comments": [
+            " This method will block (wait) for the requested amount of time ",
+            " and then return the response or error.",
+            " This method showcases how a client handles delays or retries.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Block",
+          "inputType": ".google.showcase.v1beta1.BlockRequest",
+          "outputType": ".google.showcase.v1beta1.BlockResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:block",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "response_delay",
+              "paramType": ".google.protobuf.Duration",
+              "comments": [
+                " The amount of time to block before returning a response."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that will be returned by the server. If this code is specified",
+                " to be the OK rpc code, an empty response will be returned."
+              ]
+            },
+            {
+              "paramName": "success",
+              "paramType": ".google.showcase.v1beta1.BlockResponse",
+              "comments": [
+                " The response to be returned that will signify successful method call."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "longRunning": [
+        {
+          "longRunning": {
+            "responseType": "WaitResponse",
+            "metadataType": "WaitMetadata"
+          },
+          "longRunningResponseType": ".google.showcase.v1beta1.WaitResponse",
+          "longRunningMetadataType": ".google.showcase.v1beta1.WaitMetadata",
+          "inputInterface": ".google.showcase.v1beta1.WaitRequest",
+          "outputInterface": ".google.longrunning.Operation",
+          "comments": [
+            " This method will wait the requested amount of and then return.",
+            " This method showcases how a client handles a request timing out.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Wait",
+          "inputType": ".google.showcase.v1beta1.WaitRequest",
+          "outputType": ".google.longrunning.Operation",
+          "options": {
+            ".google.longrunning.operationInfo": {
+              "responseType": "WaitResponse",
+              "metadataType": "WaitMetadata"
+            },
+            ".google.api.http": {
+              "post": "/v1beta1/echo:wait",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "end_time",
+              "paramType": ".google.protobuf.Timestamp",
+              "comments": [
+                " The time that this operation will complete."
+              ]
+            },
+            {
+              "paramName": "ttl",
+              "paramType": ".google.protobuf.Duration",
+              "comments": [
+                " The duration of this operation."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that will be returned by the server. If this code is specified",
+                " to be the OK rpc code, an empty response will be returned."
+              ]
+            },
+            {
+              "paramName": "success",
+              "paramType": ".google.showcase.v1beta1.WaitResponse",
+              "comments": [
+                " The response to be returned on operation completion."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "streaming": [
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ExpandRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method split the given content into words and will pass each word back",
+            " through the stream. This method showcases server-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Expand",
+          "inputType": ".google.showcase.v1beta1.ExpandRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.methodSignature": [
+              "content,error"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/echo:expand",
+              "body": "*"
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content that will be split into words and returned on the stream."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that is thrown after all words are sent on the stream."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method will collect the words given to it. When the stream is closed",
+            " by the client, this method will return the a concatenation of the strings",
+            " passed to it. This method showcases client-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Collect",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:collect",
+              "body": "*"
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method, upon receiving a request on the stream, the same content will",
+            " be passed  back on the stream. This method showcases bidirectional",
+            " streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Chat",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "clientStreaming": [
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method will collect the words given to it. When the stream is closed",
+            " by the client, this method will return the a concatenation of the strings",
+            " passed to it. This method showcases client-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Collect",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:collect",
+              "body": "*"
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "serverStreaming": [
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ExpandRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method split the given content into words and will pass each word back",
+            " through the stream. This method showcases server-side streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Expand",
+          "inputType": ".google.showcase.v1beta1.ExpandRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "options": {
+            ".google.api.methodSignature": [
+              "content,error"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/echo:expand",
+              "body": "*"
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content that will be split into words and returned on the stream."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error that is thrown after all words are sent on the stream."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "bidiStreaming": [
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.EchoRequest",
+          "outputInterface": ".google.showcase.v1beta1.EchoResponse",
+          "comments": [
+            " This method, upon receiving a request on the stream, the same content will",
+            " be passed  back on the stream. This method showcases bidirectional",
+            " streaming rpcs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Chat",
+          "inputType": ".google.showcase.v1beta1.EchoRequest",
+          "outputType": ".google.showcase.v1beta1.EchoResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The content to be echoed by the server."
+              ]
+            },
+            {
+              "paramName": "error",
+              "paramType": ".google.rpc.Status",
+              "comments": [
+                " The error to be thrown by the server."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "paging": [
+        {
+          "pagingFieldName": "responses",
+          "pagingResponseType": ".google.showcase.v1beta1.EchoResponse",
+          "inputInterface": ".google.showcase.v1beta1.PagedExpandRequest",
+          "outputInterface": ".google.showcase.v1beta1.PagedExpandResponse",
+          "comments": [
+            " This is similar to the Expand method but instead of returning a stream of",
+            " expanded words, this method returns a paged list of expanded words.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "PagedExpand",
+          "inputType": ".google.showcase.v1beta1.PagedExpandRequest",
+          "outputType": ".google.showcase.v1beta1.PagedExpandResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/echo:pagedExpand",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "content",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The string to expand."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The amount of words to returned in each page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The position of the page to be returned."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "hostname": "localhost",
+      "port": 7469,
+      "oauthScopes": [],
+      "pathTemplates": [
+        {
+          "name": "Blueprint",
+          "params": [
+            "session",
+            "test",
+            "blueprint"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}/blueprints/{blueprint}"
+          ],
+          "type": "showcase.googleapis.com/Blueprint"
+        },
+        {
+          "name": "Room",
+          "params": [
+            "room_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}"
+          ],
+          "type": "showcase.googleapis.com/Room"
+        },
+        {
+          "name": "room_id_blurb_id",
+          "params": [
+            "room_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        },
+        {
+          "name": "Session",
+          "params": [
+            "session"
+          ],
+          "pattern": [
+            "sessions/{session}"
+          ],
+          "type": "showcase.googleapis.com/Session"
+        },
+        {
+          "name": "Test",
+          "params": [
+            "session",
+            "test"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}"
+          ],
+          "type": "showcase.googleapis.com/Test"
+        },
+        {
+          "name": "User",
+          "params": [
+            "user_id"
+          ],
+          "pattern": [
+            "users/{user_id}"
+          ],
+          "type": "showcase.googleapis.com/User"
+        },
+        {
+          "name": "user_id_blurb_id",
+          "params": [
+            "user_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "user/{user_id}/profile/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        }
+      ]
+    },
+    {
+      "method": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Creates a user.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateUser",
+          "inputType": ".google.showcase.v1beta1.CreateUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.methodSignature": [
+              "user.display_name,user.email"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/users",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "user",
+              "paramType": ".google.showcase.v1beta1.User",
+              "comments": [
+                " The user to create."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Retrieves the User with the given uri.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetUser",
+          "inputType": ".google.showcase.v1beta1.GetUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=users/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested user."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Updates a user.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateUser",
+          "inputType": ".google.showcase.v1beta1.UpdateUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{user.name=users/*}",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "user",
+              "paramType": ".google.showcase.v1beta1.User",
+              "comments": [
+                " The user to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "user",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteUserRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a user, their profile, and all of their authored messages.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteUser",
+          "inputType": ".google.showcase.v1beta1.DeleteUserRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=users/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the user to delete."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "pagingFieldName": "users",
+          "pagingResponseType": ".google.showcase.v1beta1.User",
+          "inputInterface": ".google.showcase.v1beta1.ListUsersRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListUsersResponse",
+          "comments": [
+            " Lists all users.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListUsers",
+          "inputType": ".google.showcase.v1beta1.ListUsersRequest",
+          "outputType": ".google.showcase.v1beta1.ListUsersResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/users"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of users to return. Server may return fewer users",
+                " than requested. If unspecified, server will pick an appropriate default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListUsersResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Identity\\ListUsers` method."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "name": "Identity",
+      "options": {
+        ".google.api.defaultHost": "localhost:7469"
+      },
+      "packageName": "google.showcase.v1beta1",
+      "comments": [
+        " A simple identity service."
+      ],
+      "commentsMap": {
+        "comments": {
+          "Identity": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " A simple identity service."
+            ]
+          },
+          "Identity:CreateUser": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Creates a user.",
+              ""
+            ]
+          },
+          "Identity:GetUser": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Retrieves the User with the given uri.",
+              ""
+            ]
+          },
+          "Identity:UpdateUser": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Updates a user.",
+              ""
+            ]
+          },
+          "Identity:DeleteUser": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Deletes a user, their profile, and all of their authored messages.",
+              ""
+            ]
+          },
+          "Identity:ListUsers": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Lists all users.",
+              ""
+            ]
+          },
+          "User:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the user."
+            ]
+          },
+          "User:display_name": {
+            "paramName": "display_name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The display_name of the user."
+            ],
+            "fieldBehavior": 2
+          },
+          "User:email": {
+            "paramName": "email",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The email address of the user."
+            ],
+            "fieldBehavior": 2
+          },
+          "User:create_time": {
+            "paramName": "create_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The timestamp at which the user was created."
+            ],
+            "fieldBehavior": 3
+          },
+          "User:update_time": {
+            "paramName": "update_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The latest timestamp at which the user was updated."
+            ],
+            "fieldBehavior": 3
+          },
+          "CreateUserRequest:user": {
+            "paramName": "user",
+            "paramType": ".google.showcase.v1beta1.User",
+            "comments": [
+              " The user to create."
+            ]
+          },
+          "GetUserRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested user."
+            ],
+            "fieldBehavior": 2
+          },
+          "UpdateUserRequest:user": {
+            "paramName": "user",
+            "paramType": ".google.showcase.v1beta1.User",
+            "comments": [
+              " The user to update."
+            ]
+          },
+          "UpdateUserRequest:update_mask": {
+            "paramName": "update_mask",
+            "paramType": ".google.protobuf.FieldMask",
+            "comments": [
+              " The field mask to determine wich fields are to be updated. If empty, the",
+              " server will assume all fields are to be updated."
+            ]
+          },
+          "DeleteUserRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the user to delete."
+            ],
+            "fieldBehavior": 2
+          },
+          "ListUsersRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of users to return. Server may return fewer users",
+              " than requested. If unspecified, server will pick an appropriate default."
+            ]
+          },
+          "ListUsersRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The value of google.showcase.v1beta1.ListUsersResponse.next_page_token",
+              " returned from the previous call to",
+              " `google.showcase.v1beta1.Identity\\ListUsers` method."
+            ]
+          },
+          "ListUsersResponse:users": {
+            "paramName": "users",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The list of users."
+            ]
+          },
+          "ListUsersResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A token to retrieve next page of results.",
+              " Pass this value in ListUsersRequest.page_token field in the subsequent",
+              " call to `google.showcase.v1beta1.Message\\ListUsers` method to retrieve the",
+              " next page of results."
+            ]
+          }
+        }
+      },
+      "retryableCodeMap": {
+        "uniqueCodesNamesMap": {
+          "": "non_idempotent",
+          "deadline_exceeded_unavailable": "idempotent"
+        },
+        "prettyCodesNamesMap": {
+          "non_idempotent": [],
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ]
+        },
+        "uniqueParamsNamesMap": {
+          "94312e9926796a52a8fcbbedaac41972e07ccd1c": "default"
+        },
+        "prettyParamNamesMap": {
+          "default": {
+            "initial_retry_delay_millis": 100,
+            "retry_delay_multiplier": 1.3,
+            "max_retry_delay_millis": 60000,
+            "initial_rpc_timeout_millis": 60000,
+            "rpc_timeout_multiplier": 1,
+            "max_rpc_timeout_millis": 60000,
+            "total_timeout_millis": 600000
+          }
+        },
+        "codeEnumMapping": {
+          "0": "OK",
+          "1": "CANCELLED",
+          "2": "UNKNOWN",
+          "3": "INVALID_ARGUMENT",
+          "4": "DEADLINE_EXCEEDED",
+          "5": "NOT_FOUND",
+          "6": "ALREADY_EXISTS",
+          "7": "PERMISSION_DENIED",
+          "8": "RESOURCE_EXHAUSTED",
+          "9": "FAILED_PRECONDITION",
+          "10": "ABORTED",
+          "11": "OUT_OF_RANGE",
+          "12": "UNIMPLEMENTED",
+          "13": "INTERNAL",
+          "14": "UNAVAILABLE",
+          "15": "DATA_LOSS",
+          "16": "UNAUTHENTICATED"
+        }
+      },
+      "grpcServiceConfig": {},
+      "simpleMethods": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Creates a user.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateUser",
+          "inputType": ".google.showcase.v1beta1.CreateUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.methodSignature": [
+              "user.display_name,user.email"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/users",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "user",
+              "paramType": ".google.showcase.v1beta1.User",
+              "comments": [
+                " The user to create."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Retrieves the User with the given uri.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetUser",
+          "inputType": ".google.showcase.v1beta1.GetUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=users/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested user."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateUserRequest",
+          "outputInterface": ".google.showcase.v1beta1.User",
+          "comments": [
+            " Updates a user.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateUser",
+          "inputType": ".google.showcase.v1beta1.UpdateUserRequest",
+          "outputType": ".google.showcase.v1beta1.User",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{user.name=users/*}",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "user",
+              "paramType": ".google.showcase.v1beta1.User",
+              "comments": [
+                " The user to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "user",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteUserRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a user, their profile, and all of their authored messages.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteUser",
+          "inputType": ".google.showcase.v1beta1.DeleteUserRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=users/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the user to delete."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        }
+      ],
+      "longRunning": [],
+      "streaming": [],
+      "clientStreaming": [],
+      "serverStreaming": [],
+      "bidiStreaming": [],
+      "paging": [
+        {
+          "pagingFieldName": "users",
+          "pagingResponseType": ".google.showcase.v1beta1.User",
+          "inputInterface": ".google.showcase.v1beta1.ListUsersRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListUsersResponse",
+          "comments": [
+            " Lists all users.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListUsers",
+          "inputType": ".google.showcase.v1beta1.ListUsersRequest",
+          "outputType": ".google.showcase.v1beta1.ListUsersResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/users"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of users to return. Server may return fewer users",
+                " than requested. If unspecified, server will pick an appropriate default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListUsersResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Identity\\ListUsers` method."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "hostname": "localhost",
+      "port": 7469,
+      "oauthScopes": [],
+      "pathTemplates": [
+        {
+          "name": "Blueprint",
+          "params": [
+            "session",
+            "test",
+            "blueprint"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}/blueprints/{blueprint}"
+          ],
+          "type": "showcase.googleapis.com/Blueprint"
+        },
+        {
+          "name": "Room",
+          "params": [
+            "room_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}"
+          ],
+          "type": "showcase.googleapis.com/Room"
+        },
+        {
+          "name": "room_id_blurb_id",
+          "params": [
+            "room_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        },
+        {
+          "name": "Session",
+          "params": [
+            "session"
+          ],
+          "pattern": [
+            "sessions/{session}"
+          ],
+          "type": "showcase.googleapis.com/Session"
+        },
+        {
+          "name": "Test",
+          "params": [
+            "session",
+            "test"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}"
+          ],
+          "type": "showcase.googleapis.com/Test"
+        },
+        {
+          "name": "User",
+          "params": [
+            "user_id"
+          ],
+          "pattern": [
+            "users/{user_id}"
+          ],
+          "type": "showcase.googleapis.com/User"
+        },
+        {
+          "name": "user_id_blurb_id",
+          "params": [
+            "user_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "user/{user_id}/profile/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        }
+      ]
+    },
+    {
+      "method": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Creates a room.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateRoom",
+          "inputType": ".google.showcase.v1beta1.CreateRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.methodSignature": [
+              "room.display_name,room.description"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/rooms",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "room",
+              "paramType": ".google.showcase.v1beta1.Room",
+              "comments": [
+                " The room to create."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Retrieves the Room with the given resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetRoom",
+          "inputType": ".google.showcase.v1beta1.GetRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=rooms/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Updates a room.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateRoom",
+          "inputType": ".google.showcase.v1beta1.UpdateRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{room.name=rooms/*}",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "room",
+              "paramType": ".google.showcase.v1beta1.Room",
+              "comments": [
+                " The room to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "room",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteRoomRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a room and all of its blurbs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteRoom",
+          "inputType": ".google.showcase.v1beta1.DeleteRoomRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=rooms/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "pagingFieldName": "rooms",
+          "pagingResponseType": ".google.showcase.v1beta1.Room",
+          "inputInterface": ".google.showcase.v1beta1.ListRoomsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListRoomsResponse",
+          "comments": [
+            " Lists all chat rooms.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListRooms",
+          "inputType": ".google.showcase.v1beta1.ListRoomsRequest",
+          "outputType": ".google.showcase.v1beta1.ListRoomsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/rooms"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of rooms return. Server may return fewer rooms",
+                " than requested. If unspecified, server will pick an appropriate default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListRoomsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\ListRooms` method."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Creates a blurb. If the parent is a room, the blurb is understood to be a",
+            " message in that room. If the parent is a profile, the blurb is understood",
+            " to be a post on the profile.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateBlurb",
+          "inputType": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.methodSignature": [
+              "parent,blurb.user,blurb.text",
+              "parent,blurb.user,blurb.image"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/*}/blurbs",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/*/profile}/blurbs",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the chat room or user profile that this blurb will",
+                " be tied to."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to create."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Retrieves the Blurb with the given resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetBlurb",
+          "inputType": ".google.showcase.v1beta1.GetBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=rooms/*/blurbs/*}",
+              "additionalBindings": [
+                {
+                  "get": "/v1beta1/{name=users/*/profile/blurbs/*}"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested blurb."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Updates a blurb.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateBlurb",
+          "inputType": ".google.showcase.v1beta1.UpdateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{blurb.name=rooms/*/blurbs/*}",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "patch": "/v1beta1/{blurb.name=users/*/profile/blurbs/*}",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "blurb",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteBlurbRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a blurb.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteBlurb",
+          "inputType": ".google.showcase.v1beta1.DeleteBlurbRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=rooms/*/blurbs/*}",
+              "additionalBindings": [
+                {
+                  "delete": "/v1beta1/{name=users/*/profile/blurbs/*}"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested blurb."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "pagingFieldName": "blurbs",
+          "pagingResponseType": ".google.showcase.v1beta1.Blurb",
+          "inputInterface": ".google.showcase.v1beta1.ListBlurbsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListBlurbsResponse",
+          "comments": [
+            " Lists blurbs for a specific chat room or user profile depending on the",
+            " parent resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListBlurbs",
+          "inputType": ".google.showcase.v1beta1.ListBlurbsRequest",
+          "outputType": ".google.showcase.v1beta1.ListBlurbsResponse",
+          "options": {
+            ".google.api.methodSignature": [
+              "parent"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{parent=rooms/*}/blurbs",
+              "additionalBindings": [
+                {
+                  "get": "/v1beta1/{parent=users/*/profile}/blurbs"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room or profile whos blurbs to list."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of blurbs to return. Server may return fewer",
+                " blurbs than requested. If unspecified, server will pick an appropriate",
+                " default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListBlurbsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\ListBlurbs` method."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "longRunning": {
+            "responseType": "SearchBlurbsResponse",
+            "metadataType": "SearchBlurbsMetadata"
+          },
+          "longRunningResponseType": ".google.showcase.v1beta1.SearchBlurbsResponse",
+          "longRunningMetadataType": ".google.showcase.v1beta1.SearchBlurbsMetadata",
+          "inputInterface": ".google.showcase.v1beta1.SearchBlurbsRequest",
+          "outputInterface": ".google.longrunning.Operation",
+          "comments": [
+            " This method searches through all blurbs across all rooms and profiles",
+            " for blurbs containing to words found in the query. Only posts that",
+            " contain an exact match of a queried word will be returned.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "SearchBlurbs",
+          "inputType": ".google.showcase.v1beta1.SearchBlurbsRequest",
+          "outputType": ".google.longrunning.Operation",
+          "options": {
+            ".google.longrunning.operationInfo": {
+              "responseType": "SearchBlurbsResponse",
+              "metadataType": "SearchBlurbsMetadata"
+            },
+            ".google.api.methodSignature": [
+              "query"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/-}/blurbs:search",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/-/profile}/blurbs:search"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "query",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The query used to search for blurbs containing to words of this string.",
+                " Only posts that contain an exact match of a queried word will be returned."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The rooms or profiles to search. If unset, `SearchBlurbs` will search all",
+                " rooms and all profiles."
+              ]
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of blurbs return. Server may return fewer",
+                " blurbs than requested. If unspecified, server will pick an appropriate",
+                " default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of",
+                " google.showcase.v1beta1.SearchBlurbsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\SearchBlurbs` method."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This returns a stream that emits the blurbs that are created for a",
+            " particular chat room or user profile.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "StreamBlurbs",
+          "inputType": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=rooms/*}/blurbs:stream",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{name=users/*/profile}/blurbs:stream",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of a chat room or user profile whose blurbs to stream."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "expire_time",
+              "paramType": ".google.protobuf.Timestamp",
+              "comments": [
+                " The time at which this stream will close."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "comments": [
+            " This is a stream to create multiple blurbs. If an invalid blurb is",
+            " requested to be created, the stream will close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "SendBlurbs",
+          "inputType": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/*}/blurbs:send",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/*/profile}/blurbs:send",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the chat room or user profile that this blurb will",
+                " be tied to."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to create."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ConnectRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This method starts a bidirectional stream that receives all blurbs that",
+            " are being created after the stream has started and sends requests to create",
+            " blurbs. If an invalid blurb is requested to be created, the stream will",
+            " close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Connect",
+          "inputType": ".google.showcase.v1beta1.ConnectRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "config",
+              "paramType": ".google.showcase.v1beta1.ConnectRequest.ConnectConfig",
+              "comments": [
+                " Provides information that specifies how to process subsequent requests.",
+                " The first `ConnectRequest` message must contain a `config`  message."
+              ]
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to be created."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "name": "Messaging",
+      "options": {
+        ".google.api.defaultHost": "localhost:7469"
+      },
+      "packageName": "google.showcase.v1beta1",
+      "comments": [
+        " A simple messaging service that implements chat rooms and profile posts.",
+        "",
+        " This messaging service showcases the features that API clients",
+        " generated by gapic-generators implement."
+      ],
+      "commentsMap": {
+        "comments": {
+          "Messaging": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " A simple messaging service that implements chat rooms and profile posts.",
+              "",
+              " This messaging service showcases the features that API clients",
+              " generated by gapic-generators implement."
+            ]
+          },
+          "Messaging:CreateRoom": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Creates a room.",
+              ""
+            ]
+          },
+          "Messaging:GetRoom": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Retrieves the Room with the given resource name.",
+              ""
+            ]
+          },
+          "Messaging:UpdateRoom": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Updates a room.",
+              ""
+            ]
+          },
+          "Messaging:DeleteRoom": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Deletes a room and all of its blurbs.",
+              ""
+            ]
+          },
+          "Messaging:ListRooms": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Lists all chat rooms.",
+              ""
+            ]
+          },
+          "Messaging:CreateBlurb": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Creates a blurb. If the parent is a room, the blurb is understood to be a",
+              " message in that room. If the parent is a profile, the blurb is understood",
+              " to be a post on the profile.",
+              ""
+            ]
+          },
+          "Messaging:GetBlurb": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Retrieves the Blurb with the given resource name.",
+              ""
+            ]
+          },
+          "Messaging:UpdateBlurb": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Updates a blurb.",
+              ""
+            ]
+          },
+          "Messaging:DeleteBlurb": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Deletes a blurb.",
+              ""
+            ]
+          },
+          "Messaging:ListBlurbs": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Lists blurbs for a specific chat room or user profile depending on the",
+              " parent resource name.",
+              ""
+            ]
+          },
+          "Messaging:SearchBlurbs": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method searches through all blurbs across all rooms and profiles",
+              " for blurbs containing to words found in the query. Only posts that",
+              " contain an exact match of a queried word will be returned.",
+              ""
+            ]
+          },
+          "Messaging:StreamBlurbs": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This returns a stream that emits the blurbs that are created for a",
+              " particular chat room or user profile.",
+              ""
+            ]
+          },
+          "Messaging:SendBlurbs": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This is a stream to create multiple blurbs. If an invalid blurb is",
+              " requested to be created, the stream will close with an error.",
+              ""
+            ]
+          },
+          "Messaging:Connect": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " This method starts a bidirectional stream that receives all blurbs that",
+              " are being created after the stream has started and sends requests to create",
+              " blurbs. If an invalid blurb is requested to be created, the stream will",
+              " close with an error.",
+              ""
+            ]
+          },
+          "Room:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the chat room."
+            ]
+          },
+          "Room:display_name": {
+            "paramName": "display_name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The human readable name of the chat room."
+            ],
+            "fieldBehavior": 2
+          },
+          "Room:description": {
+            "paramName": "description",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The description of the chat room."
+            ]
+          },
+          "Room:create_time": {
+            "paramName": "create_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The timestamp at which the room was created."
+            ],
+            "fieldBehavior": 3
+          },
+          "Room:update_time": {
+            "paramName": "update_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The latest timestamp at which the room was updated."
+            ],
+            "fieldBehavior": 3
+          },
+          "CreateRoomRequest:room": {
+            "paramName": "room",
+            "paramType": ".google.showcase.v1beta1.Room",
+            "comments": [
+              " The room to create."
+            ]
+          },
+          "GetRoomRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested room."
+            ],
+            "fieldBehavior": 2
+          },
+          "UpdateRoomRequest:room": {
+            "paramName": "room",
+            "paramType": ".google.showcase.v1beta1.Room",
+            "comments": [
+              " The room to update."
+            ]
+          },
+          "UpdateRoomRequest:update_mask": {
+            "paramName": "update_mask",
+            "paramType": ".google.protobuf.FieldMask",
+            "comments": [
+              " The field mask to determine wich fields are to be updated. If empty, the",
+              " server will assume all fields are to be updated."
+            ]
+          },
+          "DeleteRoomRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested room."
+            ],
+            "fieldBehavior": 2
+          },
+          "ListRoomsRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of rooms return. Server may return fewer rooms",
+              " than requested. If unspecified, server will pick an appropriate default."
+            ]
+          },
+          "ListRoomsRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The value of google.showcase.v1beta1.ListRoomsResponse.next_page_token",
+              " returned from the previous call to",
+              " `google.showcase.v1beta1.Messaging\\ListRooms` method."
+            ]
+          },
+          "ListRoomsResponse:rooms": {
+            "paramName": "rooms",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The list of rooms."
+            ]
+          },
+          "ListRoomsResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A token to retrieve next page of results.",
+              " Pass this value in ListRoomsRequest.page_token field in the subsequent",
+              " call to `google.showcase.v1beta1.Messaging\\ListRooms` method to retrieve the",
+              " next page of results."
+            ]
+          },
+          "Blurb:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the chat room."
+            ]
+          },
+          "Blurb:user": {
+            "paramName": "user",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the blurb's author."
+            ],
+            "fieldBehavior": 2
+          },
+          "Blurb:text": {
+            "paramName": "text",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The textual content of this blurb."
+            ]
+          },
+          "Blurb:image": {
+            "paramName": "image",
+            "paramType": "TYPE_BYTES",
+            "comments": [
+              " The image content of this blurb."
+            ]
+          },
+          "Blurb:create_time": {
+            "paramName": "create_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The timestamp at which the blurb was created."
+            ],
+            "fieldBehavior": 3
+          },
+          "Blurb:update_time": {
+            "paramName": "update_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The latest timestamp at which the blurb was updated."
+            ],
+            "fieldBehavior": 3
+          },
+          "CreateBlurbRequest:parent": {
+            "paramName": "parent",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the chat room or user profile that this blurb will",
+              " be tied to."
+            ],
+            "fieldBehavior": 2
+          },
+          "CreateBlurbRequest:blurb": {
+            "paramName": "blurb",
+            "paramType": ".google.showcase.v1beta1.Blurb",
+            "comments": [
+              " The blurb to create."
+            ]
+          },
+          "GetBlurbRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested blurb."
+            ],
+            "fieldBehavior": 2
+          },
+          "UpdateBlurbRequest:blurb": {
+            "paramName": "blurb",
+            "paramType": ".google.showcase.v1beta1.Blurb",
+            "comments": [
+              " The blurb to update."
+            ]
+          },
+          "UpdateBlurbRequest:update_mask": {
+            "paramName": "update_mask",
+            "paramType": ".google.protobuf.FieldMask",
+            "comments": [
+              " The field mask to determine wich fields are to be updated. If empty, the",
+              " server will assume all fields are to be updated."
+            ]
+          },
+          "DeleteBlurbRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested blurb."
+            ],
+            "fieldBehavior": 2
+          },
+          "ListBlurbsRequest:parent": {
+            "paramName": "parent",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of the requested room or profile whos blurbs to list."
+            ],
+            "fieldBehavior": 2
+          },
+          "ListBlurbsRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of blurbs to return. Server may return fewer",
+              " blurbs than requested. If unspecified, server will pick an appropriate",
+              " default."
+            ]
+          },
+          "ListBlurbsRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The value of google.showcase.v1beta1.ListBlurbsResponse.next_page_token",
+              " returned from the previous call to",
+              " `google.showcase.v1beta1.Messaging\\ListBlurbs` method."
+            ]
+          },
+          "ListBlurbsResponse:blurbs": {
+            "paramName": "blurbs",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The list of blurbs."
+            ]
+          },
+          "ListBlurbsResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A token to retrieve next page of results.",
+              " Pass this value in ListBlurbsRequest.page_token field in the subsequent",
+              " call to `google.showcase.v1beta1.Blurb\\ListBlurbs` method to retrieve",
+              " the next page of results."
+            ]
+          },
+          "SearchBlurbsRequest:query": {
+            "paramName": "query",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The query used to search for blurbs containing to words of this string.",
+              " Only posts that contain an exact match of a queried word will be returned."
+            ],
+            "fieldBehavior": 2
+          },
+          "SearchBlurbsRequest:parent": {
+            "paramName": "parent",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The rooms or profiles to search. If unset, `SearchBlurbs` will search all",
+              " rooms and all profiles."
+            ]
+          },
+          "SearchBlurbsRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of blurbs return. Server may return fewer",
+              " blurbs than requested. If unspecified, server will pick an appropriate",
+              " default."
+            ]
+          },
+          "SearchBlurbsRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The value of",
+              " google.showcase.v1beta1.SearchBlurbsResponse.next_page_token",
+              " returned from the previous call to",
+              " `google.showcase.v1beta1.Messaging\\SearchBlurbs` method."
+            ]
+          },
+          "SearchBlurbsMetadata:retry_info": {
+            "paramName": "retry_info",
+            "paramType": ".google.rpc.RetryInfo",
+            "comments": [
+              " This signals to the client when to next poll for response."
+            ]
+          },
+          "SearchBlurbsResponse:blurbs": {
+            "paramName": "blurbs",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " Blurbs that matched the search query."
+            ]
+          },
+          "SearchBlurbsResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A token to retrieve next page of results.",
+              " Pass this value in SearchBlurbsRequest.page_token field in the subsequent",
+              " call to `google.showcase.v1beta1.Blurb\\SearchBlurbs` method to",
+              " retrieve the next page of results."
+            ]
+          },
+          "StreamBlurbsRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The resource name of a chat room or user profile whose blurbs to stream."
+            ],
+            "fieldBehavior": 2
+          },
+          "StreamBlurbsRequest:expire_time": {
+            "paramName": "expire_time",
+            "paramType": ".google.protobuf.Timestamp",
+            "comments": [
+              " The time at which this stream will close."
+            ],
+            "fieldBehavior": 2
+          },
+          "StreamBlurbsResponse:blurb": {
+            "paramName": "blurb",
+            "paramType": ".google.showcase.v1beta1.Blurb",
+            "comments": [
+              " The blurb that was either created, updated, or deleted."
+            ]
+          },
+          "StreamBlurbsResponse:action": {
+            "paramName": "action",
+            "paramType": ".google.showcase.v1beta1.StreamBlurbsResponse.Action",
+            "comments": [
+              " The action that triggered the blurb to be returned."
+            ]
+          },
+          "SendBlurbsResponse:names": {
+            "paramName": "names",
+            "paramType": "TYPE_STRING[]",
+            "comments": [
+              " The names of successful blurb creations."
+            ]
+          },
+          "ConnectRequest:config": {
+            "paramName": "config",
+            "paramType": ".google.showcase.v1beta1.ConnectRequest.ConnectConfig",
+            "comments": [
+              " Provides information that specifies how to process subsequent requests.",
+              " The first `ConnectRequest` message must contain a `config`  message."
+            ]
+          },
+          "ConnectRequest:blurb": {
+            "paramName": "blurb",
+            "paramType": ".google.showcase.v1beta1.Blurb",
+            "comments": [
+              " The blurb to be created."
+            ]
+          }
+        }
+      },
+      "retryableCodeMap": {
+        "uniqueCodesNamesMap": {
+          "": "non_idempotent",
+          "deadline_exceeded_unavailable": "idempotent"
+        },
+        "prettyCodesNamesMap": {
+          "non_idempotent": [],
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ]
+        },
+        "uniqueParamsNamesMap": {
+          "94312e9926796a52a8fcbbedaac41972e07ccd1c": "default"
+        },
+        "prettyParamNamesMap": {
+          "default": {
+            "initial_retry_delay_millis": 100,
+            "retry_delay_multiplier": 1.3,
+            "max_retry_delay_millis": 60000,
+            "initial_rpc_timeout_millis": 60000,
+            "rpc_timeout_multiplier": 1,
+            "max_rpc_timeout_millis": 60000,
+            "total_timeout_millis": 600000
+          }
+        },
+        "codeEnumMapping": {
+          "0": "OK",
+          "1": "CANCELLED",
+          "2": "UNKNOWN",
+          "3": "INVALID_ARGUMENT",
+          "4": "DEADLINE_EXCEEDED",
+          "5": "NOT_FOUND",
+          "6": "ALREADY_EXISTS",
+          "7": "PERMISSION_DENIED",
+          "8": "RESOURCE_EXHAUSTED",
+          "9": "FAILED_PRECONDITION",
+          "10": "ABORTED",
+          "11": "OUT_OF_RANGE",
+          "12": "UNIMPLEMENTED",
+          "13": "INTERNAL",
+          "14": "UNAVAILABLE",
+          "15": "DATA_LOSS",
+          "16": "UNAUTHENTICATED"
+        }
+      },
+      "grpcServiceConfig": {},
+      "simpleMethods": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Creates a room.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateRoom",
+          "inputType": ".google.showcase.v1beta1.CreateRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.methodSignature": [
+              "room.display_name,room.description"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/rooms",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "room",
+              "paramType": ".google.showcase.v1beta1.Room",
+              "comments": [
+                " The room to create."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Retrieves the Room with the given resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetRoom",
+          "inputType": ".google.showcase.v1beta1.GetRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=rooms/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateRoomRequest",
+          "outputInterface": ".google.showcase.v1beta1.Room",
+          "comments": [
+            " Updates a room.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateRoom",
+          "inputType": ".google.showcase.v1beta1.UpdateRoomRequest",
+          "outputType": ".google.showcase.v1beta1.Room",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{room.name=rooms/*}",
+              "body": "*"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "room",
+              "paramType": ".google.showcase.v1beta1.Room",
+              "comments": [
+                " The room to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "room",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteRoomRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a room and all of its blurbs.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteRoom",
+          "inputType": ".google.showcase.v1beta1.DeleteRoomRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=rooms/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Creates a blurb. If the parent is a room, the blurb is understood to be a",
+            " message in that room. If the parent is a profile, the blurb is understood",
+            " to be a post on the profile.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateBlurb",
+          "inputType": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.methodSignature": [
+              "parent,blurb.user,blurb.text",
+              "parent,blurb.user,blurb.image"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/*}/blurbs",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/*/profile}/blurbs",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the chat room or user profile that this blurb will",
+                " be tied to."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to create."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Retrieves the Blurb with the given resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetBlurb",
+          "inputType": ".google.showcase.v1beta1.GetBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{name=rooms/*/blurbs/*}",
+              "additionalBindings": [
+                {
+                  "get": "/v1beta1/{name=users/*/profile/blurbs/*}"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested blurb."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.UpdateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.Blurb",
+          "comments": [
+            " Updates a blurb.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "UpdateBlurb",
+          "inputType": ".google.showcase.v1beta1.UpdateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.Blurb",
+          "options": {
+            ".google.api.http": {
+              "patch": "/v1beta1/{blurb.name=rooms/*/blurbs/*}",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "patch": "/v1beta1/{blurb.name=users/*/profile/blurbs/*}",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to update."
+              ]
+            },
+            {
+              "paramName": "update_mask",
+              "paramType": ".google.protobuf.FieldMask",
+              "comments": [
+                " The field mask to determine wich fields are to be updated. If empty, the",
+                " server will assume all fields are to be updated."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "blurb",
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteBlurbRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Deletes a blurb.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteBlurb",
+          "inputType": ".google.showcase.v1beta1.DeleteBlurbRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.methodSignature": [
+              "name"
+            ],
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=rooms/*/blurbs/*}",
+              "additionalBindings": [
+                {
+                  "delete": "/v1beta1/{name=users/*/profile/blurbs/*}"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested blurb."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        }
+      ],
+      "longRunning": [
+        {
+          "longRunning": {
+            "responseType": "SearchBlurbsResponse",
+            "metadataType": "SearchBlurbsMetadata"
+          },
+          "longRunningResponseType": ".google.showcase.v1beta1.SearchBlurbsResponse",
+          "longRunningMetadataType": ".google.showcase.v1beta1.SearchBlurbsMetadata",
+          "inputInterface": ".google.showcase.v1beta1.SearchBlurbsRequest",
+          "outputInterface": ".google.longrunning.Operation",
+          "comments": [
+            " This method searches through all blurbs across all rooms and profiles",
+            " for blurbs containing to words found in the query. Only posts that",
+            " contain an exact match of a queried word will be returned.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "SearchBlurbs",
+          "inputType": ".google.showcase.v1beta1.SearchBlurbsRequest",
+          "outputType": ".google.longrunning.Operation",
+          "options": {
+            ".google.longrunning.operationInfo": {
+              "responseType": "SearchBlurbsResponse",
+              "metadataType": "SearchBlurbsMetadata"
+            },
+            ".google.api.methodSignature": [
+              "query"
+            ],
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/-}/blurbs:search",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/-/profile}/blurbs:search"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "query",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The query used to search for blurbs containing to words of this string.",
+                " Only posts that contain an exact match of a queried word will be returned."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The rooms or profiles to search. If unset, `SearchBlurbs` will search all",
+                " rooms and all profiles."
+              ]
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of blurbs return. Server may return fewer",
+                " blurbs than requested. If unspecified, server will pick an appropriate",
+                " default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of",
+                " google.showcase.v1beta1.SearchBlurbsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\SearchBlurbs` method."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        }
+      ],
+      "streaming": [
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This returns a stream that emits the blurbs that are created for a",
+            " particular chat room or user profile.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "StreamBlurbs",
+          "inputType": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=rooms/*}/blurbs:stream",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{name=users/*/profile}/blurbs:stream",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of a chat room or user profile whose blurbs to stream."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "expire_time",
+              "paramType": ".google.protobuf.Timestamp",
+              "comments": [
+                " The time at which this stream will close."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "comments": [
+            " This is a stream to create multiple blurbs. If an invalid blurb is",
+            " requested to be created, the stream will close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "SendBlurbs",
+          "inputType": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/*}/blurbs:send",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/*/profile}/blurbs:send",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the chat room or user profile that this blurb will",
+                " be tied to."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to create."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ConnectRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This method starts a bidirectional stream that receives all blurbs that",
+            " are being created after the stream has started and sends requests to create",
+            " blurbs. If an invalid blurb is requested to be created, the stream will",
+            " close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Connect",
+          "inputType": ".google.showcase.v1beta1.ConnectRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "config",
+              "paramType": ".google.showcase.v1beta1.ConnectRequest.ConnectConfig",
+              "comments": [
+                " Provides information that specifies how to process subsequent requests.",
+                " The first `ConnectRequest` message must contain a `config`  message."
+              ]
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to be created."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "clientStreaming": [
+        {
+          "streaming": "CLIENT_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputInterface": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "comments": [
+            " This is a stream to create multiple blurbs. If an invalid blurb is",
+            " requested to be created, the stream will close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "SendBlurbs",
+          "inputType": ".google.showcase.v1beta1.CreateBlurbRequest",
+          "outputType": ".google.showcase.v1beta1.SendBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{parent=rooms/*}/blurbs:send",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{parent=users/*/profile}/blurbs:send",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "clientStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the chat room or user profile that this blurb will",
+                " be tied to."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to create."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        }
+      ],
+      "serverStreaming": [
+        {
+          "streaming": "SERVER_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This returns a stream that emits the blurbs that are created for a",
+            " particular chat room or user profile.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "StreamBlurbs",
+          "inputType": ".google.showcase.v1beta1.StreamBlurbsRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=rooms/*}/blurbs:stream",
+              "body": "*",
+              "additionalBindings": [
+                {
+                  "post": "/v1beta1/{name=users/*/profile}/blurbs:stream",
+                  "body": "*"
+                }
+              ]
+            }
+          },
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of a chat room or user profile whose blurbs to stream."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "expire_time",
+              "paramType": ".google.protobuf.Timestamp",
+              "comments": [
+                " The time at which this stream will close."
+              ],
+              "fieldBehavior": 2
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        }
+      ],
+      "bidiStreaming": [
+        {
+          "streaming": "BIDI_STREAMING",
+          "inputInterface": ".google.showcase.v1beta1.ConnectRequest",
+          "outputInterface": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "comments": [
+            " This method starts a bidirectional stream that receives all blurbs that",
+            " are being created after the stream has started and sends requests to create",
+            " blurbs. If an invalid blurb is requested to be created, the stream will",
+            " close with an error.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "Connect",
+          "inputType": ".google.showcase.v1beta1.ConnectRequest",
+          "outputType": ".google.showcase.v1beta1.StreamBlurbsResponse",
+          "clientStreaming": true,
+          "serverStreaming": true,
+          "paramComment": [
+            {
+              "paramName": "config",
+              "paramType": ".google.showcase.v1beta1.ConnectRequest.ConnectConfig",
+              "comments": [
+                " Provides information that specifies how to process subsequent requests.",
+                " The first `ConnectRequest` message must contain a `config`  message."
+              ]
+            },
+            {
+              "paramName": "blurb",
+              "paramType": ".google.showcase.v1beta1.Blurb",
+              "comments": [
+                " The blurb to be created."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        }
+      ],
+      "paging": [
+        {
+          "pagingFieldName": "rooms",
+          "pagingResponseType": ".google.showcase.v1beta1.Room",
+          "inputInterface": ".google.showcase.v1beta1.ListRoomsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListRoomsResponse",
+          "comments": [
+            " Lists all chat rooms.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListRooms",
+          "inputType": ".google.showcase.v1beta1.ListRoomsRequest",
+          "outputType": ".google.showcase.v1beta1.ListRoomsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/rooms"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of rooms return. Server may return fewer rooms",
+                " than requested. If unspecified, server will pick an appropriate default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListRoomsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\ListRooms` method."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "pagingFieldName": "blurbs",
+          "pagingResponseType": ".google.showcase.v1beta1.Blurb",
+          "inputInterface": ".google.showcase.v1beta1.ListBlurbsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListBlurbsResponse",
+          "comments": [
+            " Lists blurbs for a specific chat room or user profile depending on the",
+            " parent resource name.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListBlurbs",
+          "inputType": ".google.showcase.v1beta1.ListBlurbsRequest",
+          "outputType": ".google.showcase.v1beta1.ListBlurbsResponse",
+          "options": {
+            ".google.api.methodSignature": [
+              "parent"
+            ],
+            ".google.api.http": {
+              "get": "/v1beta1/{parent=rooms/*}/blurbs",
+              "additionalBindings": [
+                {
+                  "get": "/v1beta1/{parent=users/*/profile}/blurbs"
+                }
+              ]
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The resource name of the requested room or profile whos blurbs to list."
+              ],
+              "fieldBehavior": 2
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of blurbs to return. Server may return fewer",
+                " blurbs than requested. If unspecified, server will pick an appropriate",
+                " default."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The value of google.showcase.v1beta1.ListBlurbsResponse.next_page_token",
+                " returned from the previous call to",
+                " `google.showcase.v1beta1.Messaging\\ListBlurbs` method."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        }
+      ],
+      "hostname": "localhost",
+      "port": 7469,
+      "oauthScopes": [],
+      "pathTemplates": [
+        {
+          "name": "Blueprint",
+          "params": [
+            "session",
+            "test",
+            "blueprint"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}/blueprints/{blueprint}"
+          ],
+          "type": "showcase.googleapis.com/Blueprint"
+        },
+        {
+          "name": "Room",
+          "params": [
+            "room_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}"
+          ],
+          "type": "showcase.googleapis.com/Room"
+        },
+        {
+          "name": "room_id_blurb_id",
+          "params": [
+            "room_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        },
+        {
+          "name": "Session",
+          "params": [
+            "session"
+          ],
+          "pattern": [
+            "sessions/{session}"
+          ],
+          "type": "showcase.googleapis.com/Session"
+        },
+        {
+          "name": "Test",
+          "params": [
+            "session",
+            "test"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}"
+          ],
+          "type": "showcase.googleapis.com/Test"
+        },
+        {
+          "name": "User",
+          "params": [
+            "user_id"
+          ],
+          "pattern": [
+            "users/{user_id}"
+          ],
+          "type": "showcase.googleapis.com/User"
+        },
+        {
+          "name": "user_id_blurb_id",
+          "params": [
+            "user_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "user/{user_id}/profile/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        }
+      ]
+    },
+    {
+      "method": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.Session",
+          "comments": [
+            " Creates a new testing session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateSession",
+          "inputType": ".google.showcase.v1beta1.CreateSessionRequest",
+          "outputType": ".google.showcase.v1beta1.Session",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/sessions",
+              "body": "session"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "session",
+              "paramType": ".google.showcase.v1beta1.Session",
+              "comments": [
+                " The session to be created.",
+                " Sessions are immutable once they are created (although they can",
+                " be deleted)."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.Session",
+          "comments": [
+            " Gets a testing session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetSession",
+          "inputType": ".google.showcase.v1beta1.GetSessionRequest",
+          "outputType": ".google.showcase.v1beta1.Session",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/{name=sessions/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be retrieved."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "pagingFieldName": "sessions",
+          "pagingResponseType": ".google.showcase.v1beta1.Session",
+          "inputInterface": ".google.showcase.v1beta1.ListSessionsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListSessionsResponse",
+          "comments": [
+            " Lists the current test sessions.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListSessions",
+          "inputType": ".google.showcase.v1beta1.ListSessionsRequest",
+          "outputType": ".google.showcase.v1beta1.ListSessionsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/sessions"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of sessions to return per page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The page token, for retrieving subsequent pages."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteSessionRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Delete a test session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteSession",
+          "inputType": ".google.showcase.v1beta1.DeleteSessionRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=sessions/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be deleted."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.ReportSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.ReportSessionResponse",
+          "comments": [
+            " Report on the status of a session.",
+            " This generates a report detailing which tests have been completed,",
+            " and an overall rollup.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ReportSession",
+          "inputType": ".google.showcase.v1beta1.ReportSessionRequest",
+          "outputType": ".google.showcase.v1beta1.ReportSessionResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=sessions/*}:report"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be reported on."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "pagingFieldName": "tests",
+          "pagingResponseType": ".google.showcase.v1beta1.Test",
+          "inputInterface": ".google.showcase.v1beta1.ListTestsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListTestsResponse",
+          "comments": [
+            " List the tests of a sessesion.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListTests",
+          "inputType": ".google.showcase.v1beta1.ListTestsRequest",
+          "outputType": ".google.showcase.v1beta1.ListTestsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/{parent=sessions/*}/tests"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session."
+              ]
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of tests to return per page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The page token, for retrieving subsequent pages."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteTestRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Explicitly decline to implement a test.",
+            "",
+            " This removes the test from subsequent `ListTests` calls, and",
+            " attempting to do the test will error.",
+            "",
+            " This method will error if attempting to delete a required test.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteTest",
+          "inputType": ".google.showcase.v1beta1.DeleteTestRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=sessions/*/tests/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The test to be deleted."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.VerifyTestRequest",
+          "outputInterface": ".google.showcase.v1beta1.VerifyTestResponse",
+          "comments": [
+            " Register a response to a test.",
+            "",
+            " In cases where a test involves registering a final answer at the",
+            " end of the test, this method provides the means to do so.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "VerifyTest",
+          "inputType": ".google.showcase.v1beta1.VerifyTestRequest",
+          "outputType": ".google.showcase.v1beta1.VerifyTestResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=sessions/*/tests/*}:check"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The test to have an answer registered to it."
+              ]
+            },
+            {
+              "paramName": "answer",
+              "paramType": "TYPE_BYTES",
+              "comments": [
+                " The answer from the test."
+              ]
+            },
+            {
+              "paramName": "answers",
+              "paramType": "TYPE_BYTES[]",
+              "comments": [
+                " The answers from the test if multiple are to be checked"
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        }
+      ],
+      "name": "Testing",
+      "options": {
+        ".google.api.defaultHost": "localhost:7469"
+      },
+      "packageName": "google.showcase.v1beta1",
+      "comments": [
+        " A service to facilitate running discrete sets of tests",
+        " against Showcase."
+      ],
+      "commentsMap": {
+        "comments": {
+          "Testing": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " A service to facilitate running discrete sets of tests",
+              " against Showcase."
+            ]
+          },
+          "Testing:CreateSession": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Creates a new testing session.",
+              ""
+            ]
+          },
+          "Testing:GetSession": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Gets a testing session.",
+              ""
+            ]
+          },
+          "Testing:ListSessions": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Lists the current test sessions.",
+              ""
+            ]
+          },
+          "Testing:DeleteSession": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Delete a test session.",
+              ""
+            ]
+          },
+          "Testing:ReportSession": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Report on the status of a session.",
+              " This generates a report detailing which tests have been completed,",
+              " and an overall rollup.",
+              ""
+            ]
+          },
+          "Testing:ListTests": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " List the tests of a sessesion.",
+              ""
+            ]
+          },
+          "Testing:DeleteTest": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Explicitly decline to implement a test.",
+              "",
+              " This removes the test from subsequent `ListTests` calls, and",
+              " attempting to do the test will error.",
+              "",
+              " This method will error if attempting to delete a required test.",
+              ""
+            ]
+          },
+          "Testing:VerifyTest": {
+            "paramName": "",
+            "paramType": "",
+            "comments": [
+              " Register a response to a test.",
+              "",
+              " In cases where a test involves registering a final answer at the",
+              " end of the test, this method provides the means to do so.",
+              ""
+            ]
+          },
+          "Session:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The name of the session. The ID must conform to ^[a-z]+$",
+              " If this is not provided, Showcase chooses one at random."
+            ]
+          },
+          "Session:version": {
+            "paramName": "version",
+            "paramType": ".google.showcase.v1beta1.Session.Version",
+            "comments": [
+              " Required. The version this session is using."
+            ]
+          },
+          "CreateSessionRequest:session": {
+            "paramName": "session",
+            "paramType": ".google.showcase.v1beta1.Session",
+            "comments": [
+              " The session to be created.",
+              " Sessions are immutable once they are created (although they can",
+              " be deleted)."
+            ]
+          },
+          "GetSessionRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The session to be retrieved."
+            ]
+          },
+          "ListSessionsRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of sessions to return per page."
+            ]
+          },
+          "ListSessionsRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The page token, for retrieving subsequent pages."
+            ]
+          },
+          "ListSessionsResponse:sessions": {
+            "paramName": "sessions",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The sessions being returned."
+            ]
+          },
+          "ListSessionsResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The next page token, if any.",
+              " An empty value here means the last page has been reached."
+            ]
+          },
+          "DeleteSessionRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The session to be deleted."
+            ]
+          },
+          "ReportSessionRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The session to be reported on."
+            ]
+          },
+          "ReportSessionResponse:result": {
+            "paramName": "result",
+            "paramType": ".google.showcase.v1beta1.ReportSessionResponse.Result",
+            "comments": [
+              " The state of the report."
+            ]
+          },
+          "ReportSessionResponse:test_runs": {
+            "paramName": "test_runs",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The test runs of this session."
+            ]
+          },
+          "Test:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The name of the test.",
+              " The tests/* portion of the names are hard-coded, and do not change",
+              " from session to session."
+            ]
+          },
+          "Test:expectation_level": {
+            "paramName": "expectation_level",
+            "paramType": ".google.showcase.v1beta1.Test.ExpectationLevel",
+            "comments": [
+              " The expectation level for this test."
+            ]
+          },
+          "Test:description": {
+            "paramName": "description",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A description of the test."
+            ]
+          },
+          "Test:blueprints": {
+            "paramName": "blueprints",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The blueprints that will satisfy this test. There may be multiple blueprints",
+              " that can signal to the server that this test case is being exercised. Although",
+              " multiple blueprints are specified, only a single blueprint needs to be run to",
+              " signal that the test case was exercised."
+            ]
+          },
+          "Issue:type": {
+            "paramName": "type",
+            "paramType": ".google.showcase.v1beta1.Issue.Type",
+            "comments": [
+              " The type of the issue."
+            ]
+          },
+          "Issue:severity": {
+            "paramName": "severity",
+            "paramType": ".google.showcase.v1beta1.Issue.Severity",
+            "comments": [
+              " The severity of the issue."
+            ]
+          },
+          "Issue:description": {
+            "paramName": "description",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " A description of the issue."
+            ]
+          },
+          "ListTestsRequest:parent": {
+            "paramName": "parent",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The session."
+            ]
+          },
+          "ListTestsRequest:page_size": {
+            "paramName": "page_size",
+            "paramType": "TYPE_INT32",
+            "comments": [
+              " The maximum number of tests to return per page."
+            ]
+          },
+          "ListTestsRequest:page_token": {
+            "paramName": "page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The page token, for retrieving subsequent pages."
+            ]
+          },
+          "ListTestsResponse:tests": {
+            "paramName": "tests",
+            "paramType": "TYPE_MESSAGE[]",
+            "comments": [
+              " The tests being returned."
+            ]
+          },
+          "ListTestsResponse:next_page_token": {
+            "paramName": "next_page_token",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The next page token, if any.",
+              " An empty value here means the last page has been reached."
+            ]
+          },
+          "TestRun:test": {
+            "paramName": "test",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The name of the test.",
+              " The tests/* portion of the names are hard-coded, and do not change",
+              " from session to session."
+            ]
+          },
+          "TestRun:issue": {
+            "paramName": "issue",
+            "paramType": ".google.showcase.v1beta1.Issue",
+            "comments": [
+              " An issue found with the test run. If empty, this test run was successful."
+            ]
+          },
+          "DeleteTestRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The test to be deleted."
+            ]
+          },
+          "VerifyTestRequest:name": {
+            "paramName": "name",
+            "paramType": "TYPE_STRING",
+            "comments": [
+              " The test to have an answer registered to it."
+            ]
+          },
+          "VerifyTestRequest:answer": {
+            "paramName": "answer",
+            "paramType": "TYPE_BYTES",
+            "comments": [
+              " The answer from the test."
+            ]
+          },
+          "VerifyTestRequest:answers": {
+            "paramName": "answers",
+            "paramType": "TYPE_BYTES[]",
+            "comments": [
+              " The answers from the test if multiple are to be checked"
+            ]
+          },
+          "VerifyTestResponse:issue": {
+            "paramName": "issue",
+            "paramType": ".google.showcase.v1beta1.Issue",
+            "comments": [
+              " An issue if check answer was unsuccessful. This will be empty if the check answer succeeded."
+            ]
+          }
+        }
+      },
+      "retryableCodeMap": {
+        "uniqueCodesNamesMap": {
+          "": "non_idempotent",
+          "deadline_exceeded_unavailable": "idempotent"
+        },
+        "prettyCodesNamesMap": {
+          "non_idempotent": [],
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ]
+        },
+        "uniqueParamsNamesMap": {
+          "94312e9926796a52a8fcbbedaac41972e07ccd1c": "default"
+        },
+        "prettyParamNamesMap": {
+          "default": {
+            "initial_retry_delay_millis": 100,
+            "retry_delay_multiplier": 1.3,
+            "max_retry_delay_millis": 60000,
+            "initial_rpc_timeout_millis": 60000,
+            "rpc_timeout_multiplier": 1,
+            "max_rpc_timeout_millis": 60000,
+            "total_timeout_millis": 600000
+          }
+        },
+        "codeEnumMapping": {
+          "0": "OK",
+          "1": "CANCELLED",
+          "2": "UNKNOWN",
+          "3": "INVALID_ARGUMENT",
+          "4": "DEADLINE_EXCEEDED",
+          "5": "NOT_FOUND",
+          "6": "ALREADY_EXISTS",
+          "7": "PERMISSION_DENIED",
+          "8": "RESOURCE_EXHAUSTED",
+          "9": "FAILED_PRECONDITION",
+          "10": "ABORTED",
+          "11": "OUT_OF_RANGE",
+          "12": "UNIMPLEMENTED",
+          "13": "INTERNAL",
+          "14": "UNAVAILABLE",
+          "15": "DATA_LOSS",
+          "16": "UNAUTHENTICATED"
+        }
+      },
+      "grpcServiceConfig": {},
+      "simpleMethods": [
+        {
+          "inputInterface": ".google.showcase.v1beta1.CreateSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.Session",
+          "comments": [
+            " Creates a new testing session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "CreateSession",
+          "inputType": ".google.showcase.v1beta1.CreateSessionRequest",
+          "outputType": ".google.showcase.v1beta1.Session",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/sessions",
+              "body": "session"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "session",
+              "paramType": ".google.showcase.v1beta1.Session",
+              "comments": [
+                " The session to be created.",
+                " Sessions are immutable once they are created (although they can",
+                " be deleted)."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.GetSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.Session",
+          "comments": [
+            " Gets a testing session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "GetSession",
+          "inputType": ".google.showcase.v1beta1.GetSessionRequest",
+          "outputType": ".google.showcase.v1beta1.Session",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/{name=sessions/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be retrieved."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteSessionRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Delete a test session.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteSession",
+          "inputType": ".google.showcase.v1beta1.DeleteSessionRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=sessions/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be deleted."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.ReportSessionRequest",
+          "outputInterface": ".google.showcase.v1beta1.ReportSessionResponse",
+          "comments": [
+            " Report on the status of a session.",
+            " This generates a report detailing which tests have been completed,",
+            " and an overall rollup.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ReportSession",
+          "inputType": ".google.showcase.v1beta1.ReportSessionRequest",
+          "outputType": ".google.showcase.v1beta1.ReportSessionResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=sessions/*}:report"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session to be reported on."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.DeleteTestRequest",
+          "outputInterface": ".google.protobuf.Empty",
+          "comments": [
+            " Explicitly decline to implement a test.",
+            "",
+            " This removes the test from subsequent `ListTests` calls, and",
+            " attempting to do the test will error.",
+            "",
+            " This method will error if attempting to delete a required test.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "DeleteTest",
+          "inputType": ".google.showcase.v1beta1.DeleteTestRequest",
+          "outputType": ".google.protobuf.Empty",
+          "options": {
+            ".google.api.http": {
+              "delete": "/v1beta1/{name=sessions/*/tests/*}"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The test to be deleted."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        },
+        {
+          "inputInterface": ".google.showcase.v1beta1.VerifyTestRequest",
+          "outputInterface": ".google.showcase.v1beta1.VerifyTestResponse",
+          "comments": [
+            " Register a response to a test.",
+            "",
+            " In cases where a test involves registering a final answer at the",
+            " end of the test, this method provides the means to do so.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "VerifyTest",
+          "inputType": ".google.showcase.v1beta1.VerifyTestRequest",
+          "outputType": ".google.showcase.v1beta1.VerifyTestResponse",
+          "options": {
+            ".google.api.http": {
+              "post": "/v1beta1/{name=sessions/*/tests/*}:check"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "name",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The test to have an answer registered to it."
+              ]
+            },
+            {
+              "paramName": "answer",
+              "paramType": "TYPE_BYTES",
+              "comments": [
+                " The answer from the test."
+              ]
+            },
+            {
+              "paramName": "answers",
+              "paramType": "TYPE_BYTES[]",
+              "comments": [
+                " The answers from the test if multiple are to be checked"
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "name"
+            ]
+          ]
+        }
+      ],
+      "longRunning": [],
+      "streaming": [],
+      "clientStreaming": [],
+      "serverStreaming": [],
+      "bidiStreaming": [],
+      "paging": [
+        {
+          "pagingFieldName": "sessions",
+          "pagingResponseType": ".google.showcase.v1beta1.Session",
+          "inputInterface": ".google.showcase.v1beta1.ListSessionsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListSessionsResponse",
+          "comments": [
+            " Lists the current test sessions.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListSessions",
+          "inputType": ".google.showcase.v1beta1.ListSessionsRequest",
+          "outputType": ".google.showcase.v1beta1.ListSessionsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/sessions"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of sessions to return per page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The page token, for retrieving subsequent pages."
+              ]
+            }
+          ],
+          "headerRequestParams": []
+        },
+        {
+          "pagingFieldName": "tests",
+          "pagingResponseType": ".google.showcase.v1beta1.Test",
+          "inputInterface": ".google.showcase.v1beta1.ListTestsRequest",
+          "outputInterface": ".google.showcase.v1beta1.ListTestsResponse",
+          "comments": [
+            " List the tests of a sessesion.",
+            ""
+          ],
+          "methodConfig": {},
+          "retryableCodesName": "non_idempotent",
+          "retryParamsName": "default",
+          "name": "ListTests",
+          "inputType": ".google.showcase.v1beta1.ListTestsRequest",
+          "outputType": ".google.showcase.v1beta1.ListTestsResponse",
+          "options": {
+            ".google.api.http": {
+              "get": "/v1beta1/{parent=sessions/*}/tests"
+            }
+          },
+          "paramComment": [
+            {
+              "paramName": "parent",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The session."
+              ]
+            },
+            {
+              "paramName": "page_size",
+              "paramType": "TYPE_INT32",
+              "comments": [
+                " The maximum number of tests to return per page."
+              ]
+            },
+            {
+              "paramName": "page_token",
+              "paramType": "TYPE_STRING",
+              "comments": [
+                " The page token, for retrieving subsequent pages."
+              ]
+            }
+          ],
+          "headerRequestParams": [
+            [
+              "parent"
+            ]
+          ]
+        }
+      ],
+      "hostname": "localhost",
+      "port": 7469,
+      "oauthScopes": [],
+      "pathTemplates": [
+        {
+          "name": "Blueprint",
+          "params": [
+            "session",
+            "test",
+            "blueprint"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}/blueprints/{blueprint}"
+          ],
+          "type": "showcase.googleapis.com/Blueprint"
+        },
+        {
+          "name": "Room",
+          "params": [
+            "room_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}"
+          ],
+          "type": "showcase.googleapis.com/Room"
+        },
+        {
+          "name": "room_id_blurb_id",
+          "params": [
+            "room_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "rooms/{room_id}/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        },
+        {
+          "name": "Session",
+          "params": [
+            "session"
+          ],
+          "pattern": [
+            "sessions/{session}"
+          ],
+          "type": "showcase.googleapis.com/Session"
+        },
+        {
+          "name": "Test",
+          "params": [
+            "session",
+            "test"
+          ],
+          "pattern": [
+            "sessions/{session}/tests/{test}"
+          ],
+          "type": "showcase.googleapis.com/Test"
+        },
+        {
+          "name": "User",
+          "params": [
+            "user_id"
+          ],
+          "pattern": [
+            "users/{user_id}"
+          ],
+          "type": "showcase.googleapis.com/User"
+        },
+        {
+          "name": "user_id_blurb_id",
+          "params": [
+            "user_id",
+            "blurb_id"
+          ],
+          "pattern": [
+            "user/{user_id}/profile/blurbs/{blurb_id}"
+          ],
+          "type": "showcase.googleapis.com/Blurb"
+        }
+      ]
+    }
+  ]
+}

--- a/templates/typescript_gapic_metadata/api.json.njk
+++ b/templates/typescript_gapic_metadata/api.json.njk
@@ -1,0 +1,1 @@
+{{ api.dump | safe }}

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -15,7 +15,7 @@
 import * as plugin from '../../../pbjs-genfiles/plugin';
 
 import { Naming, Options as namingOptions } from './naming';
-import { Proto } from './proto';
+import { Proto, ServiceDescriptorProto } from './proto';
 import { ResourceDatabase, ResourceDescriptor } from './resource-database';
 
 export interface ProtosMap {
@@ -119,7 +119,7 @@ export class API {
           ...Object.keys(proto.services).map(name => proto.services[name])
         );
         return retval;
-      }, [] as plugin.google.protobuf.IServiceDescriptorProto[])
+      }, [] as ServiceDescriptorProto[])
       .sort((service1, service2) =>
         service1.name!.localeCompare(service2.name!)
       );
@@ -141,6 +141,16 @@ export class API {
       null,
       '  '
     );
+  }
+
+  get dump() {
+    return JSON.stringify({
+      publishName: this.publishName,
+      naming: this.naming,
+      hostname: this.hostName,
+      port: this.port,
+      services: this.services,
+    });
   }
 }
 

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -48,6 +48,7 @@ interface MethodDescriptorProto
   // into x-goog-request-params header, the array will contain
   // [ ['request', 'foo'], ['request', 'bar']]
   headerRequestParams: string[][];
+  toJSON: Function | undefined;
 }
 
 export interface ServiceDescriptorProto
@@ -69,6 +70,7 @@ export interface ServiceDescriptorProto
   commentsMap: CommentsMap;
   retryableCodeMap: RetryableCodeMap;
   grpcServiceConfig: plugin.grpc.service_config.ServiceConfig;
+  toJSON: Function | undefined;
 }
 
 export interface ServicesMap {
@@ -373,6 +375,9 @@ function augmentMethod(
   method.headerRequestParams = getHeaderRequestParams(
     method.options?.['.google.api.http']
   );
+  // protobuf.js redefines .toJSON to serialize only known fields,
+  // but we need to serialize the whole augmented object.
+  method.toJSON = undefined;
   return method;
 }
 
@@ -528,6 +533,9 @@ function augmentService(
       return 0;
     }
   );
+  // protobuf.js redefines .toJSON to serialize only known fields,
+  // but we need to serialize the whole augmented object.
+  augmentedService.toJSON = undefined;
   return augmentedService;
 }
 

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -156,4 +156,21 @@ describe('src/schema/api.ts', () => {
       });
     });
   });
+
+  it('dump should contain valid JSON with a list of services', () => {
+    const fd = new plugin.google.protobuf.FileDescriptorProto();
+    fd.name = 'google/cloud/test/v1/test.proto';
+    fd.package = 'google.cloud.test.v1';
+    fd.service = [new plugin.google.protobuf.ServiceDescriptorProto()];
+    fd.service[0].name = 'ZService';
+    fd.service[0].options = {
+      '.google.api.defaultHost': 'hostname.example.com:443',
+    };
+    const api = new API([fd], 'google.cloud.test.v1', {
+      grpcServiceConfig: new plugin.grpc.service_config.ServiceConfig(),
+    });
+    const dump = api.dump;
+    const object = JSON.parse(dump);
+    assert(object['services']);
+  });
 });

--- a/typescript/test/unit/baselines.ts
+++ b/typescript/test/unit/baselines.ts
@@ -63,7 +63,7 @@ describe('Baseline tests', () => {
     protoPath: 'google/showcase/v1beta1/*.proto',
     useCommonProto: false,
     mainServiceName: 'ShowcaseService',
-    template: 'typescript_gapic',
+    template: 'typescript_gapic;typescript_gapic_metadata',
   });
 
   runBaselineTest({


### PR DESCRIPTION
**DRAFT - for design review**

A feature to dump the contents of an `API` object (will be used by samples generation).

Discussion in the shared document.