### PR TITLE
chore: update gapic-config-validator version in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: verify error conformance
           command: |
-            curl -sSL https://github.com/googleapis/gapic-config-validator/releases/download/v0.5.0/gapic-config-validator-0.5.0-linux-amd64.tar.gz > config-validator.tar.gz
+            curl -sSL https://github.com/googleapis/gapic-config-validator/releases/download/v0.6.0/gapic-config-validator-0.6.0-linux-amd64.tar.gz > config-validator.tar.gz
             tar xzf config-validator.tar.gz --no-same-owner
             chmod +x gapic-error-conformance
             chmod +x bazel-bin/protoc_plugin.sh


### PR DESCRIPTION
Updates the version of the gapic-config-validator assets downloaded by CI. There were no changes to the `gapic-error-conformance` tool in this release.