### PR TITLE
fix: properly use method descriptors in the generated client

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -38,7 +38,12 @@ export class AssetServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -232,12 +237,13 @@ export class AssetServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -40,7 +40,12 @@ export class BigQueryStorageClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   bigQueryStorageStub?: Promise<{[name: string]: Function}>;
@@ -211,12 +216,13 @@ export class BigQueryStorageClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.stream[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -44,7 +44,12 @@ export class EchoClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -272,12 +277,15 @@ export class EchoClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.stream[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -40,7 +40,12 @@ export class IdentityClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   identityStub?: Promise<{[name: string]: Function}>;
@@ -234,12 +239,13 @@ export class IdentityClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -43,7 +43,12 @@ export class MessagingClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -273,12 +278,15 @@ export class MessagingClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.stream[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -41,7 +41,12 @@ export class TestingClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   testingStub?: Promise<{[name: string]: Function}>;
@@ -237,12 +242,13 @@ export class TestingClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -48,7 +48,12 @@ export class DlpServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   dlpServiceStub?: Promise<{[name: string]: Function}>;
@@ -253,12 +258,13 @@ export class DlpServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -50,7 +50,12 @@ export class KeyManagementServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   iamClient: IamClient;
   keyManagementServiceStub?: Promise<{[name: string]: Function}>;
@@ -219,12 +224,13 @@ export class KeyManagementServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -40,7 +40,12 @@ export class ConfigServiceV2Client {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   configServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -280,12 +285,13 @@ export class ConfigServiceV2Client {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -40,7 +40,12 @@ export class LoggingServiceV2Client {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   loggingServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -236,7 +241,7 @@ export class LoggingServiceV2Client {
     // requests; denote this.
 
     this.descriptors.batching = {
-      WriteLogEntries: new this._gaxModule.BundleDescriptor(
+      writeLogEntries: new this._gaxModule.BundleDescriptor(
         'entries',
         ['log_name','resource','labels'],
         null,
@@ -301,12 +306,14 @@ export class LoggingServiceV2Client {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.batching[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -40,7 +40,12 @@ export class MetricsServiceV2Client {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   metricsServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -273,12 +278,13 @@ export class MetricsServiceV2Client {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -48,7 +48,12 @@ export class AlertPolicyServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   alertPolicyServiceStub?: Promise<{[name: string]: Function}>;
@@ -287,12 +292,13 @@ export class AlertPolicyServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -51,7 +51,12 @@ export class GroupServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   groupServiceStub?: Promise<{[name: string]: Function}>;
@@ -292,12 +297,13 @@ export class GroupServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -41,7 +41,12 @@ export class MetricServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   metricServiceStub?: Promise<{[name: string]: Function}>;
@@ -302,12 +307,13 @@ export class MetricServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -41,7 +41,12 @@ export class NotificationChannelServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   notificationChannelServiceStub?: Promise<{[name: string]: Function}>;
@@ -282,12 +287,13 @@ export class NotificationChannelServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -43,7 +43,12 @@ export class ServiceMonitoringServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   serviceMonitoringServiceStub?: Promise<{[name: string]: Function}>;
@@ -284,12 +289,13 @@ export class ServiceMonitoringServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -47,7 +47,12 @@ export class UptimeCheckServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   uptimeCheckServiceStub?: Promise<{[name: string]: Function}>;
@@ -288,12 +293,13 @@ export class UptimeCheckServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -54,7 +54,12 @@ export class CloudRedisClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -293,12 +298,14 @@ export class CloudRedisClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -44,7 +44,12 @@ export class EchoClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -272,12 +277,15 @@ export class EchoClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.stream[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -40,7 +40,12 @@ export class IdentityClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   identityStub?: Promise<{[name: string]: Function}>;
@@ -234,12 +239,13 @@ export class IdentityClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -43,7 +43,12 @@ export class MessagingClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -273,12 +278,15 @@ export class MessagingClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.stream[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -41,7 +41,12 @@ export class TestingClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   testingStub?: Promise<{[name: string]: Function}>;
@@ -237,12 +242,13 @@ export class TestingClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -41,7 +41,12 @@ export class CloudTasksClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   cloudTasksStub?: Promise<{[name: string]: Function}>;
@@ -216,12 +221,13 @@ export class CloudTasksClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -38,7 +38,12 @@ export class TextToSpeechClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   textToSpeechStub?: Promise<{[name: string]: Function}>;
 
@@ -190,12 +195,12 @@ export class TextToSpeechClient {
           throw err;
         });
 
+      const descriptor =
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -40,7 +40,12 @@ export class TranslationServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -255,12 +260,14 @@ export class TranslationServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.page[methodName] ||
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -38,7 +38,12 @@ export class VideoIntelligenceServiceClient {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
   videoIntelligenceServiceStub?: Promise<{[name: string]: Function}>;
@@ -216,12 +221,13 @@ export class VideoIntelligenceServiceClient {
           throw err;
         });
 
+      const descriptor =
+        this.descriptors.longrunning[methodName] ||
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -50,7 +50,12 @@ export class {{ service.name }}Client {
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}, batching: {}};
+  descriptors: Descriptors = {
+    page: {},
+    stream: {},
+    longrunning: {},
+    batching: {},
+  };
   innerApiCalls: {[name: string]: Function};
   {%- if service.iamService > 0 %}
   iamClient: IamClient;
@@ -236,7 +241,7 @@ export class {{ service.name }}Client {
 
     this.descriptors.batching = {
 {%- for method in service.bundleConfigsMethods %}
-      {{ method.name }}: new this._gaxModule.BundleDescriptor(
+      {{ method.name.toCamelCase() }}: new this._gaxModule.BundleDescriptor(
         '{{ method.bundleConfig.batchDescriptor.batched_field }}',
         [
 {%- set pagingJoiner = joiner() -%}
@@ -319,12 +324,24 @@ export class {{ service.name }}Client {
           throw err;
         });
 
+      const descriptor =
+{%- if service.paging.length > 0 %}
+        this.descriptors.page[methodName] ||
+{%- endif %}
+{%- if service.streaming.length > 0 %}
+        this.descriptors.stream[methodName] ||
+{%- endif %}
+{%- if service.longRunning.length > 0 %}
+        this.descriptors.longrunning[methodName] ||
+{%- endif %}
+{%- if service.bundleConfigs.length > 0 %}
+        this.descriptors.batching[methodName] ||
+{%- endif %}
+        undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        this.descriptors.page[methodName] ||
-            this.descriptors.stream[methodName] ||
-            this.descriptors.longrunning[methodName]
+        descriptor
       );
 
       this.innerApiCalls[methodName] = apiCall;


### PR DESCRIPTION
Apparently, the batching implementation in gapic-generator-typescript never actually worked because of two things:
- wrong (not camelized) method name in the descriptors object;
- the batching descriptor was never passed to gax.

This was reported by a customer in https://github.com/googleapis/nodejs-logging/issues/835. 

Looks like we don't have any test coverage for batching functionality in logging (I submitted https://github.com/googleapis/nodejs-logging/issues/870). This kind of explains the problem :) if a feature is not covered by any working integration test, we can never be sure the feature actually works.

This PR is the first step (making it work properly in the generator). The next step would be to cover this by a test in logging library.