### PR TITLE
fix: render subresponse_field as string if it is not null

### DIFF
--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -230,7 +230,8 @@ export class LoggingServiceV2Client {
     this._descriptors.batching = {
       WriteLogEntries: new this._gaxModule.BundleDescriptor(
         'entries',
-        ['log_name','resource','labels'],null,
+        ['log_name','resource','labels'],
+        null,
         gax.createByteLengthFunction(
           // tslint:disable-next-line no-any
           protoFilesRoot.lookupType('google.logging.v2.LogEntry') as any

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -234,7 +234,11 @@ export class {{ service.name }}Client {
         '{{ field }}'
 {%- endfor -%}
         ],
+{%- if method.bundleConfig.batchDescriptor.subresponse_field === 'null' %}
         {{- method.bundleConfig.batchDescriptor.subresponse_field }},
+{%- else %}
+        '{{- method.bundleConfig.batchDescriptor.subresponse_field }}',
+{%- endif %}
         gax.createByteLengthFunction(
           // tslint:disable-next-line no-any
           protoFilesRoot.lookupType('{{ method.bundleConfig.repeatedField }}') as any

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -235,7 +235,7 @@ export class {{ service.name }}Client {
 {%- endfor -%}
         ],
 {%- if method.bundleConfig.batchDescriptor.subresponse_field === 'null' %}
-        {{- method.bundleConfig.batchDescriptor.subresponse_field }},
+        null,
 {%- else %}
         '{{- method.bundleConfig.batchDescriptor.subresponse_field }}',
 {%- endif %}


### PR DESCRIPTION
pubsub has subresponse_field set in batching params and it's rendering as 
```
    this._descriptors.batching = {
      publish: new gaxModule.BundleDescriptor(
        'messages',
        ['topic'],
        messageIds,
        gax.createByteLengthFunction(
          protoFilesRoot.lookup('google.pubsub.v1.PubsubMessage')
        )
      ),
    };
```
correct one should be:
```
    this._descriptors.batching = {
      publish: new gaxModule.BundleDescriptor(
        'messages',
        ['topic'],
        'messageIds',
        gax.createByteLengthFunction(
          protoFilesRoot.lookup('google.pubsub.v1.PubsubMessage')
        )
      ),
    };
```