### PR TITLE
refactor: allow passing multiple templates as parameters

### DIFF
--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -50,7 +50,7 @@ interface MethodDescriptorProto
   headerRequestParams: string[][];
 }
 
-interface ServiceDescriptorProto
+export interface ServiceDescriptorProto
   extends plugin.google.protobuf.IServiceDescriptorProto {
   packageName: string;
   method: MethodDescriptorProto[];

--- a/typescript/src/templater.ts
+++ b/typescript/src/templater.ts
@@ -20,13 +20,11 @@ import * as util from 'util';
 import * as plugin from '../../pbjs-genfiles/plugin';
 
 import { API } from './schema/api';
-import { commonPrefix } from './util';
 
 const commonParameters: { [name: string]: string } = {
   copyrightYear: new Date().getFullYear().toString(),
 };
 
-const readFile = util.promisify(fs.readFile);
 const readDir = util.promisify(fs.readdir);
 const fsstat = util.promisify(fs.stat);
 

--- a/typescript/test/unit/baselines.ts
+++ b/typescript/test/unit/baselines.ts
@@ -63,6 +63,7 @@ describe('Baseline tests', () => {
     protoPath: 'google/showcase/v1beta1/*.proto',
     useCommonProto: false,
     mainServiceName: 'ShowcaseService',
+    template: 'typescript_gapic',
   });
 
   runBaselineTest({

--- a/typescript/test/util.ts
+++ b/typescript/test/util.ts
@@ -33,6 +33,7 @@ export interface BaselineOptions {
   mainServiceName?: string;
   grpcServiceConfig?: string;
   packageName?: string;
+  template?: string;
 }
 
 const cwd = process.cwd();
@@ -106,6 +107,9 @@ export function runBaselineTest(options: BaselineOptions) {
     }
     if (options.packageName) {
       commandLine += ` --package-name=${options.packageName}`;
+    }
+    if (options.template) {
+      commandLine += ` --template="${options.template}"`;
     }
 
     execSync(commandLine);


### PR DESCRIPTION
This is extracted from #322 to make that PR only related to samples generation.

Here I'm allowing to pass `--template` parameter pointing to a semicolon-separated list of template folders to process (by default, it's `typescript_gapic`). It will be helpful in making the generator more flexible.