### PR TITLE
fix: make the generator work locally with and without bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,6 +72,7 @@ ts_project(
 nodejs_binary(
     name = "protoc_plugin",
     entry_point = "//:src/protoc-plugin.js",
+    link_workspace_root = True,
     data = [
         ":compile",
         ":templates",
@@ -82,6 +83,7 @@ nodejs_binary(
 nodejs_binary(
     name = "gapic_generator_typescript",
     entry_point = "//:src/gapic-generator-typescript.js",
+    link_workspace_root = True,
     data = [
         ":protoc_plugin",
         ":compile",

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -24,7 +24,7 @@ cd ..   # now in the package.json directory
 ### Test script pulling the docker image and use it against showcase proto.
 
 # Docker image tag: gapic-generator-typescript:latest.
-DIR_NAME=.showcase-typescript
+DIR_NAME=$TMPDIR/.showcase-typescript
 # Remove test directory if it already exists
 rm -rf $DIR_NAME
 # Create new directory showcase-typescript. 
@@ -32,7 +32,7 @@ mkdir $DIR_NAME
 # Use Docker Image for generating showcase client library
 docker run --rm \
   --mount type=bind,source=`pwd`/test-fixtures/protos/google/showcase/v1beta1,destination=/in/google/showcase/v1beta1,readonly \
-  --mount type=bind,source=`pwd`/$DIR_NAME,destination=/out \
+  --mount type=bind,source=$DIR_NAME,destination=/out \
   --user $UID \
   gapic-generator-typescript:latest --validation false
 # Test generated client library

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -30,7 +30,12 @@ export interface OptionsMap {
 }
 const readFile = util.promisify(fs.readFile);
 
-const templatesDirectory = path.join(__dirname, '..', 'templates');
+// support both run from Bazel and without it
+const templatesDirectory = fs.existsSync(
+  '../gapic_generator_typescript/templates'
+)
+  ? '../gapic_generator_typescript/templates'
+  : path.join(__dirname, '..', 'templates');
 const defaultTemplates = ['typescript_gapic', 'typescript_packing_test'];
 
 export class Generator {

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -132,7 +132,15 @@ export async function processTemplates(basePath: string, api: API) {
     },
   };
   if (fs.existsSync(namerLocation)) {
-    const {register, get} = require(namerLocation) as Namer;
+    let namer: Namer;
+    // different location when running from Bazel, hence try {}
+    // (because Bazel alters behavior of `require`)
+    try {
+      namer = require(namerLocation) as Namer;
+    } catch (err) {
+      namer = require(namerLocation.replace(/^..\//, '')) as Namer;
+    }
+    const {register, get} = namer;
     id.register = register;
     id.get = get;
   }


### PR DESCRIPTION
I figured out the documented way of local execution, `bazel run //:gapic_generator_typescript -- ...parameters...`, got broken. It's not used anywhere in production but is the easiest way to do local development.

Adding some fixes to make it work:
- enabling an option in `BUILD.bazel` to add one more link to make resolving things easier,
- everywhere where we try to find things based on `__dirname`, consider Bazel file placement (which is different).

With all these things in place, both local execution, `npm pack`, and execution from `googleapis` work.

The Docker test change is unrelated - it's mostly to please `eslint` which does not like to be run in folders nested into another Node project with `node_modules`.