### PR TITLE
fix: do not log parameters

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -85,8 +85,6 @@ export class Generator {
       const arr = param.split('=');
       this.paramMap[arr[0].toKebabCase()] = arr[1];
     }
-    // Print the parameters to simplify transition to Bazel build.
-    console.warn('gapic-generator-typescript parameters:', this.paramMap);
   }
 
   private async readGrpcServiceConfig() {


### PR DESCRIPTION
Since we completed the Bazel migration, we don't need to log these parameters anymore. This logging makes the Kokoro build logs too verbose.