### PR TITLE
fix: unit test template has wrong paging response type

### DIFF
--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -745,8 +745,8 @@ describe('v2.LoggingServiceV2Client', () => {
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(expectedResponse);
             const stream = client.listLogsStream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING[] = [];
-                stream.on('data', (response: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING) => {
+                const responses: string[] = [];
+                stream.on('data', (response: string) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {
@@ -780,8 +780,8 @@ describe('v2.LoggingServiceV2Client', () => {
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listLogsStream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING[] = [];
-                stream.on('data', (response: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING) => {
+                const responses: string[] = [];
+                stream.on('data', (response: string) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -666,11 +666,7 @@ describe('v2.LoggingServiceV2Client', () => {
                     },
                 },
             };
-            const expectedResponse = [
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-            ];
+            const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCall(expectedResponse);
             const [response] = await client.listLogs(request);
             assert.deepStrictEqual(response, expectedResponse);
@@ -694,11 +690,7 @@ describe('v2.LoggingServiceV2Client', () => {
                     },
                 },
             };
-            const expectedResponse = [
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-            ];
+            const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.listLogs(
@@ -749,16 +741,12 @@ describe('v2.LoggingServiceV2Client', () => {
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
             const expectedHeaderRequestParams = "parent=";
-            const expectedResponse = [
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-            ];
+            const expectedResponse = [new String(), new String(), new String()];
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(expectedResponse);
             const stream = client.listLogsStream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protosTYPE_STRING[] = [];
-                stream.on('data', (response: protosTYPE_STRING) => {
+                const responses: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING[] = [];
+                stream.on('data', (response: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {
@@ -792,8 +780,8 @@ describe('v2.LoggingServiceV2Client', () => {
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listLogsStream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protosTYPE_STRING[] = [];
-                stream.on('data', (response: protosTYPE_STRING) => {
+                const responses: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING[] = [];
+                stream.on('data', (response: protos.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {
@@ -821,11 +809,7 @@ describe('v2.LoggingServiceV2Client', () => {
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedResponse = [
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-              generateSampleMessage(new protosTYPE_STRING()),
-            ];
+            const expectedHeaderRequestParams = "parent=";const expectedResponse = [new String(), new String(), new String()];
             client.descriptors.page.listLogs.asyncIterate = stubAsyncIterationCall(expectedResponse);
             const responses: string[] = [];
             const iterable = client.listLogsAsync(request);

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -313,3 +313,12 @@ protos{{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
 {%- macro convertParamType(paramType) -%}
           {{- typescriptType(paramType) -}}
 {%- endmacro -%}
+
+{%- macro promiseResponsePaging(method) -%}
+{%- set tsType = typescriptType(method.pagingResponseType) -%}
+{%- if tsType.length > 0 -%}
+{{ tsType }}
+{%- else -%}
+protos{{ method.pagingResponseType }}
+{%- endif -%}
+{%- endmacro -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -263,11 +263,21 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endmacro -%}
 
 {%- macro initPagingResponse(method) -%}
+{%- if method.pagingResponseType.includes('TYPE_STRING') -%}
+            const expectedResponse = [new String(), new String(), new String()];
+{%- elif method.pagingResponseType.includes('TYPE_BOOL') -%}
+            const expectedResponse = [new Boolean(), new Boolean(), new Boolean()];
+{%- elif method.pagingResponseType.includes('TYPE_BYTES') -%}
+            const expectedResponse = [new Buffer(''), new Buffer(''), new Buffer('')];
+{%- elif method.pagingResponseType.includes('TYPE_') -%}
+            const expectedResponse = [new Number(), new Number(), new Number()];
+{%- else %}
             const expectedResponse = [
               generateSampleMessage(new protos{{ method.pagingResponseType }}()),
               generateSampleMessage(new protos{{ method.pagingResponseType }}()),
               generateSampleMessage(new protos{{ method.pagingResponseType }}()),
             ];
+{%- endif %}
 {%- endmacro -%}
 
 {%- macro typescriptType(protobufType) -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -281,20 +281,23 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endmacro -%}
 
 {%- macro typescriptType(protobufType) -%}
-{#- protobufType can be an array (TYPE_STRING[]), hence .startsWith -#}
-{%- if protobufType.startsWith('TYPE_BYTES') -%}
-{%- set type = protobufType.replace('TYPE_BYTES', 'Buffer') -%}
-{%- elif protobufType.startsWith('TYPE_BOOL') -%}
-{%- set type = protobufType.replace('TYPE_BOOL', 'boolean') -%}
-{%- elif protobufType.startsWith('TYPE_STRING') -%}
-{%- set type = protobufType.replace('TYPE_STRING', 'string') -%}
-{%- elif protobufType.startsWith('TYPE_') -%}
+{%- if protobufType.includes('TYPE_BYTES') -%}
+{%- set type = 'Buffer' -%}
+{%- elif protobufType.includes('TYPE_BOOL') -%}
+{%- set type = 'boolean' -%}
+{%- elif protobufType.includes('TYPE_STRING') -%}
+{%- set type = 'string' -%}
+{%- elif protobufType.includes('TYPE_') -%}
 {#- any other type is essentially a number: int32, uint32, etc. -#}
-{%- set type = protobufType.replace(r/TYPE_\w+/, 'number') -%}
+{%- set type = 'number' -%}
 {%- else -%}
 {%- set type = '' -%}
 {%- endif -%}
+{%- if protobufType.includes('[]') -%}
+{{ type }}[]
+{%- else -%}
 {{ type }}
+{%- endif -%}
 {%- endmacro -%}
 
 {%- macro toInterface(type) -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -268,7 +268,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- elif method.pagingResponseType.includes('TYPE_BOOL') -%}
             const expectedResponse = [new Boolean(), new Boolean(), new Boolean()];
 {%- elif method.pagingResponseType.includes('TYPE_BYTES') -%}
-            const expectedResponse = [new Buffer(''), new Buffer(''), new Buffer('')];
+            const expectedResponse = [Buffer.from(''), Buffer.from(''), Buffer.from('')];
 {%- elif method.pagingResponseType.includes('TYPE_') -%}
             const expectedResponse = [new Number(), new Number(), new Number()];
 {%- else -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -271,7 +271,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
             const expectedResponse = [new Buffer(''), new Buffer(''), new Buffer('')];
 {%- elif method.pagingResponseType.includes('TYPE_') -%}
             const expectedResponse = [new Number(), new Number(), new Number()];
-{%- else %}
+{%- else -%}
             const expectedResponse = [
               generateSampleMessage(new protos{{ method.pagingResponseType }}()),
               generateSampleMessage(new protos{{ method.pagingResponseType }}()),

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -620,8 +620,8 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.descriptors.page.{{ method.name.toCamelCase() }}.createStream = stubPageStreamingCall(expectedResponse);
             const stream = client.{{ method.name.toCamelCase() }}Stream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protos{{ method.pagingResponseType }}[] = [];
-                stream.on('data', (response: protos{{ method.pagingResponseType }}) => {
+                const responses: {{ util.promiseResponsePaging(method) }}[] = [];
+                stream.on('data', (response: {{ util.promiseResponsePaging(method) }}) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {
@@ -655,8 +655,8 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.descriptors.page.{{ method.name.toCamelCase() }}.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}Stream(request);
             const promise = new Promise((resolve, reject) => {
-                const responses: protos{{ method.pagingResponseType }}[] = [];
-                stream.on('data', (response: protos{{ method.pagingResponseType }}) => {
+                const responses: {{ util.promiseResponsePaging(method) }}[] = [];
+                stream.on('data', (response: {{ util.promiseResponsePaging(method) }}) => {
                     responses.push(response);
                 });
                 stream.on('end', () => {

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -246,7 +246,9 @@ function pagingResponseType(
   ) {
     return field.typeName; //.google.showcase.v1beta1.EchoResponse
   }
-  return plugin.google.protobuf.FieldDescriptorProto.Type[field.type];
+  const type = plugin.google.protobuf.FieldDescriptorProto.Type[field.type];
+  // .google.protobuf.FieldDescriptorProto.Type.TYPE_STRING
+  return '.google.protobuf.FieldDescriptorProto.Type.' + type;
 }
 
 export function getSingleHeaderParam(


### PR DESCRIPTION
fix: #380 
Now if the pagingResponseType is not `TYPE_MESSAGE`, we will use `.google.google.protobuf.FieldDescriptorProto.Type.TYPE_STRING (type field)` as the return type.
1.  In _util it will be truncated as `string` in primitive type check for client template. 
2. use `String` to create object for `generateSampleMessage` for unit test.

Only `logging` baseline got changed and start to use the new object.