### PR TITLE
fix: use es2018 as a target

### DIFF
--- a/baselines/asset/tsconfig.json.baseline
+++ b/baselines/asset/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/bigquery-storage/tsconfig.json.baseline
+++ b/baselines/bigquery-storage/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/disable-packing-test/tsconfig.json.baseline
+++ b/baselines/disable-packing-test/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/dlp/tsconfig.json.baseline
+++ b/baselines/dlp/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/kms/tsconfig.json.baseline
+++ b/baselines/kms/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/logging/tsconfig.json.baseline
+++ b/baselines/logging/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/monitoring/tsconfig.json.baseline
+++ b/baselines/monitoring/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/redis/tsconfig.json.baseline
+++ b/baselines/redis/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/showcase/tsconfig.json.baseline
+++ b/baselines/showcase/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/tasks/tsconfig.json.baseline
+++ b/baselines/tasks/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/texttospeech/tsconfig.json.baseline
+++ b/baselines/texttospeech/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/translate/tsconfig.json.baseline
+++ b/baselines/translate/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/baselines/videointelligence/tsconfig.json.baseline
+++ b/baselines/videointelligence/tsconfig.json.baseline
@@ -5,7 +5,7 @@
     "outDir": "build",
     "resolveJsonModule": true,
     "lib": [
-      "es2016",
+      "es2018",
       "dom"
     ]
   },

--- a/templates/typescript_gapic/tsconfig.json.njk
+++ b/templates/typescript_gapic/tsconfig.json.njk
@@ -21,7 +21,7 @@ limitations under the License.
     "rootDir": ".",
     "outDir": "build",
     "resolveJsonModule": true,
-    "lib": ["es2016", "dom"]
+    "lib": ["es2018", "dom"]
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
Fixes #479 - we can now use `es2018` as a target for new libraries (all existing should already be at `es2018` after the Node 8 deprecation party).