### PR TITLE
fix: make plugin parameters work properly

### DIFF
--- a/rules_typescript_gapic/typescript_gapic.bzl
+++ b/rules_typescript_gapic/typescript_gapic.bzl
@@ -26,8 +26,6 @@ def typescript_gapic_library(
   extra_protoc_parameters = [],
   extra_protoc_file_parameters = {},
   **kwargs):
-  # Note: if extra parameters contain any of the named parameters, the behavior is undefined
-  # (up to the plugin implementation)
 
   plugin_args_dict = {}
   if package_name:
@@ -38,12 +36,16 @@ def typescript_gapic_library(
     plugin_args_dict["iam-service"] = iam_service
 
   file_args = {} # note: keys are filenames, values are parameter name, aligned with the prior art
+  for key, value in extra_protoc_file_parameters:
+    file_args[key] = value
   if grpc_service_config:
     file_args[grpc_service_config] = "grpc-service-config"
   if bundle_config:
     file_args[bundle_config] = "bundle-config"
 
-  plugin_args = extra_protoc_parameters
+  plugin_args = []
+  for parameter in extra_protoc_parameters:
+    plugin_args.append(parameter)
   for key, value in plugin_args_dict.items():
     plugin_args.append("{}={}".format(key, value))
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -79,10 +79,14 @@ export class Generator {
     const parameters = parameter.split(',');
     for (let param of parameters) {
       // remove double quote
-      param = param.substring(1, param.length - 1);
+      if (param[0] === '"' && param[param.length - 1] === '"') {
+        param = param.substring(1, param.length - 1);
+      }
       const arr = param.split('=');
       this.paramMap[arr[0].toKebabCase()] = arr[1];
     }
+    // Print the parameters to simplify transition to Bazel build.
+    console.warn('gapic-generator-typescript parameters:', this.paramMap);
   }
 
   private async readGrpcServiceConfig() {


### PR DESCRIPTION
Handling extra plugin parameters properly.

Also, adding a debug print to simplify transitioning from Docker containers to Bazel builds.