### PR TITLE
fix: allow trailing segments after version in package name

### DIFF
--- a/test/unit/naming.ts
+++ b/test/unit/naming.ts
@@ -63,6 +63,21 @@ describe('src/schema/naming.ts', () => {
     assert.strictEqual(naming.protoPackage, 'company.service.v1beta1');
   });
 
+  it('ignores everything after the version', () => {
+    const descriptor1 = new protos.google.protobuf.FileDescriptorProto();
+    descriptor1.package = 'company.service.v1beta1.unexpected';
+    descriptor1.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    const naming = new Naming([descriptor1]);
+    assert.strictEqual(naming.name, 'Service');
+    assert.strictEqual(naming.productName, 'Service');
+    assert.deepStrictEqual(naming.namespace, ['company']);
+    assert.strictEqual(naming.version, 'v1beta1');
+    assert.strictEqual(
+      naming.protoPackage,
+      'company.service.v1beta1.unexpected'
+    );
+  });
+
   it('ignores files with no services when determining package name', () => {
     const descriptor1 = new protos.google.protobuf.FileDescriptorProto();
     const descriptor2 = new protos.google.protobuf.FileDescriptorProto();


### PR DESCRIPTION
Ads protos have all services residing under `"google.ads.googleads.v4.services"` (see [here](https://github.com/googleapis/googleapis/blob/master/google/ads/googleads/v4/services/account_budget_proposal_service.proto#L17)) and having this `services` segment after the version apparently breaks the current naming heuristics.

Fixing that so that whenever a segment matching a possible version is found, everything after it is ignored for the naming purposes.

Cc: @lukesneeringer (since I largely taken the naming logic from your original Python implementation)
Cc: @aohren - FYI, this is the first of 2 PRs that will make Ads TypeScript work. The second one is coming.