### PR TITLE
feat: support proto3 optional fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,9 @@ jobs:
       - run:
           name: Install protoc
           command: |
-            wget https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip
-            cd / && sudo unzip /tmp/protoc-3.10.0-linux-x86_64.zip
+            wget https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc-1-linux-x86_64.zip
+            cd / && sudo unzip /tmp/protoc-3.12.0-rc-1-linux-x86_64.zip
+            sudo chmod +x /bin/protoc
             protoc --version
           working_directory: /tmp
       - run:

--- a/baselines/disable-packing-test/protos/google/showcase/v1beta1/echo.proto.baseline
+++ b/baselines/disable-packing-test/protos/google/showcase/v1beta1/echo.proto.baseline
@@ -117,6 +117,8 @@ message EchoRequest {
     // The error to be thrown by the server.
     google.rpc.Status error = 2;
   }
+
+  optional string presence = 3;
 }
 
 // The response message for the Echo methods.

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -352,6 +352,7 @@ export class EchoClient {
  *   The content to be echoed by the server.
  * @param {google.rpc.Status} request.error
  *   The error to be thrown by the server.
+ * @param {string} request.presence
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.

--- a/baselines/showcase/protos/google/showcase/v1beta1/echo.proto.baseline
+++ b/baselines/showcase/protos/google/showcase/v1beta1/echo.proto.baseline
@@ -117,6 +117,8 @@ message EchoRequest {
     // The error to be thrown by the server.
     google.rpc.Status error = 2;
   }
+
+  optional string presence = 3;
 }
 
 // The response message for the Echo methods.

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -352,6 +352,7 @@ export class EchoClient {
  *   The content to be echoed by the server.
  * @param {google.rpc.Status} request.error
  *   The error to be thrown by the server.
+ * @param {string} request.presence
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN npm install -g /root/files/package.tgz
 
 # Download and install protoc
 RUN cd /root/files && \
-    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip
-RUN cd /usr/local && unzip /root/files/protoc-3.11.2-linux-x86_64.zip
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc-1-linux-x86_64.zip
+RUN cd /usr/local && unzip /root/files/protoc-3.12.0-rc-1-linux-x86_64.zip
 
 # Download a copy of API common protos
 RUN cd /root/files && \

--- a/test-fixtures/protos/google/showcase/v1beta1/echo.proto
+++ b/test-fixtures/protos/google/showcase/v1beta1/echo.proto
@@ -117,6 +117,8 @@ message EchoRequest {
     // The error to be thrown by the server.
     google.rpc.Status error = 2;
   }
+
+  optional string presence = 3;
 }
 
 // The response message for the Echo methods.

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -202,6 +202,8 @@ export class Generator {
 
   async generate() {
     this.response = plugin.google.protobuf.compiler.CodeGeneratorResponse.create();
+    this.response.supportedFeatures =
+      plugin.google.protobuf.compiler.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL;
 
     this.addProtosToResponse();
     const api = this.buildAPIObject();

--- a/typescript/src/start-script.ts
+++ b/typescript/src/start-script.ts
@@ -87,6 +87,7 @@ const cliPath = path.join(__dirname, 'cli.js');
 const protocCommand = [
   `--plugin=protoc-gen-typescript_gapic=${cliPath}`,
   `--typescript_gapic_out=${outputDir}`,
+  '--experimental_allow_proto3_optional',
 ];
 if (grpcServiceConfig) {
   protocCommand.push(


### PR DESCRIPTION
This is a draft pull request that depends on several things to be done:
- `google-proto-files` update to include new `descriptor.proto` and `plugin.proto`;
- `google-gax` update to include new `descriptor.proto` and `plugin.proto`.

Note: the CI will fail until this is done.

When https://github.com/googleapis/gapic-showcase/pull/357 is merged we'll need to make one more PR here to update test applications (we cannot do it now, because it's a kind of circular dependency).

Note: with this basic PR, there is one huge caveat: because of the way how `optional` fields are supported in `protobuf.js`, the default values for those fields will be **wrong** (`null`, not the type-specific default value). It will be hard or impossible to fix it in `protobuf.js` (after all, it's a huge breaking change). We can handle it here in the generator, it will require some helper code to be written to set optional fields for all request message field, recursively. The generated code should do something like

```diff
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
       ...):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
+    request.presence = request.presence ?? '';
+    // if there are nested messages with optional fields...
+    if (request.nested) {
+      request.nested.optionalIntField = request.nested.optionalIntField ?? 0;
+    }
+    // might look weird for deeper nested fields
+    if (request.nested && request.nested.deeper) {
+      request.nested.deeper.optionalStringField = request.nested.deeper.optionalStringField ?? '';
+    }
     ...
 }
```
Note that this PR does not add this extra code, I consider this as a separate medium-sized feature to be implemented.

Also, note that this extra change might not be needed at all if the server side works properly with an optional field being unset (and not set to its default value). This needs to be investigated when the first real APIs supporting optional fields appear.

Cc: @xiaozhenliu-gg5 @summer-ji-eng 