### PR TITLE
feat: sort package-json for generator to avoid noise in API conversion

### DIFF
--- a/baselines/bigquery-storage/package.json
+++ b/baselines/bigquery-storage/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-storage",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/disable-packing-test/package.json
+++ b/baselines/disable-packing-test/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-showcase",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/dlp/package.json
+++ b/baselines/dlp/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-dlp",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/kms/package.json
+++ b/baselines/kms/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-kms",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/logging/package.json
+++ b/baselines/logging/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-logging",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/monitoring/package.json
+++ b/baselines/monitoring/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-monitoring",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/redis/package.json
+++ b/baselines/redis/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-redis",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/showcase/package.json
+++ b/baselines/showcase/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-showcase",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/texttospeech/package.json
+++ b/baselines/texttospeech/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-texttospeech",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/baselines/translate/package.json
+++ b/baselines/translate/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-translation",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   },
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "bin": {
+    "gapic-generator-typescript": "build/src/start-script.js",
+    "protoc-gen-typescript_gapic": "build/src/cli.js"
+  },
   "files": [
     "build/src",
     "pbjs-genfiles",
     "templates"
   ],
-  "bin": {
-    "gapic-generator-typescript": "build/src/start-script.js",
-    "protoc-gen-typescript_gapic": "build/src/cli.js"
-  },
   "scripts": {
     "baseline": "node build/tools/update-baselines.js",
     "clean": "gts clean",
@@ -28,23 +28,23 @@
     "compile": "tsc -p .",
     "compile-protos": "pbjs -p protos -p node_modules/google-gax/protos -t static-module -o pbjs-genfiles/plugin.js google/protobuf/compiler/plugin.proto google/api/annotations.proto google/api/field_behavior.proto google/api/resource.proto google/api/client.proto google/longrunning/operations.proto service_config.proto && pbts pbjs-genfiles/plugin.js -o pbjs-genfiles/plugin.d.ts",
     "docker-test": "sh docker/test.sh",
-    "ts-test-application": "mocha build/test/test-application/test-ts --timeout 600000",
-    "js-test-application": "mocha build/test/test-application/test-js --timeout 600000",
     "fix": "gts fix",
+    "js-test-application": "mocha build/test/test-application/test-js --timeout 600000",
     "lint": "gts check",
+    "prepack": "cd templates/typescript_gapic && rm -f package.json.njk && mv package.json package.json.njk",
+    "postpack": "cd templates/typescript_gapic && mv package.json.njk package.json && ln -s package.json package.json.njk",
     "prepare": "npm run compile-protos && npm run compile",
     "pretest": "npm run compile-protos && npm run compile",
     "test": "c8 --reporter=lcov mocha build/test/unit",
-    "prepack": "cd templates/typescript_gapic && rm -f package.json.njk && mv package.json package.json.njk",
-    "postpack": "cd templates/typescript_gapic && mv package.json.njk package.json && ln -s package.json package.json.njk"
+    "ts-test-application": "mocha build/test/test-application/test-ts --timeout 600000"
   },
   "dependencies": {
     "@types/js-yaml": "^3.12.2",
     "file-system": "^2.2.2",
     "fs-extra": "^9.0.0",
     "get-stdin": "^7.0.0",
-    "js-yaml": "^3.13.1",
     "google-gax": "^1.15.1",
+    "js-yaml": "^3.13.1",
     "nunjucks": "^3.2.1",
     "object-hash": "^2.0.3",
     "protobufjs": "^6.8.9",

--- a/templates/typescript_gapic/package.json
+++ b/templates/typescript_gapic/package.json
@@ -5,20 +5,20 @@
   "repository": "googleapis/nodejs-{{ api.naming.productName.toKebabCase() }}",
   "license": "Apache-2.0",
   "author": "Google LLC",
+  "main": "build/src/index.js",
   "files": [
     "build/src",
     "build/protos"
   ],
-  "main": "build/src/index.js",
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "lint": "gts check",
-    "predocs-test": "npm run docs",
     "prepare": "npm run compile-protos && npm run compile",
     "system-test": "c8 mocha build/system-test",
     "test": "c8 mocha build/test"
@@ -36,8 +36,8 @@
     "jsdoc-region-tag": "^1.0.4",
     "linkinator": "^2.0.4",
     "mocha": "^6.2.2",
-    "pack-n-play": "^1.0.0-2",
     "null-loader": "^3.0.0",
+    "pack-n-play": "^1.0.0-2",
     "ts-loader": "^6.2.1",
     "typescript": "~3.8.3",
     "webpack": "^4.42.0",


### PR DESCRIPTION
1. sort package-json
2. sort package-json in templates

This will avoid some diff noise during API conversion.