### PR TITLE
fix: fix the default value of validation option

### DIFF
--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -80,7 +80,7 @@ const packageName = argv.packageName as string | undefined;
 const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
-const validation = argv.validation as string | undefined;
+const validation = (argv.validation as string | undefined) ?? 'true';
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));
@@ -101,7 +101,7 @@ const protocCommand = [
   `--plugin=protoc-gen-typescript_gapic=${protocPlugin}`,
   `--typescript_gapic_out=${outputDir}`,
 ];
-if (gapicValidatorOut && (!validation || validation === 'true')) {
+if (gapicValidatorOut && validation === 'true') {
   protocCommand.push(`--gapic-validator_out=${gapicValidatorOut}`);
 }
 if (grpcServiceConfig) {

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -80,7 +80,7 @@ const packageName = argv.packageName as string | undefined;
 const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
-const validation = argv.validation as string | 'true';
+const validation = argv.validation as string | undefined;
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));
@@ -101,7 +101,7 @@ const protocCommand = [
   `--plugin=protoc-gen-typescript_gapic=${protocPlugin}`,
   `--typescript_gapic_out=${outputDir}`,
 ];
-if (gapicValidatorOut && validation === 'true') {
+if (gapicValidatorOut && (!validation || validation === 'true')) {
   protocCommand.push(`--gapic-validator_out=${gapicValidatorOut}`);
 }
 if (grpcServiceConfig) {


### PR DESCRIPTION
TWIL: `const validation = argv.validation as string | 'true';` is not setting the default value to be true.
`const validation = argv.validation ?? 'true';` does the job.