### PR TITLE
chore(deps): use @types/node v14 in test app

### DIFF
--- a/test-fixtures/test-application-ts/package.json
+++ b/test-fixtures/test-application-ts/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "gts": "^2.0.2",
     "typescript": "^3.9.5",
-    "@types/node": "^12.12.46",
+    "@types/node": "^14.0.12",
     "@types/mocha": "^7.0.2",
     "mocha": "^7.2.0",
     "karma": "^5.0.9",


### PR DESCRIPTION
When I bumped all `@types/node` versions yesterday in #556 I apparently missed this one.