### PR TITLE
fix: make batching descriptor compile

### DIFF
--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -308,7 +308,7 @@ export class LoggingServiceV2Client {
 
       const descriptor =
         this.descriptors.page[methodName] ||
-        this.descriptors.batching[methodName] ||
+        this.descriptors.batching?.[methodName] ||
         undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -335,7 +335,7 @@ export class {{ service.name }}Client {
         this.descriptors.longrunning[methodName] ||
 {%- endif %}
 {%- if service.bundleConfigs.length > 0 %}
-        this.descriptors.batching[methodName] ||
+        this.descriptors.batching?.[methodName] ||
 {%- endif %}
         undefined;
       const apiCall = this._gaxModule.createApiCall(


### PR DESCRIPTION
Apparently, `batching` can be undefined [here](https://github.com/googleapis/gax-nodejs/blob/master/src/clientInterface.ts#L46) (it was done this way for compatibility reasons), so we need to use `?.` to access it in the generated code.

This time, I completely checked it locally end to end, without cutting any corners, so it should finally work as intended.