### PR TITLE
chore: fix renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,19 +9,13 @@
   "gitAuthor": null,
   "packageRules": [
     {
-      "extends": "packages:linters",
-      "groupName": "linters"
+      "packagePatterns": ["^.*$"],
+      "groupName": "all packages"
     }
   ],
   "reviewers": [
     "alexander-fenster",
     "bcoe"
   ],
-  "rebaseWhen": "never",
-  "packageRules": [
-    {
-      "packagePatterns": ["^.*$"],
-      "groupName": "all packages"
-    }
-  ]
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#634 (duplicate key in JSON). I did not notice that :)