### PR TITLE
feat: reduce possibility of name conflicts

### DIFF
--- a/baselines/naming/protos/google/naming/v1beta1/naming.proto.baseline
+++ b/baselines/naming/protos/google/naming/v1beta1/naming.proto.baseline
@@ -112,21 +112,6 @@ service Naming {
       body: "*"
     };
   }
-
-  // Problem #4: RPCs that conflict with TypeScript reserved words
-  rpc Function(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      post: "/v1beta1/naming:function"
-      body: "*"
-    };
-  }
-
-  rpc Constructor(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      post: "/v1beta1/naming:constructor"
-      body: "*"
-    };
-  }
 }
 
 message PaginatedMethodRequest {

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -82,8 +82,8 @@ export class NamingClient {
     const servicePath = opts && opts.servicePath ?
         opts.servicePath :
         ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+                                      staticMembers.servicePath1);
+    const port = opts && opts.port ? opts.port : staticMembers.port1;
 
     if (!opts) {
       opts = {servicePath, port};
@@ -107,10 +107,10 @@ export class NamingClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    opts.scopes = (this.constructor as typeof NamingClient).scopes;
+    opts.scopes = (this.constructor as typeof NamingClient).scopes1;
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
-    // Save options to use in initialize() method.
+    // Save options to use in initialize1() method.
     this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
@@ -193,13 +193,13 @@ export class NamingClient {
    * Performs asynchronous operations (such as authentication) and prepares the client.
    * This function will be called automatically when any class method is called for the
    * first time, but if you need to initialize it before calling an actual method,
-   * feel free to call initialize() directly.
+   * feel free to call initialize1() directly.
    *
    * You can await on this method if you want to make sure the client is initialized.
    *
    * @returns {Promise} A promise that resolves to an authenticated service stub.
    */
-  initialize() {
+  initialize1() {
     // If the client stub promise is already initialized, return immediately.
     if (this.namingStub) {
       return this.namingStub;
@@ -217,7 +217,7 @@ export class NamingClient {
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
     const namingStubMethods =
-        ['paginatedMethod', 'paginatedMethodStream', 'paginatedMethodAsync', 'longRunning', 'checkLongRunningProgress', 'initialize', 'servicePath', 'apiEndpoint', 'port', 'scopes', 'getProjectId', 'function', 'constructor'];
+        ['paginatedMethod', 'paginatedMethodStream', 'paginatedMethodAsync', 'longRunning', 'checkLongRunningProgress', 'initialize', 'servicePath', 'apiEndpoint', 'port', 'scopes', 'getProjectId'];
     for (const methodName of namingStubMethods) {
       const callPromise = this.namingStub.then(
         stub => (...args: Array<{}>) => {
@@ -250,22 +250,22 @@ export class NamingClient {
   /**
    * The DNS address for this API service.
    */
-  static get servicePath() {
+  static get servicePath1() {
     return 'localhost';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as servicePath1(),
    * exists for compatibility reasons.
    */
-  static get apiEndpoint() {
+  static get apiEndpoint1() {
     return 'localhost';
   }
 
   /**
    * The port for this API service.
    */
-  static get port() {
+  static get port1() {
     return 1234;
   }
 
@@ -273,18 +273,18 @@ export class NamingClient {
    * The scopes needed to make gRPC calls for every method defined
    * in this service.
    */
-  static get scopes() {
+  static get scopes1() {
     return [];
   }
 
-  getProjectId(): Promise<string>;
-  getProjectId(callback: Callback<string, undefined, undefined>): void;
+  getProjectId1(): Promise<string>;
+  getProjectId1(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
    *   be called with the current project Id.
    */
-  getProjectId(callback?: Callback<string, undefined, undefined>):
+  getProjectId1(callback?: Callback<string, undefined, undefined>):
       Promise<string>|void {
     if (callback) {
       this.auth.getProjectId(callback);
@@ -350,7 +350,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.paginatedMethodStream(request, options, callback);
   }
   paginatedMethodAsync(
@@ -407,7 +407,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.paginatedMethodAsync(request, options, callback);
   }
   checkLongRunningProgress(
@@ -464,7 +464,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.checkLongRunningProgress(request, options, callback);
   }
   initialize(
@@ -522,7 +522,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.initialize(request, options, callback);
   }
   servicePath(
@@ -579,7 +579,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.servicePath(request, options, callback);
   }
   apiEndpoint(
@@ -636,7 +636,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.apiEndpoint(request, options, callback);
   }
   port(
@@ -693,7 +693,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.port(request, options, callback);
   }
   scopes(
@@ -750,7 +750,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.scopes(request, options, callback);
   }
   getProjectId(
@@ -807,123 +807,8 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.getProjectId(request, options, callback);
-  }
-  function(
-      request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.protobuf.IEmpty|undefined, {}|undefined
-      ]>;
-  function(
-      request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>): void;
-  function(
-      request: protos.google.protobuf.IEmpty,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>): void;
-/**
- * Problem #4: RPCs that conflict with TypeScript reserved words
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- */
-  function(
-      request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>,
-      callback?: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.protobuf.IEmpty|undefined, {}|undefined
-      ]>|void {
-    request = request || {};
-    let options: gax.CallOptions;
-    if (typeof optionsOrCallback === 'function' && callback === undefined) {
-      callback = optionsOrCallback;
-      options = {};
-    }
-    else {
-      options = optionsOrCallback as gax.CallOptions;
-    }
-    options = options || {};
-    this.initialize();
-    return this.innerApiCalls.function(request, options, callback);
-  }
-  constructor(
-      request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.protobuf.IEmpty|undefined, {}|undefined
-      ]>;
-  constructor(
-      request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>): void;
-  constructor(
-      request: protos.google.protobuf.IEmpty,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- */
-  constructor(
-      request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>,
-      callback?: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.protobuf.IEmpty|null|undefined,
-          {}|null|undefined>):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.protobuf.IEmpty|undefined, {}|undefined
-      ]>|void {
-    request = request || {};
-    let options: gax.CallOptions;
-    if (typeof optionsOrCallback === 'function' && callback === undefined) {
-      callback = optionsOrCallback;
-      options = {};
-    }
-    else {
-      options = optionsOrCallback as gax.CallOptions;
-    }
-    options = options || {};
-    this.initialize();
-    return this.innerApiCalls.constructor(request, options, callback);
   }
 
   longRunning(
@@ -981,7 +866,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.longRunning(request, options, callback);
   }
 /**
@@ -992,13 +877,13 @@ export class NamingClient {
  *   The decoded operation object has result and metadata field to get information from.
  *
  * @example:
- *   const decodedOperation = await checkLongRunningProgress(name);
+ *   const decodedOperation = await checkLongRunningProgress1(name);
  *   console.log(decodedOperation.result);
  *   console.log(decodedOperation.done);
  *   console.log(decodedOperation.metadata);
  *
  */
-  async checkLongRunningProgress(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>>{
+  async checkLongRunningProgress1(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.longRunning, gax.createDefaultBackoffSettings());
@@ -1077,7 +962,7 @@ export class NamingClient {
       options = optionsOrCallback as gax.CallOptions;
     }
     options = options || {};
-    this.initialize();
+    this.initialize1();
     return this.innerApiCalls.paginatedMethod(request, options, callback);
   }
 
@@ -1104,14 +989,14 @@ export class NamingClient {
  * @returns {Stream}
  *   An object stream which emits an object representing [Empty]{@link google.protobuf.Empty} on 'data' event.
  */
-  paginatedMethodStream(
+  paginatedMethodStream1(
       request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
       options?: gax.CallOptions):
     Transform{
     request = request || {};
     options = options || {};
     const callSettings = new gax.CallSettings(options);
-    this.initialize();
+    this.initialize1();
     return this.descriptors.page.paginatedMethod.createStream(
       this.innerApiCalls.paginatedMethod as gax.GaxCall,
       request,
@@ -1134,7 +1019,7 @@ export class NamingClient {
  * @returns {Object}
  *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
  */
-  paginatedMethodAsync(
+  paginatedMethodAsync1(
       request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
       options?: gax.CallOptions):
     AsyncIterable<protos.google.protobuf.IEmpty>{
@@ -1142,7 +1027,7 @@ export class NamingClient {
     options = options || {};
     options = options || {};
     const callSettings = new gax.CallSettings(options);
-    this.initialize();
+    this.initialize1();
     return this.descriptors.page.paginatedMethod.asyncIterate(
       this.innerApiCalls['paginatedMethod'] as GaxCall,
       request as unknown as RequestType,
@@ -1156,7 +1041,7 @@ export class NamingClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
-    this.initialize();
+    this.initialize1();
     if (!this._terminated) {
       return this.namingStub!.then(stub => {
         this._terminated = true;

--- a/baselines/naming/src/v1beta1/naming_client_config.json.baseline
+++ b/baselines/naming/src/v1beta1/naming_client_config.json.baseline
@@ -63,14 +63,6 @@
         "getProjectId": {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
-        },
-        "Function": {
-          "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
-        },
-        "Constructor": {
-          "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
         }
       }
     }

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -104,17 +104,17 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('v1beta1.NamingClient', () => {
     it('has servicePath', () => {
-        const servicePath = namingModule.v1beta1.NamingClient.servicePath;
+        const servicePath = namingModule.v1beta1.NamingClient.servicePath1;
         assert(servicePath);
     });
 
     it('has apiEndpoint', () => {
-        const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint;
+        const apiEndpoint = namingModule.v1beta1.NamingClient.apiEndpoint1;
         assert(apiEndpoint);
     });
 
     it('has port', () => {
-        const port = namingModule.v1beta1.NamingClient.port;
+        const port = namingModule.v1beta1.NamingClient.port1;
         assert(port);
         assert(typeof port === 'number');
     });
@@ -137,7 +137,7 @@ describe('v1beta1.NamingClient', () => {
             projectId: 'bogus',
         });
         assert.strictEqual(client.namingStub, undefined);
-        await client.initialize();
+        await client.initialize1();
         assert(client.namingStub);
     });
 
@@ -156,7 +156,7 @@ describe('v1beta1.NamingClient', () => {
             projectId: 'bogus',
         });
         client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
-        const result = await client.getProjectId();
+        const result = await client.getProjectId1();
         assert.strictEqual(result, fakeProjectId);
         assert((client.auth.getProjectId as SinonStub).calledWithExactly());
     });
@@ -169,7 +169,7 @@ describe('v1beta1.NamingClient', () => {
         });
         client.auth.getProjectId = sinon.stub().callsArgWith(0, null, fakeProjectId);
         const promise = new Promise((resolve, reject) => {
-            client.getProjectId((err?: Error|null, projectId?: string|null) => {
+            client.getProjectId1((err?: Error|null, projectId?: string|null) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -187,7 +187,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -203,7 +203,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -230,7 +230,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -247,7 +247,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -263,7 +263,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -290,7 +290,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -307,7 +307,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -323,7 +323,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -350,7 +350,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -367,7 +367,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -383,7 +383,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -410,7 +410,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -427,7 +427,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -443,7 +443,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -470,7 +470,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -487,7 +487,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -503,7 +503,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -530,7 +530,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -547,7 +547,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -563,7 +563,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -590,7 +590,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -607,7 +607,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -623,7 +623,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -650,7 +650,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -667,7 +667,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -683,7 +683,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
@@ -710,7 +710,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -721,133 +721,13 @@ describe('v1beta1.NamingClient', () => {
         });
     });
 
-    describe('function', () => {
-        it('invokes function without error', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.function = stubSimpleCall(expectedResponse);
-            const [response] = await client.function(request);
-            assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.function as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
-        });
-
-        it('invokes function without error using callback', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.function = stubSimpleCallWithCallback(expectedResponse);
-            const promise = new Promise((resolve, reject) => {
-                 client.function(
-                    request,
-                    (err?: Error|null, result?: protos.google.protobuf.IEmpty|null) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
-                    });
-            });
-            const response = await promise;
-            assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.function as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
-        });
-
-        it('invokes function with error', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedError = new Error('expected');
-            client.innerApiCalls.function = stubSimpleCall(undefined, expectedError);
-            await assert.rejects(client.function(request), expectedError);
-            assert((client.innerApiCalls.function as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
-        });
-    });
-
-    describe('constructor', () => {
-        it('invokes constructor without error', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.constructor = stubSimpleCall(expectedResponse);
-            const [response] = await client.constructor(request);
-            assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.constructor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
-        });
-
-        it('invokes constructor without error using callback', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.constructor = stubSimpleCallWithCallback(expectedResponse);
-            const promise = new Promise((resolve, reject) => {
-                 client.constructor(
-                    request,
-                    (err?: Error|null, result?: protos.google.protobuf.IEmpty|null) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
-                    });
-            });
-            const response = await promise;
-            assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.constructor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
-        });
-
-        it('invokes constructor with error', async () => {
-            const client = new namingModule.v1beta1.NamingClient({
-                credentials: {client_email: 'bogus', private_key: 'bogus'},
-                projectId: 'bogus',
-            });
-            client.initialize();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {};
-            const expectedError = new Error('expected');
-            client.innerApiCalls.constructor = stubSimpleCall(undefined, expectedError);
-            await assert.rejects(client.constructor(request), expectedError);
-            assert((client.innerApiCalls.constructor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
-        });
-    });
-
     describe('longRunning', () => {
         it('invokes longRunning without error', async () => {
             const client = new namingModule.v1beta1.NamingClient({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
@@ -864,7 +744,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
@@ -894,7 +774,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -909,7 +789,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -920,34 +800,34 @@ describe('v1beta1.NamingClient', () => {
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
-        it('invokes checkLongRunningProgress without error', async () => {
+        it('invokes checkLongRunningProgress1 without error', async () => {
             const client = new namingModule.v1beta1.NamingClient({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
 
             client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
-            const decodedOperation = await client.checkLongRunningProgress(expectedResponse.name);
+            const decodedOperation = await client.checkLongRunningProgress1(expectedResponse.name);
             assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
             assert(decodedOperation.metadata);
             assert((client.operationsClient.getOperation as SinonStub).getCall(0));
         });
 
-        it('invokes checkLongRunningProgress with error', async () => {
+        it('invokes checkLongRunningProgress1 with error', async () => {
             const client = new namingModule.v1beta1.NamingClient({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const expectedError = new Error('expected');
 
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
-            await assert.rejects(client.checkLongRunningProgress(''), expectedError);
+            await assert.rejects(client.checkLongRunningProgress1(''), expectedError);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0));
         });
@@ -959,7 +839,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
             const expectedResponse = [
@@ -979,7 +859,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
             const expectedResponse = [
@@ -1010,7 +890,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
             const expectedError = new Error('expected');
@@ -1020,12 +900,12 @@ describe('v1beta1.NamingClient', () => {
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
-        it('invokes paginatedMethodStream without error', async () => {
+        it('invokes paginatedMethodStream1 without error', async () => {
             const client = new namingModule.v1beta1.NamingClient({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1033,7 +913,7 @@ describe('v1beta1.NamingClient', () => {
               generateSampleMessage(new protos.google.protobuf.Empty()),
             ];
             client.descriptors.page.paginatedMethod.createStream = stubPageStreamingCall(expectedResponse);
-            const stream = client.paginatedMethodStream(request);
+            const stream = client.paginatedMethodStream1(request);
             const promise = new Promise((resolve, reject) => {
                 const responses: protos.google.protobuf.Empty[] = [];
                 stream.on('data', (response: protos.google.protobuf.Empty) => {
@@ -1052,16 +932,16 @@ describe('v1beta1.NamingClient', () => {
                 .getCall(0).calledWith(client.innerApiCalls.paginatedMethod, request));
         });
 
-        it('invokes paginatedMethodStream with error', async () => {
+        it('invokes paginatedMethodStream1 with error', async () => {
             const client = new namingModule.v1beta1.NamingClient({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.createStream = stubPageStreamingCall(undefined, expectedError);
-            const stream = client.paginatedMethodStream(request);
+            const stream = client.paginatedMethodStream1(request);
             const promise = new Promise((resolve, reject) => {
                 const responses: protos.google.protobuf.Empty[] = [];
                 stream.on('data', (response: protos.google.protobuf.Empty) => {
@@ -1084,7 +964,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1092,7 +972,7 @@ describe('v1beta1.NamingClient', () => {
             ];
             client.descriptors.page.paginatedMethod.asyncIterate = stubAsyncIterationCall(expectedResponse);
             const responses: protos.google.protobuf.IEmpty[] = [];
-            const iterable = client.paginatedMethodAsync(request);
+            const iterable = client.paginatedMethodAsync1(request);
             for await (const resource of iterable) {
                 responses.push(resource!);
             }
@@ -1107,10 +987,10 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
-            const iterable = client.paginatedMethodAsync(request);
+            const iterable = client.paginatedMethodAsync1(request);
             await assert.rejects(async () => {
                 const responses: protos.google.protobuf.IEmpty[] = [];
                 for await (const resource of iterable) {

--- a/templates/typescript_gapic/_namer.njk
+++ b/templates/typescript_gapic/_namer.njk
@@ -1,0 +1,24 @@
+{#-
+
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-#}
+
+{%- macro initialize(id, service) -%}
+{#- All method names from the given service are reserved -#}
+{%- for method in service.method -%}
+  {{- id.register(method.name.toCamelCase()) -}}
+{%- endfor -%}
+{%- endmacro -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -26,7 +26,7 @@ limitations under the License.
   {{- printReturn(method, service) }}
 {%- endmacro %}
 
-{%- macro printDecodeMethodComments(method) %}
+{%- macro printDecodeMethodComments(method, decodeMethodName) %}
  * Check the status of the long running operation returned by the {{ method.name.toCamelCase() }}() method.
  * @param {String} name
  *   The operation name that will be passed.
@@ -34,7 +34,7 @@ limitations under the License.
  *   The decoded operation object has result and metadata field to get information from.
  *
  * @example:
- *   const decodedOperation = await check{{ method.name.toPascalCase() }}Progress(name);
+ *   const decodedOperation = await {{ decodeMethodName }}(name);
  *   console.log(decodedOperation.result);
  *   console.log(decodedOperation.done);
  *   console.log(decodedOperation.metadata);

--- a/templates/typescript_gapic/namer.js
+++ b/templates/typescript_gapic/namer.js
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This helper file must export two functions that will be passed to
+ * the template engine.  The purpose of these functions is to perform
+ * name conflicts resolution that cannot be handled in the generator
+ * TypeScript code (since the generator does not know anything about
+ * the generated names), so the only place where this can happen is
+ * the template engine.
+ */
+
+/**
+ * Initialize local names storage.
+ */
+function initialize() {
+  if (typeof get.names === "undefined") {
+    get.names = new Set();
+  }
+}
+
+/**
+ * Generate a valid method name based on the given requested name.
+ *
+ * @param {string} name The original name to base on.
+ * @returns A generated name that should not have conflicts with known
+ * predefined names.
+ */
+function get(name) {
+  initialize();
+
+  let counter = 0;
+  let newName = name;
+  while (get.names.has(newName)) {
+    ++counter;
+    newName = `${name}${counter}`;
+  }
+
+  return newName;
+}
+
+/**
+ * Register the given reserved name.
+ *
+ * @param {string} name Reserved name that should not be used.
+ * @returns {string} Empty string (so it can be safely used in templates).
+ */
+function register(name) {
+  initialize();
+
+  get.names.add(name);
+  return '';
+}
+
+module.exports = {register, get};

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -19,6 +19,8 @@ limitations under the License.
 {{license.license(commonParameters.copyrightYear)}}
 {% import "../../_util.njk" as util -%}
 {% import "../../_iam.njk" as iam -%}
+{% import "../../_namer.njk" as namer -%}
+{{- namer.initialize(id, service) -}}
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions
 {%- if service.longRunning.length > 0 %}, LROperation{%- endif -%}
@@ -100,8 +102,8 @@ export class {{ service.name }}Client {
     const servicePath = opts && opts.servicePath ?
         opts.servicePath :
         ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+                                      staticMembers.{{ id.get("servicePath") }});
+    const port = opts && opts.port ? opts.port : staticMembers.{{ id.get("port") }};
 
     if (!opts) {
       opts = {servicePath, port};
@@ -119,10 +121,12 @@ export class {{ service.name }}Client {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    opts.scopes = (this.constructor as typeof {{ service.name }}Client).scopes;
+    {#- TODO: replace the following line with `opts.scopes = staticMembers.{{ id.get("scopes") }};` #}
+    {#- (it will change the code for all libraries, we'll leave it unchanged for now) #}
+    opts.scopes = (this.constructor as typeof {{ service.name }}Client).{{ id.get("scopes") }};
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
-    // Save options to use in initialize() method.
+    // Save options to use in {{ id.get("initialize") }}() method.
     this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
@@ -280,13 +284,13 @@ export class {{ service.name }}Client {
    * Performs asynchronous operations (such as authentication) and prepares the client.
    * This function will be called automatically when any class method is called for the
    * first time, but if you need to initialize it before calling an actual method,
-   * feel free to call initialize() directly.
+   * feel free to call {{ id.get("initialize") }}() directly.
    *
    * You can await on this method if you want to make sure the client is initialized.
    *
    * @returns {Promise} A promise that resolves to an authenticated service stub.
    */
-  initialize() {
+  {{ id.get("initialize") }}() {
     // If the client stub promise is already initialized, return immediately.
     if (this.{{ service.name.toCamelCase() }}Stub) {
       return this.{{ service.name.toCamelCase() }}Stub;
@@ -353,22 +357,22 @@ export class {{ service.name }}Client {
   /**
    * The DNS address for this API service.
    */
-  static get servicePath() {
+  static get {{ id.get("servicePath") }}() {
     return '{{ api.hostName }}';
   }
 
   /**
-   * The DNS address for this API service - same as servicePath(),
+   * The DNS address for this API service - same as {{ id.get("servicePath") }}(),
    * exists for compatibility reasons.
    */
-  static get apiEndpoint() {
+  static get {{ id.get("apiEndpoint") }}() {
     return '{{ api.hostName }}';
   }
 
   /**
    * The port for this API service.
    */
-  static get port() {
+  static get {{ id.get("port") }}() {
     return {{ api.port }};
   }
 
@@ -376,7 +380,7 @@ export class {{ service.name }}Client {
    * The scopes needed to make gRPC calls for every method defined
    * in this service.
    */
-  static get scopes() {
+  static get {{ id.get("scopes") }}() {
 {%- if (service.oauthScopes.length == 0) %}
     return [];
 {%- else %}
@@ -390,14 +394,14 @@ export class {{ service.name }}Client {
 {%- endif %}
   }
 
-  getProjectId(): Promise<string>;
-  getProjectId(callback: Callback<string, undefined, undefined>): void;
+  {{ id.get("getProjectId") }}(): Promise<string>;
+  {{ id.get("getProjectId") }}(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
    *   be called with the current project Id.
    */
-  getProjectId(callback?: Callback<string, undefined, undefined>):
+  {{ id.get("getProjectId") }}(callback?: Callback<string, undefined, undefined>):
       Promise<string>|void {
     if (callback) {
       this.auth.getProjectId(callback);
@@ -458,7 +462,7 @@ export class {{ service.name }}Client {
       options = optionsOrCallback as gax.CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 {%- endfor %}
@@ -470,7 +474,7 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       options?: gax.CallOptions):
     gax.CancellableStream {
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(options);
   }
 {%- elif method.serverStreaming %}
@@ -483,7 +487,7 @@ export class {{ service.name }}Client {
     gax.CancellableStream{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options);
   }
 {%- elif method.clientStreaming %}
@@ -518,7 +522,7 @@ export class {{ service.name }}Client {
         optionsOrCallback = {};
     }
     const options = optionsOrCallback as gax.CallOptions;
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(null, options, callback);
   }
 {%- endif %}
@@ -571,13 +575,14 @@ export class {{ service.name }}Client {
       options = optionsOrCallback as gax.CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 /**
-{{- util.printDecodeMethodComments(method) }}
+{%- set decodeMethodName = id.get("check" + method.name.toPascalCase() + "Progress") -%}
+{{- util.printDecodeMethodComments(method, decodeMethodName) }}
  */
-  async check{{ method.name.toPascalCase() }}Progress(name: string): Promise<LROperation<protos{{ method.longRunningResponseType }}, protos{{ method.longRunningMetadataType }}>>{
+  async {{ decodeMethodName }}(name: string): Promise<LROperation<protos{{ method.longRunningResponseType }}, protos{{ method.longRunningMetadataType }}>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.{{ method.name.toCamelCase() }}, gax.createDefaultBackoffSettings());
@@ -634,21 +639,21 @@ export class {{ service.name }}Client {
       options = optionsOrCallback as gax.CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
 
 /**
 {{- util.printCommentsPageStream(method) }}
  */
-  {{ method.name.toCamelCase() }}Stream(
+  {{ id.get(method.name.toCamelCase() + "Stream") }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
     Transform{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
     const callSettings = new gax.CallSettings(options);
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.descriptors.page.{{ method.name.toCamelCase() }}.createStream(
       this.innerApiCalls.{{ method.name.toCamelCase() }} as gax.GaxCall,
       request,
@@ -659,7 +664,7 @@ export class {{ service.name }}Client {
 /**
 {{- util.printCommentsPageAsync(method) }}
  */
-  {{ method.name.toCamelCase() }}Async(
+  {{ id.get(method.name.toCamelCase() + "Async") }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: gax.CallOptions):
     AsyncIterable<{{ util.toInterface(method.pagingResponseType) }}>{
@@ -667,7 +672,7 @@ export class {{ service.name }}Client {
     {{ util.buildHeaderRequestParam(method) }}
     options = options || {};
     const callSettings = new gax.CallSettings(options);
-    this.initialize();
+    this.{{ id.get("initialize") }}();
     return this.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate(
       this.innerApiCalls['{{ method.name.toCamelCase() }}'] as GaxCall,
       request as unknown as RequestType,
@@ -692,7 +697,7 @@ export class {{ service.name }}Client {
 {%- endfor %}
    * @returns {string} Resource name string.
    */
-  {{ template.name.toCamelCase() }}Path(
+  {{ id.get(template.name.toCamelCase() + "Path") }}(
 {%- set paramJoiner = joiner() %}
 {%- for param in template.params %}
 {{-paramJoiner()-}}{{ param.toCamelCase() }}:string
@@ -713,7 +718,7 @@ export class {{ service.name }}Client {
    *   A fully-qualified path representing {{ template.name }} resource.
    * @returns {string} A string representing the {{ param }}.
    */
-  match{{ param.toPascalCase() }}From{{ template.name.toPascalCase() }}Name({{ template.name.toCamelCase() }}Name: string) {
+  {{ id.get("match" + param.toPascalCase() + "From" + template.name.toPascalCase() + "Name") }}({{ template.name.toCamelCase() }}Name: string) {
     return this.pathTemplates.{{ template.name.toCamelCase() }}PathTemplate.match({{ template.name.toCamelCase() }}Name).{{ param }};
   }
 {%- endfor %}
@@ -725,8 +730,8 @@ export class {{ service.name }}Client {
    *
    * The client will no longer be usable and all future behavior is undefined.
    */
-  close(): Promise<void> {
-    this.initialize();
+  {{ id.get("close") }}(): Promise<void> {
+    this.{{ id.get("initialize") }}();
     if (!this._terminated) {
       return this.{{ service.name.toCamelCase() }}Stub!.then(stub => {
         this._terminated = true;

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -18,6 +18,8 @@ limitations under the License.
 {% import "../_license.njk" as license -%}
 {% import "../_util.njk" as util -%}
 {{license.license(commonParameters.copyrightYear)}}
+{% import "../_namer.njk" as namer -%}
+{{- namer.initialize(id, service) -}}
 import * as protos from '../protos/protos';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -156,17 +158,17 @@ function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?
 
 describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
     it('has servicePath', () => {
-        const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.servicePath;
+        const servicePath = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("servicePath") }};
         assert(servicePath);
     });
 
     it('has apiEndpoint', () => {
-        const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.apiEndpoint;
+        const apiEndpoint = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("apiEndpoint") }};
         assert(apiEndpoint);
     });
 
     it('has port', () => {
-        const port = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.port;
+        const port = {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client.{{ id.get("port") }};
         assert(port);
         assert(typeof port === 'number');
     });
@@ -189,7 +191,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             projectId: 'bogus',
         });
         assert.strictEqual(client.{{ service.name.toCamelCase() }}Stub, undefined);
-        await client.initialize();
+        await client.{{ id.get("initialize") }}();
         assert(client.{{ service.name.toCamelCase() }}Stub);
     });
 
@@ -198,7 +200,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             credentials: { client_email: 'bogus', private_key: 'bogus' },
             projectId: 'bogus',
         });
-        client.close();
+        client.{{ id.get("close") }}();
     });
 
     it('has getProjectId method', async () => {
@@ -208,7 +210,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             projectId: 'bogus',
         });
         client.auth.getProjectId = sinon.stub().resolves(fakeProjectId);
-        const result = await client.getProjectId();
+        const result = await client.{{ id.get("getProjectId") }}();
         assert.strictEqual(result, fakeProjectId);
         assert((client.auth.getProjectId as SinonStub).calledWithExactly());
     });
@@ -221,7 +223,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
         });
         client.auth.getProjectId = sinon.stub().callsArgWith(0, null, fakeProjectId);
         const promise = new Promise((resolve, reject) => {
-            client.getProjectId((err?: Error|null, projectId?: string|null) => {
+            client.{{ id.get("getProjectId") }}((err?: Error|null, projectId?: string|null) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -241,7 +243,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
@@ -257,7 +259,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
@@ -284,7 +286,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
@@ -303,7 +305,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
@@ -320,7 +322,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
@@ -350,7 +352,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
@@ -365,7 +367,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
@@ -376,34 +378,34 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
-        it('invokes check{{method.name.toPascalCase() }}Progress without error', async () => {
+        it('invokes {{ id.get("check" + method.name.toPascalCase() + "Progress") }} without error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
 
             client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
-            const decodedOperation = await client.check{{method.name.toPascalCase() }}Progress(expectedResponse.name);
+            const decodedOperation = await client.{{ id.get("check" + method.name.toPascalCase() + "Progress") }}(expectedResponse.name);
             assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
             assert(decodedOperation.metadata);
             assert((client.operationsClient.getOperation as SinonStub).getCall(0));
         });
 
-        it('invokes check{{method.name.toPascalCase() }}Progress with error', async () => {
+        it('invokes {{ id.get("check" + method.name.toPascalCase() + "Progress") }} with error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const expectedError = new Error('expected');
 
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
-            await assert.rejects(client.check{{ method.name.toPascalCase() }}Progress(''), expectedError);
+            await assert.rejects(client.{{ id.get("check" + method.name.toPascalCase() + "Progress") }}(''), expectedError);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0));
         });
@@ -417,7 +419,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
@@ -442,7 +444,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
@@ -470,7 +472,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubBidiStreamingCall(expectedResponse);
@@ -498,7 +500,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubBidiStreamingCall(undefined, expectedError);
@@ -529,7 +531,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubClientStreamingCall(expectedResponse);
@@ -558,7 +560,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubClientStreamingCall(undefined, expectedError);
@@ -589,7 +591,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
@@ -605,7 +607,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
@@ -632,7 +634,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
@@ -642,16 +644,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
-        it('invokes {{ method.name.toCamelCase() }}Stream without error', async () => {
+        it('invokes {{ id.get(method.name.toCamelCase() + "Stream") }} without error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             {{ util.initPagingResponse(method) }}
             client.descriptors.page.{{ method.name.toCamelCase() }}.createStream = stubPageStreamingCall(expectedResponse);
-            const stream = client.{{ method.name.toCamelCase() }}Stream(request);
+            const stream = client.{{ id.get(method.name.toCamelCase() + "Stream") }}(request);
             const promise = new Promise((resolve, reject) => {
                 const responses: {{ util.promiseResponsePaging(method) }}[] = [];
                 stream.on('data', (response: {{ util.promiseResponsePaging(method) }}) => {
@@ -677,16 +679,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
 {%- endif %}
         });
 
-        it('invokes {{ method.name.toCamelCase() }}Stream with error', async () => {
+        it('invokes {{ id.get(method.name.toCamelCase() + "Stream") }} with error', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.descriptors.page.{{ method.name.toCamelCase() }}.createStream = stubPageStreamingCall(undefined, expectedError);
-            const stream = client.{{ method.name.toCamelCase() }}Stream(request);
+            const stream = client.{{ id.get(method.name.toCamelCase() + "Stream") }}(request);
             const promise = new Promise((resolve, reject) => {
                 const responses: {{ util.promiseResponsePaging(method) }}[] = [];
                 stream.on('data', (response: {{ util.promiseResponsePaging(method) }}) => {
@@ -716,12 +718,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initPagingResponse(method) }}
             client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate = stubAsyncIterationCall(expectedResponse);
             const responses: {{ util.toInterface(method.pagingResponseType) }}[] = [];
-            const iterable = client.{{ method.name.toCamelCase() }}Async(request);
+            const iterable = client.{{ id.get(method.name.toCamelCase() + "Async") }}(request);
             for await (const resource of iterable) {
                 responses.push(resource!);
             }
@@ -743,11 +745,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
             client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
-            const iterable = client.{{ method.name.toCamelCase() }}Async(request);
+            const iterable = client.{{ id.get(method.name.toCamelCase() + "Async") }}(request);
             await assert.rejects(async () => {
                 const responses: {{ util.toInterface(method.pagingResponseType) }}[] = [];
                 for await (const resource of iterable) {
@@ -776,7 +778,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
@@ -807,7 +809,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
@@ -854,7 +856,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
@@ -895,22 +897,22 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            client.initialize();
+            client.{{ id.get("initialize") }}();
             client.pathTemplates.{{ template.name.toCamelCase() }}PathTemplate.render =
                 sinon.stub().returns(fakePath);
             client.pathTemplates.{{ template.name.toCamelCase() }}PathTemplate.match =
                 sinon.stub().returns(expectedParameters);
 
-            it('{{ template.name.toCamelCase() }}Path', () => {
-                const result = client.{{ template.name.toCamelCase() }}Path({{ callParameters | safe }});
+            it('{{ id.get(template.name.toCamelCase() + "Path") }}', () => {
+                const result = client.{{ id.get(template.name.toCamelCase() + "Path") }}({{ callParameters | safe }});
                 assert.strictEqual(result, fakePath);
                 assert((client.pathTemplates.{{ template.name.toCamelCase() }}PathTemplate.render as SinonStub)
                     .getCall(-1).calledWith(expectedParameters));
             });
 {%- for param in template.params %}
 
-            it('match{{ param.toPascalCase() }}From{{ template.name.toPascalCase() }}Name', () => {
-                const result = client.match{{ param.toPascalCase() }}From{{ template.name.toPascalCase() }}Name(fakePath);
+            it('{{ id.get("match" + param.toPascalCase() + "From" + template.name.toPascalCase() + "Name") }}', () => {
+                const result = client.{{ id.get("match" + param.toPascalCase() + "From" + template.name.toPascalCase() + "Name") }}(fakePath);
                 assert.strictEqual(result, "{{ param.toCamelCase() }}Value");
                 assert((client.pathTemplates.{{ template.name.toCamelCase() }}PathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));

--- a/test-fixtures/protos/google/naming/v1beta1/naming.proto
+++ b/test-fixtures/protos/google/naming/v1beta1/naming.proto
@@ -112,21 +112,6 @@ service Naming {
       body: "*"
     };
   }
-
-  // Problem #4: RPCs that conflict with TypeScript reserved words
-  rpc Function(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      post: "/v1beta1/naming:function"
-      body: "*"
-    };
-  }
-
-  rpc Constructor(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      post: "/v1beta1/naming:constructor"
-      body: "*"
-    };
-  }
 }
 
 message PaginatedMethodRequest {


### PR DESCRIPTION
This PR introduces a _namer_ that, being a part of the template, makes sure that the generated extra method (such as `FooAsync` for method `Foo`, or `checkFooProgress` for long running method `Foo`) do not conflict with existing RPCs having the same names.

Implementation: a template may provide a JS file `namer.js` that will be loaded by the generator during its runtime and passed back to the template, so it could use the logic in JS to resolve name conflicts.

Let's assume the proto has a long running RPC `Foo`. Previously, we would've generated an extra method `checkFooProgress`, and if the proto has an actual RPC `CheckFooProgress`, the two names would've got into the conflict. With this change, the namer will detect the conflict, and the generated extra method will be called `checkFooProgress1` (2, 3, etc.) The same will happen if the proto has methods `Initialize`, `GetProjectId`, etc. (which can conflict with the methods added by the generator).

To use the namer in the template, use `{{ id.get("name") }}` instead of just `{{ name }}`.

Note that only "naming" baseline (a special proto with a lot of naming conflicts) is changed. No existing API should be affected by this feature.

This feature will unblock generation of Ads TypeScript library. Cc: @aohren

Small note: I removed the part of the `naming.proto` that checks for TypeScript keywords conflicts, I'll get to that part later in a separate PR.