### PR TITLE
feat: GAPIC metadata file

### DIFF
--- a/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
@@ -47,7 +47,7 @@
           ]
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "NamingClient",
         "rpcs": {
           "PaginatedMethodStream": [

--- a/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
@@ -37,8 +37,7 @@
             "getProjectId"
           ],
           "LongRunning": [
-            "longRunning",
-            "checkLongRunningProgress1"
+            "longRunning"
           ],
           "PaginatedMethod": [
             "paginatedMethod",
@@ -78,8 +77,7 @@
             "getProjectId"
           ],
           "LongRunning": [
-            "longRunning",
-            "checkLongRunningProgress1"
+            "longRunning"
           ],
           "PaginatedMethod": [
             "paginatedMethod",

--- a/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/naming/src/v1beta1/gapic_metadata.json.baseline
@@ -1,0 +1,93 @@
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "typescript",
+  "protoPackage": "google.naming.v1beta1",
+  "libraryPackage": "naming",
+  "services": {
+    "Naming": {
+      "grpc": {
+        "libraryClient": "NamingClient",
+        "rpcs": {
+          "PaginatedMethodStream": [
+            "paginatedMethodStream"
+          ],
+          "PaginatedMethodAsync": [
+            "paginatedMethodAsync"
+          ],
+          "CheckLongRunningProgress": [
+            "checkLongRunningProgress"
+          ],
+          "Initialize": [
+            "initialize"
+          ],
+          "ServicePath": [
+            "servicePath"
+          ],
+          "ApiEndpoint": [
+            "apiEndpoint"
+          ],
+          "Port": [
+            "port"
+          ],
+          "Scopes": [
+            "scopes"
+          ],
+          "getProjectId": [
+            "getProjectId"
+          ],
+          "LongRunning": [
+            "longRunning",
+            "checkLongRunningProgress1"
+          ],
+          "PaginatedMethod": [
+            "paginatedMethod",
+            "paginatedMethodStream1",
+            "paginatedMethodAsync1"
+          ]
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "NamingClient",
+        "rpcs": {
+          "PaginatedMethodStream": [
+            "paginatedMethodStream"
+          ],
+          "PaginatedMethodAsync": [
+            "paginatedMethodAsync"
+          ],
+          "CheckLongRunningProgress": [
+            "checkLongRunningProgress"
+          ],
+          "Initialize": [
+            "initialize"
+          ],
+          "ServicePath": [
+            "servicePath"
+          ],
+          "ApiEndpoint": [
+            "apiEndpoint"
+          ],
+          "Port": [
+            "port"
+          ],
+          "Scopes": [
+            "scopes"
+          ],
+          "getProjectId": [
+            "getProjectId"
+          ],
+          "LongRunning": [
+            "longRunning",
+            "checkLongRunningProgress1"
+          ],
+          "PaginatedMethod": [
+            "paginatedMethod",
+            "paginatedMethodStream1",
+            "paginatedMethodAsync1"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
@@ -1,0 +1,271 @@
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "typescript",
+  "protoPackage": "google.showcase.v1beta1",
+  "libraryPackage": "showcase",
+  "services": {
+    "Echo": {
+      "grpc": {
+        "libraryClient": "EchoClient",
+        "rpcs": {
+          "Echo": [
+            "echo"
+          ],
+          "Block": [
+            "block"
+          ],
+          "Expand": [
+            "expand"
+          ],
+          "Collect": [
+            "collect"
+          ],
+          "Chat": [
+            "chat"
+          ],
+          "Wait": [
+            "wait",
+            "checkWaitProgress"
+          ],
+          "PagedExpand": [
+            "pagedExpand",
+            "pagedExpandStream",
+            "pagedExpandAsync"
+          ]
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "EchoClient",
+        "rpcs": {
+          "Echo": [
+            "echo"
+          ],
+          "Block": [
+            "block"
+          ],
+          "Wait": [
+            "wait",
+            "checkWaitProgress"
+          ],
+          "PagedExpand": [
+            "pagedExpand",
+            "pagedExpandStream",
+            "pagedExpandAsync"
+          ]
+        }
+      }
+    },
+    "Identity": {
+      "grpc": {
+        "libraryClient": "IdentityClient",
+        "rpcs": {
+          "CreateUser": [
+            "createUser"
+          ],
+          "GetUser": [
+            "getUser"
+          ],
+          "UpdateUser": [
+            "updateUser"
+          ],
+          "DeleteUser": [
+            "deleteUser"
+          ],
+          "ListUsers": [
+            "listUsers",
+            "listUsersStream",
+            "listUsersAsync"
+          ]
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "IdentityClient",
+        "rpcs": {
+          "CreateUser": [
+            "createUser"
+          ],
+          "GetUser": [
+            "getUser"
+          ],
+          "UpdateUser": [
+            "updateUser"
+          ],
+          "DeleteUser": [
+            "deleteUser"
+          ],
+          "ListUsers": [
+            "listUsers",
+            "listUsersStream",
+            "listUsersAsync"
+          ]
+        }
+      }
+    },
+    "Messaging": {
+      "grpc": {
+        "libraryClient": "MessagingClient",
+        "rpcs": {
+          "CreateRoom": [
+            "createRoom"
+          ],
+          "GetRoom": [
+            "getRoom"
+          ],
+          "UpdateRoom": [
+            "updateRoom"
+          ],
+          "DeleteRoom": [
+            "deleteRoom"
+          ],
+          "CreateBlurb": [
+            "createBlurb"
+          ],
+          "GetBlurb": [
+            "getBlurb"
+          ],
+          "UpdateBlurb": [
+            "updateBlurb"
+          ],
+          "DeleteBlurb": [
+            "deleteBlurb"
+          ],
+          "StreamBlurbs": [
+            "streamBlurbs"
+          ],
+          "SendBlurbs": [
+            "sendBlurbs"
+          ],
+          "Connect": [
+            "connect"
+          ],
+          "SearchBlurbs": [
+            "searchBlurbs",
+            "checkSearchBlurbsProgress"
+          ],
+          "ListRooms": [
+            "listRooms",
+            "listRoomsStream",
+            "listRoomsAsync"
+          ],
+          "ListBlurbs": [
+            "listBlurbs",
+            "listBlurbsStream",
+            "listBlurbsAsync"
+          ]
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "MessagingClient",
+        "rpcs": {
+          "CreateRoom": [
+            "createRoom"
+          ],
+          "GetRoom": [
+            "getRoom"
+          ],
+          "UpdateRoom": [
+            "updateRoom"
+          ],
+          "DeleteRoom": [
+            "deleteRoom"
+          ],
+          "CreateBlurb": [
+            "createBlurb"
+          ],
+          "GetBlurb": [
+            "getBlurb"
+          ],
+          "UpdateBlurb": [
+            "updateBlurb"
+          ],
+          "DeleteBlurb": [
+            "deleteBlurb"
+          ],
+          "SearchBlurbs": [
+            "searchBlurbs",
+            "checkSearchBlurbsProgress"
+          ],
+          "ListRooms": [
+            "listRooms",
+            "listRoomsStream",
+            "listRoomsAsync"
+          ],
+          "ListBlurbs": [
+            "listBlurbs",
+            "listBlurbsStream",
+            "listBlurbsAsync"
+          ]
+        }
+      }
+    },
+    "Testing": {
+      "grpc": {
+        "libraryClient": "TestingClient",
+        "rpcs": {
+          "CreateSession": [
+            "createSession"
+          ],
+          "GetSession": [
+            "getSession"
+          ],
+          "DeleteSession": [
+            "deleteSession"
+          ],
+          "ReportSession": [
+            "reportSession"
+          ],
+          "DeleteTest": [
+            "deleteTest"
+          ],
+          "VerifyTest": [
+            "verifyTest"
+          ],
+          "ListSessions": [
+            "listSessions",
+            "listSessionsStream",
+            "listSessionsAsync"
+          ],
+          "ListTests": [
+            "listTests",
+            "listTestsStream",
+            "listTestsAsync"
+          ]
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "TestingClient",
+        "rpcs": {
+          "CreateSession": [
+            "createSession"
+          ],
+          "GetSession": [
+            "getSession"
+          ],
+          "DeleteSession": [
+            "deleteSession"
+          ],
+          "ReportSession": [
+            "reportSession"
+          ],
+          "DeleteTest": [
+            "deleteTest"
+          ],
+          "VerifyTest": [
+            "verifyTest"
+          ],
+          "ListSessions": [
+            "listSessions",
+            "listSessionsStream",
+            "listSessionsAsync"
+          ],
+          "ListTests": [
+            "listTests",
+            "listTestsStream",
+            "listTestsAsync"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
@@ -25,8 +25,7 @@
             "chat"
           ],
           "Wait": [
-            "wait",
-            "checkWaitProgress"
+            "wait"
           ],
           "PagedExpand": [
             "pagedExpand",
@@ -45,8 +44,7 @@
             "block"
           ],
           "Wait": [
-            "wait",
-            "checkWaitProgress"
+            "wait"
           ],
           "PagedExpand": [
             "pagedExpand",
@@ -140,8 +138,7 @@
             "connect"
           ],
           "SearchBlurbs": [
-            "searchBlurbs",
-            "checkSearchBlurbsProgress"
+            "searchBlurbs"
           ],
           "ListRooms": [
             "listRooms",
@@ -183,8 +180,7 @@
             "deleteBlurb"
           ],
           "SearchBlurbs": [
-            "searchBlurbs",
-            "checkSearchBlurbsProgress"
+            "searchBlurbs"
           ],
           "ListRooms": [
             "listRooms",

--- a/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
+++ b/baselines/showcase/src/v1beta1/gapic_metadata.json.baseline
@@ -35,7 +35,7 @@
           ]
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "EchoClient",
         "rpcs": {
           "Echo": [
@@ -79,7 +79,7 @@
           ]
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "IdentityClient",
         "rpcs": {
           "CreateUser": [
@@ -155,7 +155,7 @@
           ]
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "MessagingClient",
         "rpcs": {
           "CreateRoom": [
@@ -233,7 +233,7 @@
           ]
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "TestingClient",
         "rpcs": {
           "CreateSession": [

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -83,7 +83,7 @@ const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
 const validation = (argv.validation as string | undefined) ?? 'true';
-const metadata = argv.metadata as string | undefined;
+const metadata = argv.metadata as boolean | undefined;
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -32,48 +32,57 @@ const protocPlugin = fs.existsSync(protocPluginBash)
   ? protocPluginBash
   : path.join(__dirname, 'protoc-plugin.js');
 
-const argv = yargs
-  .array('I')
-  .nargs('I', 1)
-  .alias('proto_path', 'I')
-  .alias('proto-path', 'I')
-  .demandOption('output_dir')
-  .describe('I', 'Include directory to pass to protoc')
-  .alias('output-dir', 'output_dir')
-  .describe('gapic-validator_out', 'Path to the output of the gapic validator')
-  .alias('gapic-validator_out', 'gapic_validator_out')
-  .describe(
-    'validation',
-    'Option to set the validation of proto files, default value is true'
-  )
-  .describe('output_dir', 'Path to a directory for the generated code')
-  .alias('grpc-service-config', 'grpc_service_config')
-  .describe('grpc-service-config', 'Path to gRPC service config JSON')
-  .alias('bundle-config', 'bundle_config')
-  .describe('bundle-config', 'Path to bundle request config JSON')
-  .alias('iam-service', 'iam_service')
-  .describe('iam-service', 'Include IAM service to the generated client')
-  .alias('package-name', 'package_name')
-  .describe('package-name', 'Publish package name')
-  .alias('main-service', 'main_service')
-  .describe(
-    'main_service',
-    'Main service name (if the package has multiple services, this one will be used for Webpack bundle name)'
-  )
-  .alias('common-proto-path', 'common_protos_path')
-  .describe(
-    'common_proto_path',
-    'Path to API common protos to use (if unset, will use protos shipped with google-gax)'
-  )
-  .describe(
-    'template',
-    'Semicolon-separated list of templates to use. Allowed values: ' +
-      `"${allTemplates.join(';')}"`
-  )
-  .describe('metadata', 'Set to true if GAPIC metadata generation is requested')
-  .boolean('metadata').usage(`Usage: $0 -I /path/to/googleapis \\
-  --output_dir /path/to/output_directory \\
-  google/example/api/v1/api.proto`).argv;
+yargs.array('I');
+yargs.nargs('I', 1);
+yargs.alias('proto_path', 'I');
+yargs.alias('proto-path', 'I');
+yargs.demandOption('output_dir');
+yargs.describe('I', 'Include directory to pass to protoc');
+yargs.alias('output-dir', 'output_dir');
+yargs.describe(
+  'gapic-validator_out',
+  'Path to the output of the gapic validator'
+);
+yargs.alias('gapic-validator_out', 'gapic_validator_out');
+yargs.describe(
+  'validation',
+  'Option to set the validation of proto files, default value is true'
+);
+yargs.describe('output_dir', 'Path to a directory for the generated code');
+yargs.alias('grpc-service-config', 'grpc_service_config');
+yargs.describe('grpc-service-config', 'Path to gRPC service config JSON');
+yargs.alias('bundle-config', 'bundle_config');
+yargs.describe('bundle-config', 'Path to bundle request config JSON');
+yargs.alias('iam-service', 'iam_service');
+yargs.describe('iam-service', 'Include IAM service to the generated client');
+yargs.alias('package-name', 'package_name');
+yargs.describe('package-name', 'Publish package name');
+yargs.alias('main-service', 'main_service');
+yargs.describe(
+  'main_service',
+  'Main service name (if the package has multiple services, this one will be used for Webpack bundle name)'
+);
+yargs.alias('common-proto-path', 'common_protos_path');
+yargs.describe(
+  'common_proto_path',
+  'Path to API common protos to use (if unset, will use protos shipped with google-gax)'
+);
+yargs.describe(
+  'template',
+  `Semicolon-separated list of templates to use. Allowed values: "${allTemplates.join(
+    ';'
+  )}"`
+);
+yargs.describe(
+  'metadata',
+  'Set to true if GAPIC metadata generation is requested'
+);
+yargs.boolean('metadata');
+yargs.usage('Usage: $0 -I /path/to/googleapis');
+yargs.usage('  --output_dir /path/to/output_directory');
+yargs.usage('  google/example/api/v1/api.proto');
+
+const argv = yargs.argv;
 const outputDir = argv.outputDir as string;
 const grpcServiceConfig = argv.grpcServiceConfig as string | undefined;
 const bundleConfig = argv.bundleConfig as string | undefined;

--- a/src/gapic-generator-typescript.ts
+++ b/src/gapic-generator-typescript.ts
@@ -69,7 +69,9 @@ const argv = yargs
     'template',
     'Semicolon-separated list of templates to use. Allowed values: ' +
       `"${allTemplates.join(';')}"`
-  ).usage(`Usage: $0 -I /path/to/googleapis \\
+  )
+  .describe('metadata', 'Set to true if GAPIC metadata generation is requested')
+  .boolean('metadata').usage(`Usage: $0 -I /path/to/googleapis \\
   --output_dir /path/to/output_directory \\
   google/example/api/v1/api.proto`).argv;
 const outputDir = argv.outputDir as string;
@@ -81,6 +83,7 @@ const mainServiceName = argv.mainService as string | undefined;
 const template = argv.template as string | undefined;
 const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
 const validation = (argv.validation as string | undefined) ?? 'true';
+const metadata = argv.metadata as string | undefined;
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));
@@ -125,6 +128,9 @@ if (mainServiceName) {
 }
 if (template) {
   protocCommand.push(`--typescript_gapic_opt="template=${template}"`);
+}
+if (metadata) {
+  protocCommand.push('--typescript_gapic_opt="metadata"');
 }
 protocCommand.push('--experimental_allow_proto3_optional');
 protocCommand.push(...protoDirsArg);

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -37,6 +37,7 @@ const templatesDirectory = fs.existsSync(
   ? '../gapic_generator_typescript/templates'
   : path.join(__dirname, '..', 'templates');
 const defaultTemplates = ['typescript_gapic', 'typescript_packing_test'];
+const metadataTemplate = 'typescript_gapic_metadata';
 
 export class Generator {
   request: protos.google.protobuf.compiler.CodeGeneratorRequest;
@@ -51,6 +52,7 @@ export class Generator {
   mainServiceName?: string;
   iamService?: boolean;
   templates: string[];
+  metadata?: boolean;
 
   constructor() {
     this.request = protos.google.protobuf.compiler.CodeGeneratorRequest.create();
@@ -88,6 +90,9 @@ export class Generator {
         param = param.substring(1, param.length - 1);
       }
       const arr = param.split('=');
+      if (arr.length === 1) {
+        arr.push('true'); // "param" with no value gets converted to "param=true"
+      }
       this.paramMap[arr[0].toKebabCase()] = arr[1];
     }
   }
@@ -137,10 +142,13 @@ export class Generator {
   }
 
   private readTemplates() {
-    if (!this.paramMap['template']) {
-      return;
+    if (this.paramMap['template']) {
+      this.templates = this.paramMap['template'].split(';');
     }
-    this.templates = this.paramMap['template'].split(';');
+
+    if (this.paramMap['metadata'] === 'true') {
+      this.templates.push(metadataTemplate);
+    }
   }
 
   async initializeFromStdin() {

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -22,8 +22,8 @@ import * as protos from 'gapic_generator_typescript/protos';
 import {API} from './schema/api';
 
 interface Namer {
-  register: (name: string) => string;
-  get: (name: string) => string;
+  register: (name: string, serviceName?: string) => string;
+  get: (name: string, serviceName?: string) => string;
 }
 
 const commonParameters: {[name: string]: string} = {
@@ -110,6 +110,7 @@ function processOneTemplate(
       renderFile(outputFilename, relativeTemplateName, {
         api,
         commonParameters,
+        id,
       })
     );
   }

--- a/templates/typescript_gapic/_namer.njk
+++ b/templates/typescript_gapic/_namer.njk
@@ -16,6 +16,17 @@ limitations under the License.
 
 -#}
 
+{#-
+  initialize() macro should be called in the very beginning of
+  the template that wants to use the namer. It builds a local
+  dictionary of the names that are used by the given service
+  to prevent duplication (e.g. if the service has an RPC called
+  "FooAsync" and a paginated RPC called "Foo", the async iterator
+  implementation of the latter will conflict with the former;
+  initialize() will add "Foo" and "FooAsync" to the dictionary
+  and the conflicting "FooAsync" will become "FooAsync1".
+-#}
+
 {%- macro initialize(id, service) -%}
 {#- All method names from the given service are reserved -#}
 {%- for method in service.method -%}

--- a/templates/typescript_gapic_metadata/_namer.njk
+++ b/templates/typescript_gapic_metadata/_namer.njk
@@ -16,6 +16,17 @@ limitations under the License.
 
 -#}
 
+{#-
+  initialize() macro should be called in the very beginning of
+  the template that wants to use the namer. It builds a local
+  dictionary of the names that are used by the given service
+  to prevent duplication (e.g. if the service has an RPC called
+  "FooAsync" and a paginated RPC called "Foo", the async iterator
+  implementation of the latter will conflict with the former;
+  initialize() will add "Foo" and "FooAsync" to the dictionary
+  and the conflicting "FooAsync" will become "FooAsync1".
+-#}
+
 {%- macro initialize(id, api) -%}
 {#- All method names from all the services are reserved -#}
 {%- for service in api.services -%}

--- a/templates/typescript_gapic_metadata/_namer.njk
+++ b/templates/typescript_gapic_metadata/_namer.njk
@@ -1,0 +1,26 @@
+{#-
+
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-#}
+
+{%- macro initialize(id, api) -%}
+{#- All method names from all the services are reserved -#}
+{%- for service in api.services -%}
+  {%- for method in service.method -%}
+    {{- id.register(method.name.toCamelCase(), service.name) -}}
+  {%- endfor -%}
+{%- endfor -%}
+{%- endmacro -%}

--- a/templates/typescript_gapic_metadata/namer.js
+++ b/templates/typescript_gapic_metadata/namer.js
@@ -1,0 +1,67 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This helper file must export two functions that will be passed to
+ * the template engine.  The purpose of these functions is to perform
+ * name conflicts resolution that cannot be handled in the generator
+ * TypeScript code (since the generator does not know anything about
+ * the generated names), so the only place where this can happen is
+ * the template engine.
+ */
+
+/**
+ * Initialize local names storage.
+ */
+function initialize() {
+  if (typeof get.names === "undefined") {
+    get.names = new Set();
+  }
+}
+
+/**
+ * Generate a valid method name based on the given requested name.
+ *
+ * @param {string} name The original name to base on.
+ * @param {string} serviceName The service name the given name belongs to.
+ * @returns A generated name that should not have conflicts with known
+ * predefined names.
+ */
+function get(name, serviceName) {
+  initialize();
+
+  let counter = 0;
+  let newName = name;
+  while (get.names.has(`${serviceName}!${newName}`)) {
+    ++counter;
+    newName = `${name}${counter}`;
+  }
+
+  return newName;
+}
+
+/**
+ * Register the given reserved name.
+ *
+ * @param {string} name Reserved name that should not be used.
+ * @param {string} serviceName The service name the given name belongs to.
+ * @returns {string} Empty string (so it can be safely used in templates).
+ */
+function register(name, serviceName) {
+  initialize();
+
+  get.names.add(`${serviceName}!${name}`);
+  return '';
+}
+
+module.exports = {register, get};

--- a/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -1,0 +1,103 @@
+{#-
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-#}
+
+{#-
+  This template generates the metadata JSON that describes the generated
+  client library. To enable metadata generation, pass --metadata to the
+  generator (or, if using Bazel, set "metadata" plugin parameter to "true").
+
+  This JSON is supposed to match the given proto schema.
+  The generator design won't let us produce the proper proto JSON because
+  the generator itself has no idea about method naming (and, in general,
+  has no idea about TypeScript): all the naming logic is in the templates.
+  Hence, the metadata JSON is also a template that uses the same naming
+  logic. We'll do our best to make it compatible with the proper schema.
+-#}
+
+{% import "../../_namer.njk" as namer -%}
+{{- namer.initialize(id, api) -}}
+
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "typescript",
+  "protoPackage": "{{ api.naming.protoPackage }}",
+  "libraryPackage": "{{ api.publishName }}",
+  "services": {
+{%- set serviceJoiner = joiner(',') -%}
+{%- for service in api.services -%}
+    {{- serviceJoiner() -}}
+    "{{ service.name }}": {
+      "grpc": {
+        "libraryClient": "{{ service.name }}Client",
+        "rpcs": {
+{%- set grpcMethodJoiner = joiner(',') -%}
+{%- for method in service.simpleMethods -%}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": ["{{ method.name.toCamelCase() }}"]
+{%- endfor -%}
+{%- for method in service.streaming -%}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": ["{{ method.name.toCamelCase() }}"]
+{%- endfor -%}
+{%- for method in service.longRunning -%}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": [
+                                "{{ method.name.toCamelCase() }}",
+                                "{{ id.get("check" + method.name.toPascalCase() + "Progress", service.name) }}"
+                               ]
+{%- endfor -%}
+{%- for method in service.paging %}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": [
+                                "{{ method.name.toCamelCase() }}",
+                                "{{ id.get(method.name.toCamelCase() + "Stream", service.name) }}",
+                                "{{ id.get(method.name.toCamelCase() + "Async", service.name) }}"
+                               ]
+{%- endfor -%}
+        }
+      },
+      "proto-over-http": {
+        "libraryClient": "{{ service.name }}Client",
+        "rpcs": {
+{%- set fallbackMethodJoiner = joiner(',') -%}
+{%- for method in service.simpleMethods -%}
+          {{- fallbackMethodJoiner() -}}
+          "{{ method.name }}": ["{{ method.name.toCamelCase() }}"]
+{%- endfor -%}
+{%- for method in service.longRunning -%}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": [
+                                "{{ method.name.toCamelCase() }}",
+                                "{{ id.get("check" + method.name.toPascalCase() + "Progress", service.name) }}"
+                               ]
+{%- endfor -%}
+{%- for method in service.paging %}
+          {{- grpcMethodJoiner() -}}
+          "{{ method.name }}": [
+                                "{{ method.name.toCamelCase() }}",
+                                "{{ id.get(method.name.toCamelCase() + "Stream", service.name) }}",
+                                "{{ id.get(method.name.toCamelCase() + "Async", service.name) }}"
+                               ]
+{%- endfor -%}
+        }
+      }
+    }
+{%- endfor -%}
+  }
+}

--- a/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -59,8 +59,7 @@ limitations under the License.
 {%- for method in service.longRunning -%}
           {{- grpcMethodJoiner() -}}
           "{{ method.name }}": [
-                                "{{ method.name.toCamelCase() }}",
-                                "{{ id.get("check" + method.name.toPascalCase() + "Progress", service.name) }}"
+                                "{{ method.name.toCamelCase() }}"
                                ]
 {%- endfor -%}
 {%- for method in service.paging %}
@@ -84,8 +83,7 @@ limitations under the License.
 {%- for method in service.longRunning -%}
           {{- grpcMethodJoiner() -}}
           "{{ method.name }}": [
-                                "{{ method.name.toCamelCase() }}",
-                                "{{ id.get("check" + method.name.toPascalCase() + "Progress", service.name) }}"
+                                "{{ method.name.toCamelCase() }}"
                                ]
 {%- endfor -%}
 {%- for method in service.paging %}

--- a/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -73,7 +73,7 @@ limitations under the License.
 {%- endfor -%}
         }
       },
-      "proto-over-http": {
+      "grpc-fallback": {
         "libraryClient": "{{ service.name }}Client",
         "rpcs": {
 {%- set fallbackMethodJoiner = joiner(',') -%}

--- a/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -43,6 +43,7 @@ limitations under the License.
 {%- for service in api.services -%}
     {{- serviceJoiner() -}}
     "{{ service.name }}": {
+{#- TODO(@alexander-fenster): replace hardcoded transports ("grpc", etc.) with an iteration. -#}
       "grpc": {
         "libraryClient": "{{ service.name }}Client",
         "rpcs": {

--- a/test/unit/baselines.ts
+++ b/test/unit/baselines.ts
@@ -76,6 +76,7 @@ describe('Baseline tests', () => {
     useCommonProto: false,
     mainServiceName: 'ShowcaseService',
     template: 'typescript_gapic;typescript_packing_test',
+    metadata: true,
   });
 
   runBaselineTest({
@@ -133,5 +134,6 @@ describe('Baseline tests', () => {
     outputDir: '.test-out-naming',
     protoPath: 'google/naming/v1beta1/*.proto',
     useCommonProto: false,
+    metadata: true,
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -35,6 +35,7 @@ export interface BaselineOptions {
   template?: string;
   bundleConfig?: string;
   iamService?: boolean;
+  metadata?: boolean;
 }
 
 const cwd = process.cwd();
@@ -108,6 +109,9 @@ export function runBaselineTest(options: BaselineOptions) {
     }
     if (options.iamService) {
       commandLine += ` --iam-service="${iamService}"`;
+    }
+    if (options.metadata) {
+      commandLine += ' --metadata';
     }
     execSync(commandLine);
     assert(equalToBaseline(outputDir, baselineDir));


### PR DESCRIPTION
This PR implements GAPIC metadata proposal. When `--metadata` is passed to the generator (or `"metadata"` parameter is passed to the generator `protoc` plugin), an extra file `gapic_metadata.json`, one per version, is generated and placed into `src/v*/` folder.  The JSON file format is consistent with the schema that will be published to `googleapis` repository soon.

@vchudnov-g Please take a look at the baseline output for Showcase. A few notes:
- we generate an extra method, `check....Progress`, that can be used to check the progress of the given long running operation by name, and get its result if it's completed. This call technically does not call the corresponding long running RPC, but is related to it. Not sure if it should be included in the JSON.
- I called our existing HTTP implementation `proto-over-http`, not `rest`, because `rest` will be reserved for DIREGAPIC implementation. I can use any other name if you prefer.

Just FYI, the `naming` baseline test checks some weird situations where the extra method name conflicts with an existing RPC. It's based on [this proto](https://github.com/googleapis/gapic-generator-typescript/blob/master/test-fixtures/protos/google/naming/v1beta1/naming.proto) that I created to expose all possible naming conflicts in the generated TypeScript library. From what I see, the JSON is generated properly for this proto.

Thank you for your review!