### PR TITLE
fix: add option to disable validator 

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -32,6 +32,7 @@ mkdir $DIR_NAME
 docker run --rm \
   --mount type=bind,source=`pwd`/test-fixtures/protos/google/showcase/v1beta1,destination=/in/google/showcase/v1beta1,readonly \
   --mount type=bind,source=`pwd`/$DIR_NAME,destination=/out \
+  --validation false
   gapic-generator-typescript:latest
 # Test generated client library
 cd $DIR_NAME

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -42,6 +42,8 @@ const argv = yargs
   .alias('output-dir', 'output_dir')
   .describe('gapic-validator_out', 'Path to the output of the gapic validator')
   .alias('gapic-validator_out', 'gapic_validator_out')
+  .describe('no-validation', 'Option to disable the check for proto files')
+  .alias('no-validation', 'no_validation')
   .describe('output_dir', 'Path to a directory for the generated code')
   .alias('grpc-service-config', 'grpc_service_config')
   .describe('grpc-service-config', 'Path to gRPC service config JSON')
@@ -76,6 +78,7 @@ const packageName = argv.packageName as string | undefined;
 const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
+const noValidation = argv.noValidation as string | undefined;
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));
@@ -96,7 +99,7 @@ const protocCommand = [
   `--plugin=protoc-gen-typescript_gapic=${protocPlugin}`,
   `--typescript_gapic_out=${outputDir}`,
 ];
-if (gapicValidatorOut) {
+if (gapicValidatorOut && noValidation !== 'true') {
   protocCommand.push(`--gapic-validator_out=${gapicValidatorOut}`);
 }
 if (grpcServiceConfig) {

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -42,8 +42,10 @@ const argv = yargs
   .alias('output-dir', 'output_dir')
   .describe('gapic-validator_out', 'Path to the output of the gapic validator')
   .alias('gapic-validator_out', 'gapic_validator_out')
-  .describe('no-validation', 'Option to disable the check for proto files')
-  .alias('no-validation', 'no_validation')
+  .describe(
+    'validation',
+    'Option to set the validation of proto files, default value is true'
+  )
   .describe('output_dir', 'Path to a directory for the generated code')
   .alias('grpc-service-config', 'grpc_service_config')
   .describe('grpc-service-config', 'Path to gRPC service config JSON')
@@ -78,7 +80,7 @@ const packageName = argv.packageName as string | undefined;
 const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
-const noValidation = argv.noValidation as string | undefined;
+const validation = argv.validation as string | 'true';
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));
@@ -99,7 +101,7 @@ const protocCommand = [
   `--plugin=protoc-gen-typescript_gapic=${protocPlugin}`,
   `--typescript_gapic_out=${outputDir}`,
 ];
-if (gapicValidatorOut && noValidation !== 'true') {
+if (gapicValidatorOut && validation !== 'true') {
   protocCommand.push(`--gapic-validator_out=${gapicValidatorOut}`);
 }
 if (grpcServiceConfig) {


### PR DESCRIPTION
This is for `dialogflow` special, by default we should run validator for all proto files.