### PR TITLE
fix: do not overwrite options object

### DIFF
--- a/baselines/asset/src/index.ts.baseline
+++ b/baselines/asset/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1 from './v1';
 const AssetServiceClient = v1.AssetServiceClient;
+type AssetServiceClient = v1.AssetServiceClient;
 export {v1, AssetServiceClient};
 export default {v1, AssetServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -74,12 +74,7 @@ export class AssetServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1/asset_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -90,9 +85,9 @@ export class AssetServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AssetServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -73,40 +73,34 @@ export class AssetServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1/asset_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AssetServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the AssetServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof AssetServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {AssetServiceClient} from '@google-cloud/asset';
 
+// check that the client class type name can be used
+function doStuffWithAssetServiceClient(client: AssetServiceClient) {
+  client.close();
+}
+
 function main() {
-  new AssetServiceClient();
+  // check that the client instance can be created
+  const assetServiceClient = new AssetServiceClient();
+  doStuffWithAssetServiceClient(assetServiceClient);
 }
 
 main();

--- a/baselines/asset/system-test/install.ts.baseline
+++ b/baselines/asset/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/bigquery-storage/src/index.ts.baseline
+++ b/baselines/bigquery-storage/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1beta1 from './v1beta1';
 const BigQueryStorageClient = v1beta1.BigQueryStorageClient;
+type BigQueryStorageClient = v1beta1.BigQueryStorageClient;
 export {v1beta1, BigQueryStorageClient};
 export default {v1beta1, BigQueryStorageClient};
 import * as protos from '../protos/protos';

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -74,40 +74,34 @@ export class BigQueryStorageClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/big_query_storage_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof BigQueryStorageClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the BigQueryStorageClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof BigQueryStorageClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -75,12 +75,7 @@ export class BigQueryStorageClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/big_query_storage_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class BigQueryStorageClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof BigQueryStorageClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {BigQueryStorageClient} from 'storage';
 
+// check that the client class type name can be used
+function doStuffWithBigQueryStorageClient(client: BigQueryStorageClient) {
+  client.close();
+}
+
 function main() {
-  new BigQueryStorageClient();
+  // check that the client instance can be created
+  const bigQueryStorageClient = new BigQueryStorageClient();
+  doStuffWithBigQueryStorageClient(bigQueryStorageClient);
 }
 
 main();

--- a/baselines/bigquery-storage/system-test/install.ts.baseline
+++ b/baselines/bigquery-storage/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/disable-packing-test/src/index.ts.baseline
+++ b/baselines/disable-packing-test/src/index.ts.baseline
@@ -18,9 +18,13 @@
 
 import * as v1beta1 from './v1beta1';
 const EchoClient = v1beta1.EchoClient;
+type EchoClient = v1beta1.EchoClient;
 const IdentityClient = v1beta1.IdentityClient;
+type IdentityClient = v1beta1.IdentityClient;
 const MessagingClient = v1beta1.MessagingClient;
+type MessagingClient = v1beta1.MessagingClient;
 const TestingClient = v1beta1.TestingClient;
+type TestingClient = v1beta1.TestingClient;
 export {v1beta1, EchoClient, IdentityClient, MessagingClient, TestingClient};
 export default {v1beta1, EchoClient, IdentityClient, MessagingClient, TestingClient};
 import * as protos from '../protos/protos';

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -80,12 +80,7 @@ export class EchoClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/echo_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -96,9 +91,9 @@ export class EchoClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -79,40 +79,34 @@ export class EchoClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/echo_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the EchoClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof EchoClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -75,12 +75,7 @@ export class IdentityClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/identity_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class IdentityClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -74,40 +74,34 @@ export class IdentityClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/identity_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the IdentityClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof IdentityClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -78,40 +78,34 @@ export class MessagingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/messaging_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the MessagingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof MessagingClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -79,12 +79,7 @@ export class MessagingClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/messaging_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -95,9 +90,9 @@ export class MessagingClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -76,12 +76,7 @@ export class TestingClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/testing_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class TestingClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -75,40 +75,34 @@ export class TestingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/testing_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the TestingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof TestingClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/dlp/src/index.ts.baseline
+++ b/baselines/dlp/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v2 from './v2';
 const DlpServiceClient = v2.DlpServiceClient;
+type DlpServiceClient = v2.DlpServiceClient;
 export {v2, DlpServiceClient};
 export default {v2, DlpServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -82,40 +82,34 @@ export class DlpServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v2/dlp_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DlpServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the DlpServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof DlpServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -83,12 +83,7 @@ export class DlpServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v2/dlp_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -99,9 +94,9 @@ export class DlpServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DlpServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {DlpServiceClient} from 'dlp';
 
+// check that the client class type name can be used
+function doStuffWithDlpServiceClient(client: DlpServiceClient) {
+  client.close();
+}
+
 function main() {
-  new DlpServiceClient();
+  // check that the client instance can be created
+  const dlpServiceClient = new DlpServiceClient();
+  doStuffWithDlpServiceClient(dlpServiceClient);
 }
 
 main();

--- a/baselines/dlp/system-test/install.ts.baseline
+++ b/baselines/dlp/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/kms/src/index.ts.baseline
+++ b/baselines/kms/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1 from './v1';
 const KeyManagementServiceClient = v1.KeyManagementServiceClient;
+type KeyManagementServiceClient = v1.KeyManagementServiceClient;
 export {v1, KeyManagementServiceClient};
 export default {v1, KeyManagementServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -85,12 +85,7 @@ export class KeyManagementServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1/key_management_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -101,9 +96,9 @@ export class KeyManagementServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof KeyManagementServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -84,40 +84,34 @@ export class KeyManagementServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1/key_management_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof KeyManagementServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the KeyManagementServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof KeyManagementServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {KeyManagementServiceClient} from 'kms';
 
+// check that the client class type name can be used
+function doStuffWithKeyManagementServiceClient(client: KeyManagementServiceClient) {
+  client.close();
+}
+
 function main() {
-  new KeyManagementServiceClient();
+  // check that the client instance can be created
+  const keyManagementServiceClient = new KeyManagementServiceClient();
+  doStuffWithKeyManagementServiceClient(keyManagementServiceClient);
 }
 
 main();

--- a/baselines/kms/system-test/install.ts.baseline
+++ b/baselines/kms/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/logging/src/index.ts.baseline
+++ b/baselines/logging/src/index.ts.baseline
@@ -18,8 +18,11 @@
 
 import * as v2 from './v2';
 const ConfigServiceV2Client = v2.ConfigServiceV2Client;
+type ConfigServiceV2Client = v2.ConfigServiceV2Client;
 const LoggingServiceV2Client = v2.LoggingServiceV2Client;
+type LoggingServiceV2Client = v2.LoggingServiceV2Client;
 const MetricsServiceV2Client = v2.MetricsServiceV2Client;
+type MetricsServiceV2Client = v2.MetricsServiceV2Client;
 export {v2, ConfigServiceV2Client, LoggingServiceV2Client, MetricsServiceV2Client};
 export default {v2, ConfigServiceV2Client, LoggingServiceV2Client, MetricsServiceV2Client};
 import * as protos from '../protos/protos';

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -74,40 +74,34 @@ export class ConfigServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v2/config_service_v2_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the ConfigServiceV2Client constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof ConfigServiceV2Client).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -75,12 +75,7 @@ export class ConfigServiceV2Client {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v2/config_service_v2_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class ConfigServiceV2Client {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -74,40 +74,34 @@ export class LoggingServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v2/logging_service_v2_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the LoggingServiceV2Client constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof LoggingServiceV2Client).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -75,12 +75,7 @@ export class LoggingServiceV2Client {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v2/logging_service_v2_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class LoggingServiceV2Client {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -75,12 +75,7 @@ export class MetricsServiceV2Client {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v2/metrics_service_v2_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class MetricsServiceV2Client {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -74,40 +74,34 @@ export class MetricsServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v2/metrics_service_v2_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the MetricsServiceV2Client constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof MetricsServiceV2Client).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,10 +18,27 @@
 
 import {ConfigServiceV2Client, LoggingServiceV2Client, MetricsServiceV2Client} from 'logging';
 
+// check that the client class type name can be used
+function doStuffWithConfigServiceV2Client(client: ConfigServiceV2Client) {
+  client.close();
+}
+function doStuffWithLoggingServiceV2Client(client: LoggingServiceV2Client) {
+  client.close();
+}
+function doStuffWithMetricsServiceV2Client(client: MetricsServiceV2Client) {
+  client.close();
+}
+
 function main() {
-  new ConfigServiceV2Client();
-  new LoggingServiceV2Client();
-  new MetricsServiceV2Client();
+  // check that the client instance can be created
+  const configServiceV2Client = new ConfigServiceV2Client();
+  doStuffWithConfigServiceV2Client(configServiceV2Client);
+  // check that the client instance can be created
+  const loggingServiceV2Client = new LoggingServiceV2Client();
+  doStuffWithLoggingServiceV2Client(loggingServiceV2Client);
+  // check that the client instance can be created
+  const metricsServiceV2Client = new MetricsServiceV2Client();
+  doStuffWithMetricsServiceV2Client(metricsServiceV2Client);
 }
 
 main();

--- a/baselines/logging/system-test/install.ts.baseline
+++ b/baselines/logging/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/monitoring/src/index.ts.baseline
+++ b/baselines/monitoring/src/index.ts.baseline
@@ -18,11 +18,17 @@
 
 import * as v3 from './v3';
 const AlertPolicyServiceClient = v3.AlertPolicyServiceClient;
+type AlertPolicyServiceClient = v3.AlertPolicyServiceClient;
 const GroupServiceClient = v3.GroupServiceClient;
+type GroupServiceClient = v3.GroupServiceClient;
 const MetricServiceClient = v3.MetricServiceClient;
+type MetricServiceClient = v3.MetricServiceClient;
 const NotificationChannelServiceClient = v3.NotificationChannelServiceClient;
+type NotificationChannelServiceClient = v3.NotificationChannelServiceClient;
 const ServiceMonitoringServiceClient = v3.ServiceMonitoringServiceClient;
+type ServiceMonitoringServiceClient = v3.ServiceMonitoringServiceClient;
 const UptimeCheckServiceClient = v3.UptimeCheckServiceClient;
+type UptimeCheckServiceClient = v3.UptimeCheckServiceClient;
 export {v3, AlertPolicyServiceClient, GroupServiceClient, MetricServiceClient, NotificationChannelServiceClient, ServiceMonitoringServiceClient, UptimeCheckServiceClient};
 export default {v3, AlertPolicyServiceClient, GroupServiceClient, MetricServiceClient, NotificationChannelServiceClient, ServiceMonitoringServiceClient, UptimeCheckServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -83,12 +83,7 @@ export class AlertPolicyServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/alert_policy_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -99,9 +94,9 @@ export class AlertPolicyServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AlertPolicyServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -82,40 +82,34 @@ export class AlertPolicyServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/alert_policy_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AlertPolicyServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the AlertPolicyServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof AlertPolicyServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -86,12 +86,7 @@ export class GroupServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/group_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -102,9 +97,9 @@ export class GroupServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof GroupServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -85,40 +85,34 @@ export class GroupServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/group_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof GroupServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the GroupServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof GroupServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -75,40 +75,34 @@ export class MetricServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/metric_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the MetricServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof MetricServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -76,12 +76,7 @@ export class MetricServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/metric_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class MetricServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -75,40 +75,34 @@ export class NotificationChannelServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/notification_channel_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NotificationChannelServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the NotificationChannelServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof NotificationChannelServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -76,12 +76,7 @@ export class NotificationChannelServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/notification_channel_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class NotificationChannelServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NotificationChannelServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -78,12 +78,7 @@ export class ServiceMonitoringServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/service_monitoring_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -94,9 +89,9 @@ export class ServiceMonitoringServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ServiceMonitoringServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -77,40 +77,34 @@ export class ServiceMonitoringServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/service_monitoring_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ServiceMonitoringServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the ServiceMonitoringServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof ServiceMonitoringServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -82,12 +82,7 @@ export class UptimeCheckServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3/uptime_check_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -98,9 +93,9 @@ export class UptimeCheckServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof UptimeCheckServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -81,40 +81,34 @@ export class UptimeCheckServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3/uptime_check_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof UptimeCheckServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the UptimeCheckServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof UptimeCheckServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,13 +18,45 @@
 
 import {AlertPolicyServiceClient, GroupServiceClient, MetricServiceClient, NotificationChannelServiceClient, ServiceMonitoringServiceClient, UptimeCheckServiceClient} from 'monitoring';
 
+// check that the client class type name can be used
+function doStuffWithAlertPolicyServiceClient(client: AlertPolicyServiceClient) {
+  client.close();
+}
+function doStuffWithGroupServiceClient(client: GroupServiceClient) {
+  client.close();
+}
+function doStuffWithMetricServiceClient(client: MetricServiceClient) {
+  client.close();
+}
+function doStuffWithNotificationChannelServiceClient(client: NotificationChannelServiceClient) {
+  client.close();
+}
+function doStuffWithServiceMonitoringServiceClient(client: ServiceMonitoringServiceClient) {
+  client.close();
+}
+function doStuffWithUptimeCheckServiceClient(client: UptimeCheckServiceClient) {
+  client.close();
+}
+
 function main() {
-  new AlertPolicyServiceClient();
-  new GroupServiceClient();
-  new MetricServiceClient();
-  new NotificationChannelServiceClient();
-  new ServiceMonitoringServiceClient();
-  new UptimeCheckServiceClient();
+  // check that the client instance can be created
+  const alertPolicyServiceClient = new AlertPolicyServiceClient();
+  doStuffWithAlertPolicyServiceClient(alertPolicyServiceClient);
+  // check that the client instance can be created
+  const groupServiceClient = new GroupServiceClient();
+  doStuffWithGroupServiceClient(groupServiceClient);
+  // check that the client instance can be created
+  const metricServiceClient = new MetricServiceClient();
+  doStuffWithMetricServiceClient(metricServiceClient);
+  // check that the client instance can be created
+  const notificationChannelServiceClient = new NotificationChannelServiceClient();
+  doStuffWithNotificationChannelServiceClient(notificationChannelServiceClient);
+  // check that the client instance can be created
+  const serviceMonitoringServiceClient = new ServiceMonitoringServiceClient();
+  doStuffWithServiceMonitoringServiceClient(serviceMonitoringServiceClient);
+  // check that the client instance can be created
+  const uptimeCheckServiceClient = new UptimeCheckServiceClient();
+  doStuffWithUptimeCheckServiceClient(uptimeCheckServiceClient);
 }
 
 main();

--- a/baselines/monitoring/system-test/install.ts.baseline
+++ b/baselines/monitoring/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/naming/src/index.ts.baseline
+++ b/baselines/naming/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1beta1 from './v1beta1';
 const NamingClient = v1beta1.NamingClient;
+type NamingClient = v1beta1.NamingClient;
 export {v1beta1, NamingClient};
 export default {v1beta1, NamingClient};
 import * as protos from '../protos/protos';

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -75,12 +75,7 @@ export class NamingClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/naming_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class NamingClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NamingClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath1;
-    const port = opts?.port ?? staticMembers.port1;
-    const scopes = opts?.scopes ?? staticMembers.scopes1;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath1;
+    const port = opts?.port || staticMembers.port1;
+    const scopes = opts?.scopes || staticMembers.scopes1;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -74,40 +74,34 @@ export class NamingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/naming_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NamingClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath1);
-    const port = opts && opts.port ? opts.port : staticMembers.port1;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath1;
+    const port = opts?.port ?? staticMembers.port1;
+    const scopes = opts?.scopes ?? staticMembers.scopes1;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the NamingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof NamingClient).scopes1;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize1() method.

--- a/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {NamingClient} from 'naming';
 
+// check that the client class type name can be used
+function doStuffWithNamingClient(client: NamingClient) {
+  client.close();
+}
+
 function main() {
-  new NamingClient();
+  // check that the client instance can be created
+  const namingClient = new NamingClient();
+  doStuffWithNamingClient(namingClient);
 }
 
 main();

--- a/baselines/naming/system-test/install.ts.baseline
+++ b/baselines/naming/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/redis/src/index.ts.baseline
+++ b/baselines/redis/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1beta1 from './v1beta1';
 const CloudRedisClient = v1beta1.CloudRedisClient;
+type CloudRedisClient = v1beta1.CloudRedisClient;
 export {v1beta1, CloudRedisClient};
 export default {v1beta1, CloudRedisClient};
 import * as protos from '../protos/protos';

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -89,40 +89,34 @@ export class CloudRedisClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/cloud_redis_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudRedisClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the CloudRedisClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof CloudRedisClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -90,12 +90,7 @@ export class CloudRedisClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/cloud_redis_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -106,9 +101,9 @@ export class CloudRedisClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudRedisClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {CloudRedisClient} from 'redis';
 
+// check that the client class type name can be used
+function doStuffWithCloudRedisClient(client: CloudRedisClient) {
+  client.close();
+}
+
 function main() {
-  new CloudRedisClient();
+  // check that the client instance can be created
+  const cloudRedisClient = new CloudRedisClient();
+  doStuffWithCloudRedisClient(cloudRedisClient);
 }
 
 main();

--- a/baselines/redis/system-test/install.ts.baseline
+++ b/baselines/redis/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/showcase/src/index.ts.baseline
+++ b/baselines/showcase/src/index.ts.baseline
@@ -18,9 +18,13 @@
 
 import * as v1beta1 from './v1beta1';
 const EchoClient = v1beta1.EchoClient;
+type EchoClient = v1beta1.EchoClient;
 const IdentityClient = v1beta1.IdentityClient;
+type IdentityClient = v1beta1.IdentityClient;
 const MessagingClient = v1beta1.MessagingClient;
+type MessagingClient = v1beta1.MessagingClient;
 const TestingClient = v1beta1.TestingClient;
+type TestingClient = v1beta1.TestingClient;
 export {v1beta1, EchoClient, IdentityClient, MessagingClient, TestingClient};
 export default {v1beta1, EchoClient, IdentityClient, MessagingClient, TestingClient};
 import * as protos from '../protos/protos';

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -80,12 +80,7 @@ export class EchoClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/echo_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -96,9 +91,9 @@ export class EchoClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -79,40 +79,34 @@ export class EchoClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/echo_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the EchoClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof EchoClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -75,12 +75,7 @@ export class IdentityClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/identity_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -91,9 +86,9 @@ export class IdentityClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -74,40 +74,34 @@ export class IdentityClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/identity_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the IdentityClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof IdentityClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -78,40 +78,34 @@ export class MessagingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/messaging_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the MessagingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof MessagingClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -79,12 +79,7 @@ export class MessagingClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/messaging_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -95,9 +90,9 @@ export class MessagingClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -76,12 +76,7 @@ export class TestingClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1beta1/testing_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class TestingClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -75,40 +75,34 @@ export class TestingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1beta1/testing_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the TestingClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof TestingClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,11 +18,33 @@
 
 import {EchoClient, IdentityClient, MessagingClient, TestingClient} from 'showcase';
 
+// check that the client class type name can be used
+function doStuffWithEchoClient(client: EchoClient) {
+  client.close();
+}
+function doStuffWithIdentityClient(client: IdentityClient) {
+  client.close();
+}
+function doStuffWithMessagingClient(client: MessagingClient) {
+  client.close();
+}
+function doStuffWithTestingClient(client: TestingClient) {
+  client.close();
+}
+
 function main() {
-  new EchoClient();
-  new IdentityClient();
-  new MessagingClient();
-  new TestingClient();
+  // check that the client instance can be created
+  const echoClient = new EchoClient();
+  doStuffWithEchoClient(echoClient);
+  // check that the client instance can be created
+  const identityClient = new IdentityClient();
+  doStuffWithIdentityClient(identityClient);
+  // check that the client instance can be created
+  const messagingClient = new MessagingClient();
+  doStuffWithMessagingClient(messagingClient);
+  // check that the client instance can be created
+  const testingClient = new TestingClient();
+  doStuffWithTestingClient(testingClient);
 }
 
 main();

--- a/baselines/showcase/system-test/install.ts.baseline
+++ b/baselines/showcase/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/tasks/src/index.ts.baseline
+++ b/baselines/tasks/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v2 from './v2';
 const CloudTasksClient = v2.CloudTasksClient;
+type CloudTasksClient = v2.CloudTasksClient;
 export {v2, CloudTasksClient};
 export default {v2, CloudTasksClient};
 import * as protos from '../protos/protos';

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -76,12 +76,7 @@ export class CloudTasksClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v2/cloud_tasks_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class CloudTasksClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudTasksClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -75,40 +75,34 @@ export class CloudTasksClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v2/cloud_tasks_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudTasksClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the CloudTasksClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof CloudTasksClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {CloudTasksClient} from 'tasks';
 
+// check that the client class type name can be used
+function doStuffWithCloudTasksClient(client: CloudTasksClient) {
+  client.close();
+}
+
 function main() {
-  new CloudTasksClient();
+  // check that the client instance can be created
+  const cloudTasksClient = new CloudTasksClient();
+  doStuffWithCloudTasksClient(cloudTasksClient);
 }
 
 main();

--- a/baselines/tasks/system-test/install.ts.baseline
+++ b/baselines/tasks/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/texttospeech/src/index.ts.baseline
+++ b/baselines/texttospeech/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1 from './v1';
 const TextToSpeechClient = v1.TextToSpeechClient;
+type TextToSpeechClient = v1.TextToSpeechClient;
 export {v1, TextToSpeechClient};
 export default {v1, TextToSpeechClient};
 import * as protos from '../protos/protos';

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -71,40 +71,34 @@ export class TextToSpeechClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1/text_to_speech_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TextToSpeechClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the TextToSpeechClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof TextToSpeechClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -72,12 +72,7 @@ export class TextToSpeechClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1/text_to_speech_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -88,9 +83,9 @@ export class TextToSpeechClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TextToSpeechClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {TextToSpeechClient} from '@google-cloud/text-to-speech';
 
+// check that the client class type name can be used
+function doStuffWithTextToSpeechClient(client: TextToSpeechClient) {
+  client.close();
+}
+
 function main() {
-  new TextToSpeechClient();
+  // check that the client instance can be created
+  const textToSpeechClient = new TextToSpeechClient();
+  doStuffWithTextToSpeechClient(textToSpeechClient);
 }
 
 main();

--- a/baselines/texttospeech/system-test/install.ts.baseline
+++ b/baselines/texttospeech/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/translate/src/index.ts.baseline
+++ b/baselines/translate/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v3beta1 from './v3beta1';
 const TranslationServiceClient = v3beta1.TranslationServiceClient;
+type TranslationServiceClient = v3beta1.TranslationServiceClient;
 export {v3beta1, TranslationServiceClient};
 export default {v3beta1, TranslationServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -75,40 +75,34 @@ export class TranslationServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v3beta1/translation_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TranslationServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the TranslationServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof TranslationServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -76,12 +76,7 @@ export class TranslationServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v3beta1/translation_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -92,9 +87,9 @@ export class TranslationServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TranslationServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {TranslationServiceClient} from 'translation';
 
+// check that the client class type name can be used
+function doStuffWithTranslationServiceClient(client: TranslationServiceClient) {
+  client.close();
+}
+
 function main() {
-  new TranslationServiceClient();
+  // check that the client instance can be created
+  const translationServiceClient = new TranslationServiceClient();
+  doStuffWithTranslationServiceClient(translationServiceClient);
 }
 
 main();

--- a/baselines/translate/system-test/install.ts.baseline
+++ b/baselines/translate/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/baselines/videointelligence/src/index.ts.baseline
+++ b/baselines/videointelligence/src/index.ts.baseline
@@ -18,6 +18,7 @@
 
 import * as v1 from './v1';
 const VideoIntelligenceServiceClient = v1.VideoIntelligenceServiceClient;
+type VideoIntelligenceServiceClient = v1.VideoIntelligenceServiceClient;
 export {v1, VideoIntelligenceServiceClient};
 export default {v1, VideoIntelligenceServiceClient};
 import * as protos from '../protos/protos';

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -73,12 +73,7 @@ export class VideoIntelligenceServiceClient {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/v1/video_intelligence_service_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -89,9 +84,9 @@ export class VideoIntelligenceServiceClient {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof VideoIntelligenceServiceClient;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
-    const port = opts?.port ?? staticMembers.port;
-    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const scopes = opts?.scopes || staticMembers.scopes;
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -72,40 +72,34 @@ export class VideoIntelligenceServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/v1/video_intelligence_service_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof VideoIntelligenceServiceClient;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.servicePath);
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.servicePath;
+    const port = opts?.port ?? staticMembers.port;
+    const scopes = opts?.scopes ?? staticMembers.scopes;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the VideoIntelligenceServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this.constructor as typeof VideoIntelligenceServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.

--- a/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
+++ b/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
@@ -18,8 +18,15 @@
 
 import {VideoIntelligenceServiceClient} from 'videointelligence';
 
+// check that the client class type name can be used
+function doStuffWithVideoIntelligenceServiceClient(client: VideoIntelligenceServiceClient) {
+  client.close();
+}
+
 function main() {
-  new VideoIntelligenceServiceClient();
+  // check that the client instance can be created
+  const videoIntelligenceServiceClient = new VideoIntelligenceServiceClient();
+  doStuffWithVideoIntelligenceServiceClient(videoIntelligenceServiceClient);
 }
 
 main();

--- a/baselines/videointelligence/system-test/install.ts.baseline
+++ b/baselines/videointelligence/system-test/install.ts.baseline
@@ -20,30 +20,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -337,12 +337,3 @@ protos{{ type.substring(0, index + 1) + 'I' + type.substring(index + 1) }}
 protos{{ method.pagingResponseType }}
 {%- endif -%}
 {%- endmacro -%}
-
-{%- macro bundlingOptionsComments() %}
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-{%- endmacro -%}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -94,36 +94,34 @@ export class {{ service.name }}Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     Client configuration set in the JSON config
+   *     (`src/{{ api.naming.version }}/{{ service.name.toSnakeCase() }}_client_config.json`)
+   *     can be overridden by passing `clientConfig` to the client constructor.
+   *     The detailed structure of the clientConfig can be found
+   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
+   *     Pass any subset of that JSON config as `options.clientConfig`.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
 
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
-    const servicePath = opts && opts.servicePath ?
-        opts.servicePath :
-        ((opts && opts.apiEndpoint) ? opts.apiEndpoint :
-                                      staticMembers.{{ id.get("servicePath") }});
-    const port = opts && opts.port ? opts.port : staticMembers.{{ id.get("port") }};
+    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.{{ id.get("servicePath") }};
+    const port = opts?.port ?? staticMembers.{{ id.get("port") }};
+    const scopes = opts?.scopes ?? staticMembers.{{ id.get("scopes") }};
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? (typeof window !== "undefined");
+    opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
-    }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
-{{ util.bundlingOptionsComments() }}
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the {{ service.name}}Client constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    {#- TODO: replace the following line with `opts.scopes = staticMembers.{{ id.get("scopes") }};` #}
-    {#- (it will change the code for all libraries, we'll leave it unchanged for now) #}
-    opts.scopes = (this.constructor as typeof {{ service.name }}Client).{{ id.get("scopes") }};
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in {{ id.get("initialize") }}() method.

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -95,12 +95,7 @@ export class {{ service.name }}Client {
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Client configuration set in the JSON config
-   *     (`src/{{ api.naming.version }}/{{ service.name.toSnakeCase() }}_client_config.json`)
-   *     can be overridden by passing `clientConfig` to the client constructor.
-   *     The detailed structure of the clientConfig can be found
-   *     {@link https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L564-L611 here}.
-   *     Pass any subset of that JSON config as `options.clientConfig`.
+   *     TODO(@alexander-fenster): link to gax documentation.
    * @param {boolean} fallback - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
@@ -111,9 +106,9 @@ export class {{ service.name }}Client {
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
-    const servicePath = opts?.servicePath ?? opts?.apiEndpoint ?? staticMembers.{{ id.get("servicePath") }};
-    const port = opts?.port ?? staticMembers.{{ id.get("port") }};
-    const scopes = opts?.scopes ?? staticMembers.{{ id.get("scopes") }};
+    const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
+    const port = opts?.port || staticMembers.{{ id.get("port") }};
+    const scopes = opts?.scopes || staticMembers.{{ id.get("scopes") }};
     const clientConfig = opts?.clientConfig ?? {};
     const fallback = opts?.fallback ?? (typeof window !== "undefined");
     opts = Object.assign({servicePath, port, scopes, clientConfig, fallback}, opts);

--- a/templates/typescript_gapic/src/index.ts.njk
+++ b/templates/typescript_gapic/src/index.ts.njk
@@ -20,6 +20,7 @@ limitations under the License.
 import * as {{ api.naming.version }} from './{{ api.naming.version }}';
 {%- for service in api.services %}
 const {{ service.name.toPascalCase() }}Client = {{ api.naming.version }}.{{ service.name.toPascalCase() }}Client;
+type {{ service.name.toPascalCase() }}Client = {{ api.naming.version }}.{{ service.name.toPascalCase() }}Client;
 {%- endfor %}
 export { {{- api.naming.version }}
 {%- for service in api.services -%}

--- a/templates/typescript_packing_test/system-test/fixtures/sample/src/index.js.njk
+++ b/templates/typescript_packing_test/system-test/fixtures/sample/src/index.js.njk
@@ -23,7 +23,7 @@ const {{ api.naming.productName.toKebabCase()}} = require('{{ api.publishName }}
 
 function main() {
 {%- for service in api.services %}
-  const {{ service.name.toCamelCase() -}}Client = new {{ api.naming.productName.toKebabCase() }}.{{ service.name.toPascalCase() + 'Client' }}();
+  const {{ service.name.toCamelCase() }}Client = new {{ api.naming.productName.toKebabCase() }}.{{ service.name.toPascalCase() + 'Client' }}();
 {%- endfor %}
 }
 

--- a/templates/typescript_packing_test/system-test/fixtures/sample/src/index.ts.njk
+++ b/templates/typescript_packing_test/system-test/fixtures/sample/src/index.ts.njk
@@ -25,9 +25,18 @@ import {
   {%- endfor -%}
 } from '{{ api.publishName }}';
 
+// check that the client class type name can be used
+{%- for service in api.services %}
+function doStuffWith{{ service.name.toPascalCase() + 'Client' }}(client: {{ service.name.toPascalCase() + 'Client' }}) {
+  client.close();
+}
+{%- endfor %}
+
 function main() {
 {%- for service in api.services %}
-  new {{ service.name.toPascalCase() + 'Client' -}}();
+  // check that the client instance can be created
+  const {{ service.name.toCamelCase() }}Client = new {{ service.name.toPascalCase() + 'Client' }}();
+  doStuffWith{{ service.name.toPascalCase() + 'Client' }}({{ service.name.toCamelCase() }}Client);
 {%- endfor %}
 }
 

--- a/templates/typescript_packing_test/system-test/install.ts.njk
+++ b/templates/typescript_packing_test/system-test/install.ts.njk
@@ -21,30 +21,30 @@ import { packNTest } from 'pack-n-play';
 import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
 
-describe('typescript consumer tests', () => {
+describe('📦 pack-n-play test', () => {
 
-  it('should have correct type signature for typescript users', async function() {
+  it('TypeScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync('./system-test/fixtures/sample/src/index.ts').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function() {
+  it('JavaScript code', async function() {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(),  // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync('./system-test/fixtures/sample/src/index.js').toString()
       }
     };
-    await packNTest(options);  // will throw upon error.
+    await packNTest(options);
   });
 
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-kms/issues/381, https://github.com/googleapis/google-cloud-node-core/issues/636.

This change to the generator will be applied to all the generated libraries. 

The main change improves the handling of `opts` object in the generated client constructor (making sure that it never changes the object passed as a parameter). Using `??` and `?.` operators improved the code a little bit.

Another important change is to use TypeScript [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to make sure that the main client is exported both as a class and as a type (to allow both `const client = new FooClient()` and `let client: FooClient`, the latter does not work without this change.

Also, made some smaller changes here and there to improve the generated code (please see the baseline changes).

All changes are supposed to be compatible and non-breaking.