### PR TITLE
fix: chmod protoc in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN npm install -g /root/files/package.tgz
 RUN cd /root/files && \
     wget https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip
 RUN cd /usr/local && unzip /root/files/protoc-3.12.3-linux-x86_64.zip
+RUN chmod -R ugo+rX /usr/local
+RUN chmod ugo+rx /usr/local/bin/protoc
 
 # Download a copy of API common protos
 RUN cd /root/files && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,6 +16,7 @@
 
 ### Prepare the package and run `docker build`
 
+set -e
 SCRIPTDIR=`dirname "$0"`
 cd "$SCRIPTDIR"
 cd ..   # now in the package.json directory

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -16,6 +16,7 @@
 
 ### Prepare the package and run `docker build`
 
+set -e
 SCRIPTDIR=`dirname "$0"`
 cd "$SCRIPTDIR"
 cd ..   # now in the package.json directory

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -16,6 +16,7 @@
 
 ### Prepare the package and run `docker build`
 
+set -e
 SCRIPTDIR=`dirname "$0"`
 cd "$SCRIPTDIR"
 cd ..   # now in the package.json directory
@@ -32,6 +33,7 @@ mkdir $DIR_NAME
 docker run --rm \
   --mount type=bind,source=`pwd`/test-fixtures/protos/google/showcase/v1beta1,destination=/in/google/showcase/v1beta1,readonly \
   --mount type=bind,source=`pwd`/$DIR_NAME,destination=/out \
+  --user $UID \
   gapic-generator-typescript:latest --validation false
 # Test generated client library
 cd $DIR_NAME


### PR DESCRIPTION
Fixes https://github.com/googleapis/synthtool/issues/605 - apparently, in the latest `protoc` (3.12.3) they lost an executable bit for "others" in their released zip archive. Added an extra `chmod` in our `Dockerfile` to make our Docker image work with `--user`.