### PR TITLE
chore(deps): use @types/node v14

### DIFF
--- a/baselines/asset/package.json
+++ b/baselines/asset/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/bigquery-storage/package.json
+++ b/baselines/bigquery-storage/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/disable-packing-test/package.json
+++ b/baselines/disable-packing-test/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/dlp/package.json
+++ b/baselines/dlp/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/kms/package.json
+++ b/baselines/kms/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/logging/package.json
+++ b/baselines/logging/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/monitoring/package.json
+++ b/baselines/monitoring/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/redis/package.json
+++ b/baselines/redis/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/showcase/package.json
+++ b/baselines/showcase/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/tasks/package.json
+++ b/baselines/tasks/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/texttospeech/package.json
+++ b/baselines/texttospeech/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/translate/package.json
+++ b/baselines/translate/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/baselines/videointelligence/package.json
+++ b/baselines/videointelligence/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/long": "^4.0.1",
     "@types/mocha": "^7.0.2",
     "@types/module-alias": "^2.0.0",
-    "@types/node": "^13.13.11",
+    "@types/node": "^14.0.12",
     "@types/nunjucks": "^3.1.3",
     "@types/object-hash": "^1.3.3",
     "@types/sinon": "^9.0.4",

--- a/templates/typescript_gapic/package.json
+++ b/templates/typescript_gapic/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.45",
+    "@types/node": "^14.0.12",
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.2",
     "gts": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,15 +254,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
   integrity sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==
 
-"@types/node@^13.13.11":
-  version "13.13.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.11.tgz#f8d2acb51f793bd5f4b07d9926bb5ce1dfb7a23e"
-  integrity sha512-FX7mIFKfnGCfq10DGWNhfCNxhACEeqH5uulT6wRRA1KEt7zgLe0HdrAd9/QQkObDqp2Z0KEV3OAmNgs0lTx5tQ==
-
 "@types/node@^13.7.0":
   version "13.13.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.9.tgz#79df4ae965fb76d31943b54a6419599307a21394"
   integrity sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==
+
+"@types/node@^14.0.12":
+  version "14.0.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.12.tgz#9c1d8ffb8084e8936603a6122a7649e40e68e04b"
+  integrity sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
For some unknown reason, we use `@types/node` v12 for the generated libraries, and v13 for the generator itself. There is no reason not to use v14 for everything and save on the number of Renovate PRs.