### PR TITLE
fix: linting errors and better jsdoc

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -21,6 +21,11 @@ import {Callback, CallOptions, Descriptors, ClientOptions, LROperation} from 'go
 import * as path from 'path';
 
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1/asset_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './asset_service_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -75,9 +80,9 @@ export class AssetServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `asset_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -89,6 +94,7 @@ export class AssetServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -307,14 +313,14 @@ export class AssetServiceClient {
   // -------------------
   batchGetAssetsHistory(
       request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
         protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|undefined, {}|undefined
       ]>;
   batchGetAssetsHistory(
       request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
@@ -372,7 +378,7 @@ export class AssetServiceClient {
  */
   batchGetAssetsHistory(
       request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
           {}|null|undefined>,
@@ -385,13 +391,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -406,14 +412,14 @@ export class AssetServiceClient {
   }
   createFeed(
       request: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
         protos.google.cloud.asset.v1.ICreateFeedRequest|undefined, {}|undefined
       ]>;
   createFeed(
       request: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
@@ -457,7 +463,7 @@ export class AssetServiceClient {
  */
   createFeed(
       request: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
           {}|null|undefined>,
@@ -470,13 +476,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.ICreateFeedRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -491,14 +497,14 @@ export class AssetServiceClient {
   }
   getFeed(
       request: protos.google.cloud.asset.v1.IGetFeedRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
         protos.google.cloud.asset.v1.IGetFeedRequest|undefined, {}|undefined
       ]>;
   getFeed(
       request: protos.google.cloud.asset.v1.IGetFeedRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
@@ -531,7 +537,7 @@ export class AssetServiceClient {
  */
   getFeed(
       request: protos.google.cloud.asset.v1.IGetFeedRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
           {}|null|undefined>,
@@ -544,13 +550,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.IGetFeedRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -565,14 +571,14 @@ export class AssetServiceClient {
   }
   listFeeds(
       request: protos.google.cloud.asset.v1.IListFeedsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IListFeedsResponse,
         protos.google.cloud.asset.v1.IListFeedsRequest|undefined, {}|undefined
       ]>;
   listFeeds(
       request: protos.google.cloud.asset.v1.IListFeedsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.asset.v1.IListFeedsResponse,
           protos.google.cloud.asset.v1.IListFeedsRequest|null|undefined,
@@ -604,7 +610,7 @@ export class AssetServiceClient {
  */
   listFeeds(
       request: protos.google.cloud.asset.v1.IListFeedsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IListFeedsResponse,
           protos.google.cloud.asset.v1.IListFeedsRequest|null|undefined,
           {}|null|undefined>,
@@ -617,13 +623,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.IListFeedsRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -638,14 +644,14 @@ export class AssetServiceClient {
   }
   updateFeed(
       request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
         protos.google.cloud.asset.v1.IUpdateFeedRequest|undefined, {}|undefined
       ]>;
   updateFeed(
       request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
@@ -683,7 +689,7 @@ export class AssetServiceClient {
  */
   updateFeed(
       request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
           {}|null|undefined>,
@@ -696,13 +702,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.IUpdateFeedRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -717,14 +723,14 @@ export class AssetServiceClient {
   }
   deleteFeed(
       request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.cloud.asset.v1.IDeleteFeedRequest|undefined, {}|undefined
       ]>;
   deleteFeed(
       request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
@@ -757,7 +763,7 @@ export class AssetServiceClient {
  */
   deleteFeed(
       request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
           {}|null|undefined>,
@@ -770,13 +776,13 @@ export class AssetServiceClient {
         protos.google.cloud.asset.v1.IDeleteFeedRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -792,14 +798,14 @@ export class AssetServiceClient {
 
   exportAssets(
       request: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   exportAssets(
       request: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -856,7 +862,7 @@ export class AssetServiceClient {
  */
   exportAssets(
       request: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -869,13 +875,13 @@ export class AssetServiceClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -21,6 +21,11 @@ import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 import * as path from 'path';
 
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/big_query_storage_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './big_query_storage_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class BigQueryStorageClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `big_query_storage_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class BigQueryStorageClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -288,14 +294,14 @@ export class BigQueryStorageClient {
   // -------------------
   createReadSession(
       request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
         protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|undefined, {}|undefined
       ]>;
   createReadSession(
       request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
           protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
@@ -357,7 +363,7 @@ export class BigQueryStorageClient {
  */
   createReadSession(
       request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
           protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -370,13 +376,13 @@ export class BigQueryStorageClient {
         protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -392,14 +398,14 @@ export class BigQueryStorageClient {
   }
   batchCreateReadSessionStreams(
       request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
         protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|undefined, {}|undefined
       ]>;
   batchCreateReadSessionStreams(
       request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
@@ -436,7 +442,7 @@ export class BigQueryStorageClient {
  */
   batchCreateReadSessionStreams(
       request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
           {}|null|undefined>,
@@ -449,13 +455,13 @@ export class BigQueryStorageClient {
         protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -470,14 +476,14 @@ export class BigQueryStorageClient {
   }
   finalizeStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|undefined, {}|undefined
       ]>;
   finalizeStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
@@ -520,7 +526,7 @@ export class BigQueryStorageClient {
  */
   finalizeStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
           {}|null|undefined>,
@@ -533,13 +539,13 @@ export class BigQueryStorageClient {
         protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -554,14 +560,14 @@ export class BigQueryStorageClient {
   }
   splitReadStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
         protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|undefined, {}|undefined
       ]>;
   splitReadStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
@@ -611,7 +617,7 @@ export class BigQueryStorageClient {
  */
   splitReadStream(
       request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
           {}|null|undefined>,
@@ -624,13 +630,13 @@ export class BigQueryStorageClient {
         protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -675,7 +681,7 @@ export class BigQueryStorageClient {
  */
   readRows(
       request?: protos.google.cloud.bigquery.storage.v1beta1.IReadRowsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     options = options || {};

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/echo_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './echo_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -81,9 +86,9 @@ export class EchoClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `echo_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -95,6 +100,7 @@ export class EchoClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -347,14 +353,14 @@ export class EchoClient {
   // -------------------
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined
       ]>;
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -384,7 +390,7 @@ export class EchoClient {
  */
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
           {}|null|undefined>,
@@ -397,13 +403,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -411,14 +417,14 @@ export class EchoClient {
   }
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlockResponse,
         protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
       ]>;
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
@@ -455,7 +461,7 @@ export class EchoClient {
  */
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
           {}|null|undefined>,
@@ -468,13 +474,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -505,7 +511,7 @@ export class EchoClient {
  */
   expand(
       request?: protos.google.showcase.v1beta1.IExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     options = options || {};
@@ -514,7 +520,7 @@ export class EchoClient {
   }
 
   collect(
-      options?: gax.CallOptions,
+      options?: CallOptions,
       callback?: Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -544,7 +550,7 @@ export class EchoClient {
  * stream.end();
  */
   collect(
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
         {}|null|undefined>,
@@ -557,7 +563,7 @@ export class EchoClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    const options = optionsOrCallback as gax.CallOptions;
+    const options = optionsOrCallback as CallOptions;
     this.initialize();
     return this.innerApiCalls.collect(null, options, callback);
   }
@@ -584,7 +590,7 @@ export class EchoClient {
  * stream.end();
  */
   chat(
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
     return this.innerApiCalls.chat(options);
@@ -592,14 +598,14 @@ export class EchoClient {
 
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -640,7 +646,7 @@ export class EchoClient {
  */
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -653,13 +659,13 @@ export class EchoClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -688,7 +694,7 @@ export class EchoClient {
   }
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse[],
         protos.google.showcase.v1beta1.IPagedExpandRequest|null,
@@ -696,7 +702,7 @@ export class EchoClient {
       ]>;
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
@@ -734,7 +740,7 @@ export class EchoClient {
  */
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
           protos.google.showcase.v1beta1.IEchoResponse>,
@@ -748,13 +754,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IPagedExpandResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -785,7 +791,7 @@ export class EchoClient {
  */
   pagedExpandStream(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -828,7 +834,7 @@ export class EchoClient {
  */
   pagedExpandAsync(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>{
     request = request || {};
     options = options || {};

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/identity_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './identity_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class IdentityClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `identity_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class IdentityClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -307,14 +313,14 @@ export class IdentityClient {
   // -------------------
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.ICreateUserRequest|undefined, {}|undefined
       ]>;
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
@@ -344,7 +350,7 @@ export class IdentityClient {
  */
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
           {}|null|undefined>,
@@ -357,13 +363,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.ICreateUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -371,14 +377,14 @@ export class IdentityClient {
   }
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.IGetUserRequest|undefined, {}|undefined
       ]>;
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
@@ -408,7 +414,7 @@ export class IdentityClient {
  */
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
           {}|null|undefined>,
@@ -421,13 +427,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IGetUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -442,14 +448,14 @@ export class IdentityClient {
   }
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
       ]>;
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
@@ -482,7 +488,7 @@ export class IdentityClient {
  */
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
           {}|null|undefined>,
@@ -495,13 +501,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -516,14 +522,14 @@ export class IdentityClient {
   }
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteUserRequest|undefined, {}|undefined
       ]>;
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
@@ -553,7 +559,7 @@ export class IdentityClient {
  */
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
           {}|null|undefined>,
@@ -566,13 +572,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IDeleteUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -588,7 +594,7 @@ export class IdentityClient {
 
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser[],
         protos.google.showcase.v1beta1.IListUsersRequest|null,
@@ -596,7 +602,7 @@ export class IdentityClient {
       ]>;
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
@@ -634,7 +640,7 @@ export class IdentityClient {
  */
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
           protos.google.showcase.v1beta1.IUser>,
@@ -648,13 +654,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IListUsersResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -686,7 +692,7 @@ export class IdentityClient {
  */
   listUsersStream(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -730,7 +736,7 @@ export class IdentityClient {
  */
   listUsersAsync(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IUser>{
     request = request || {};
     options = options || {};

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/messaging_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './messaging_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -80,9 +85,9 @@ export class MessagingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `messaging_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -94,6 +99,7 @@ export class MessagingClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -348,14 +354,14 @@ export class MessagingClient {
   // -------------------
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.ICreateRoomRequest|undefined, {}|undefined
       ]>;
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
@@ -385,7 +391,7 @@ export class MessagingClient {
  */
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -398,13 +404,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.ICreateRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -412,14 +418,14 @@ export class MessagingClient {
   }
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.IGetRoomRequest|undefined, {}|undefined
       ]>;
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
@@ -449,7 +455,7 @@ export class MessagingClient {
  */
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -462,13 +468,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IGetRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -483,14 +489,14 @@ export class MessagingClient {
   }
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
       ]>;
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
@@ -523,7 +529,7 @@ export class MessagingClient {
  */
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -536,13 +542,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -557,14 +563,14 @@ export class MessagingClient {
   }
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteRoomRequest|undefined, {}|undefined
       ]>;
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
@@ -594,7 +600,7 @@ export class MessagingClient {
  */
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -607,13 +613,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IDeleteRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -628,14 +634,14 @@ export class MessagingClient {
   }
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
       ]>;
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -670,7 +676,7 @@ export class MessagingClient {
  */
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -683,13 +689,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -704,14 +710,14 @@ export class MessagingClient {
   }
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.IGetBlurbRequest|undefined, {}|undefined
       ]>;
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
@@ -741,7 +747,7 @@ export class MessagingClient {
  */
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -754,13 +760,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IGetBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -775,14 +781,14 @@ export class MessagingClient {
   }
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
       ]>;
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
@@ -815,7 +821,7 @@ export class MessagingClient {
  */
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -828,13 +834,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -849,14 +855,14 @@ export class MessagingClient {
   }
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteBlurbRequest|undefined, {}|undefined
       ]>;
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
@@ -886,7 +892,7 @@ export class MessagingClient {
  */
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -899,13 +905,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IDeleteBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -943,7 +949,7 @@ export class MessagingClient {
  */
   streamBlurbs(
       request?: protos.google.showcase.v1beta1.IStreamBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     options = options || {};
@@ -959,7 +965,7 @@ export class MessagingClient {
   }
 
   sendBlurbs(
-      options?: gax.CallOptions,
+      options?: CallOptions,
       callback?: Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -988,7 +994,7 @@ export class MessagingClient {
  * stream.end();
  */
   sendBlurbs(
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
         {}|null|undefined>,
@@ -1001,7 +1007,7 @@ export class MessagingClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    const options = optionsOrCallback as gax.CallOptions;
+    const options = optionsOrCallback as CallOptions;
     this.initialize();
     return this.innerApiCalls.sendBlurbs(null, options, callback);
   }
@@ -1029,7 +1035,7 @@ export class MessagingClient {
  * stream.end();
  */
   connect(
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
     return this.innerApiCalls.connect(options);
@@ -1037,14 +1043,14 @@ export class MessagingClient {
 
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1092,7 +1098,7 @@ export class MessagingClient {
  */
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -1105,13 +1111,13 @@ export class MessagingClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1147,7 +1153,7 @@ export class MessagingClient {
   }
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom[],
         protos.google.showcase.v1beta1.IListRoomsRequest|null,
@@ -1155,7 +1161,7 @@ export class MessagingClient {
       ]>;
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
@@ -1193,7 +1199,7 @@ export class MessagingClient {
  */
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
           protos.google.showcase.v1beta1.IRoom>,
@@ -1207,13 +1213,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IListRoomsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -1245,7 +1251,7 @@ export class MessagingClient {
  */
   listRoomsStream(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1289,7 +1295,7 @@ export class MessagingClient {
  */
   listRoomsAsync(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IRoom>{
     request = request || {};
     options = options || {};
@@ -1304,7 +1310,7 @@ export class MessagingClient {
   }
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb[],
         protos.google.showcase.v1beta1.IListBlurbsRequest|null,
@@ -1312,7 +1318,7 @@ export class MessagingClient {
       ]>;
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
@@ -1354,7 +1360,7 @@ export class MessagingClient {
  */
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
           protos.google.showcase.v1beta1.IBlurb>,
@@ -1368,13 +1374,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IListBlurbsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1416,7 +1422,7 @@ export class MessagingClient {
  */
   listBlurbsStream(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1470,7 +1476,7 @@ export class MessagingClient {
  */
   listBlurbsAsync(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IBlurb>{
     request = request || {};
     options = options || {};

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/testing_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './testing_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class TestingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `testing_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class TestingClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -310,14 +316,14 @@ export class TestingClient {
   // -------------------
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
         protos.google.showcase.v1beta1.ICreateSessionRequest|undefined, {}|undefined
       ]>;
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
@@ -349,7 +355,7 @@ export class TestingClient {
  */
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -362,13 +368,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.ICreateSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -376,14 +382,14 @@ export class TestingClient {
   }
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
         protos.google.showcase.v1beta1.IGetSessionRequest|undefined, {}|undefined
       ]>;
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
@@ -413,7 +419,7 @@ export class TestingClient {
  */
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -426,13 +432,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IGetSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -447,14 +453,14 @@ export class TestingClient {
   }
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteSessionRequest|undefined, {}|undefined
       ]>;
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
@@ -484,7 +490,7 @@ export class TestingClient {
  */
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -497,13 +503,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IDeleteSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -518,14 +524,14 @@ export class TestingClient {
   }
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IReportSessionResponse,
         protos.google.showcase.v1beta1.IReportSessionRequest|undefined, {}|undefined
       ]>;
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
@@ -557,7 +563,7 @@ export class TestingClient {
  */
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -570,13 +576,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IReportSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -591,14 +597,14 @@ export class TestingClient {
   }
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
       ]>;
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
@@ -633,7 +639,7 @@ export class TestingClient {
  */
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
           {}|null|undefined>,
@@ -646,13 +652,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -667,14 +673,14 @@ export class TestingClient {
   }
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IVerifyTestResponse,
         protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
       ]>;
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
@@ -711,7 +717,7 @@ export class TestingClient {
  */
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
           {}|null|undefined>,
@@ -724,13 +730,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -746,7 +752,7 @@ export class TestingClient {
 
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession[],
         protos.google.showcase.v1beta1.IListSessionsRequest|null,
@@ -754,7 +760,7 @@ export class TestingClient {
       ]>;
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
@@ -789,7 +795,7 @@ export class TestingClient {
  */
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
           protos.google.showcase.v1beta1.ISession>,
@@ -803,13 +809,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IListSessionsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -838,7 +844,7 @@ export class TestingClient {
  */
   listSessionsStream(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -879,7 +885,7 @@ export class TestingClient {
  */
   listSessionsAsync(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.ISession>{
     request = request || {};
     options = options || {};
@@ -894,7 +900,7 @@ export class TestingClient {
   }
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ITest[],
         protos.google.showcase.v1beta1.IListTestsRequest|null,
@@ -902,7 +908,7 @@ export class TestingClient {
       ]>;
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
@@ -939,7 +945,7 @@ export class TestingClient {
  */
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
           protos.google.showcase.v1beta1.ITest>,
@@ -953,13 +959,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IListTestsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -997,7 +1003,7 @@ export class TestingClient {
  */
   listTestsStream(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1047,7 +1053,7 @@ export class TestingClient {
  */
   listTestsAsync(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.ITest>{
     request = request || {};
     options = options || {};

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v2/dlp_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './dlp_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -84,9 +89,9 @@ export class DlpServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `dlp_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -98,6 +103,7 @@ export class DlpServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -328,14 +334,14 @@ export class DlpServiceClient {
   // -------------------
   inspectContent(
       request: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectContentResponse,
         protos.google.privacy.dlp.v2.IInspectContentRequest|undefined, {}|undefined
       ]>;
   inspectContent(
       request: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IInspectContentResponse,
           protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
@@ -387,7 +393,7 @@ export class DlpServiceClient {
  */
   inspectContent(
       request: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectContentResponse,
           protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
           {}|null|undefined>,
@@ -400,13 +406,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IInspectContentRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -421,14 +427,14 @@ export class DlpServiceClient {
   }
   redactImage(
       request: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IRedactImageResponse,
         protos.google.privacy.dlp.v2.IRedactImageRequest|undefined, {}|undefined
       ]>;
   redactImage(
       request: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IRedactImageResponse,
           protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
@@ -477,7 +483,7 @@ export class DlpServiceClient {
  */
   redactImage(
       request: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IRedactImageResponse,
           protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
           {}|null|undefined>,
@@ -490,13 +496,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IRedactImageRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -511,14 +517,14 @@ export class DlpServiceClient {
   }
   deidentifyContent(
       request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
         protos.google.privacy.dlp.v2.IDeidentifyContentRequest|undefined, {}|undefined
       ]>;
   deidentifyContent(
       request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
           protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
@@ -580,7 +586,7 @@ export class DlpServiceClient {
  */
   deidentifyContent(
       request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
           protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
           {}|null|undefined>,
@@ -593,13 +599,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeidentifyContentRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -614,14 +620,14 @@ export class DlpServiceClient {
   }
   reidentifyContent(
       request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IReidentifyContentResponse,
         protos.google.privacy.dlp.v2.IReidentifyContentRequest|undefined, {}|undefined
       ]>;
   reidentifyContent(
       request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IReidentifyContentResponse,
           protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
@@ -685,7 +691,7 @@ export class DlpServiceClient {
  */
   reidentifyContent(
       request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IReidentifyContentResponse,
           protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
           {}|null|undefined>,
@@ -698,13 +704,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IReidentifyContentRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -719,14 +725,14 @@ export class DlpServiceClient {
   }
   listInfoTypes(
       request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IListInfoTypesResponse,
         protos.google.privacy.dlp.v2.IListInfoTypesRequest|undefined, {}|undefined
       ]>;
   listInfoTypes(
       request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IListInfoTypesResponse,
           protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
@@ -766,7 +772,7 @@ export class DlpServiceClient {
  */
   listInfoTypes(
       request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IListInfoTypesResponse,
           protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
           {}|null|undefined>,
@@ -779,13 +785,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListInfoTypesRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -800,14 +806,14 @@ export class DlpServiceClient {
   }
   createInspectTemplate(
       request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
         protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|undefined, {}|undefined
       ]>;
   createInspectTemplate(
       request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
@@ -850,7 +856,7 @@ export class DlpServiceClient {
  */
   createInspectTemplate(
       request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -863,13 +869,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -884,14 +890,14 @@ export class DlpServiceClient {
   }
   updateInspectTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
         protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|undefined, {}|undefined
       ]>;
   updateInspectTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
@@ -928,7 +934,7 @@ export class DlpServiceClient {
  */
   updateInspectTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -941,13 +947,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -962,14 +968,14 @@ export class DlpServiceClient {
   }
   getInspectTemplate(
       request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
         protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|undefined, {}|undefined
       ]>;
   getInspectTemplate(
       request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
@@ -1002,7 +1008,7 @@ export class DlpServiceClient {
  */
   getInspectTemplate(
       request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1015,13 +1021,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1036,14 +1042,14 @@ export class DlpServiceClient {
   }
   deleteInspectTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|undefined, {}|undefined
       ]>;
   deleteInspectTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
@@ -1076,7 +1082,7 @@ export class DlpServiceClient {
  */
   deleteInspectTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1089,13 +1095,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1110,14 +1116,14 @@ export class DlpServiceClient {
   }
   createDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
         protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|undefined, {}|undefined
       ]>;
   createDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
@@ -1161,7 +1167,7 @@ export class DlpServiceClient {
  */
   createDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1174,13 +1180,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1195,14 +1201,14 @@ export class DlpServiceClient {
   }
   updateDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
         protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|undefined, {}|undefined
       ]>;
   updateDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
@@ -1240,7 +1246,7 @@ export class DlpServiceClient {
  */
   updateDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1253,13 +1259,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1274,14 +1280,14 @@ export class DlpServiceClient {
   }
   getDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
         protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|undefined, {}|undefined
       ]>;
   getDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
@@ -1315,7 +1321,7 @@ export class DlpServiceClient {
  */
   getDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1328,13 +1334,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1349,14 +1355,14 @@ export class DlpServiceClient {
   }
   deleteDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|undefined, {}|undefined
       ]>;
   deleteDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
@@ -1390,7 +1396,7 @@ export class DlpServiceClient {
  */
   deleteDeidentifyTemplate(
       request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
           {}|null|undefined>,
@@ -1403,13 +1409,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1424,14 +1430,14 @@ export class DlpServiceClient {
   }
   createJobTrigger(
       request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
         protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|undefined, {}|undefined
       ]>;
   createJobTrigger(
       request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
@@ -1473,7 +1479,7 @@ export class DlpServiceClient {
  */
   createJobTrigger(
       request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
           {}|null|undefined>,
@@ -1486,13 +1492,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1507,14 +1513,14 @@ export class DlpServiceClient {
   }
   updateJobTrigger(
       request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
         protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|undefined, {}|undefined
       ]>;
   updateJobTrigger(
       request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
@@ -1550,7 +1556,7 @@ export class DlpServiceClient {
  */
   updateJobTrigger(
       request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
           {}|null|undefined>,
@@ -1563,13 +1569,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1584,14 +1590,14 @@ export class DlpServiceClient {
   }
   getJobTrigger(
       request: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
         protos.google.privacy.dlp.v2.IGetJobTriggerRequest|undefined, {}|undefined
       ]>;
   getJobTrigger(
       request: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IGetJobTriggerRequest|null|undefined,
@@ -1623,7 +1629,7 @@ export class DlpServiceClient {
  */
   getJobTrigger(
       request: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IGetJobTriggerRequest|null|undefined,
           {}|null|undefined>,
@@ -1636,13 +1642,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IGetJobTriggerRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1657,14 +1663,14 @@ export class DlpServiceClient {
   }
   deleteJobTrigger(
       request: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|undefined, {}|undefined
       ]>;
   deleteJobTrigger(
       request: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|null|undefined,
@@ -1696,7 +1702,7 @@ export class DlpServiceClient {
  */
   deleteJobTrigger(
       request: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|null|undefined,
           {}|null|undefined>,
@@ -1709,13 +1715,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1730,14 +1736,14 @@ export class DlpServiceClient {
   }
   activateJobTrigger(
       request: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
         protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|undefined, {}|undefined
       ]>;
   activateJobTrigger(
       request: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|null|undefined,
@@ -1769,7 +1775,7 @@ export class DlpServiceClient {
  */
   activateJobTrigger(
       request: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|null|undefined,
           {}|null|undefined>,
@@ -1782,13 +1788,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1803,14 +1809,14 @@ export class DlpServiceClient {
   }
   createDlpJob(
       request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
         protos.google.privacy.dlp.v2.ICreateDlpJobRequest|undefined, {}|undefined
       ]>;
   createDlpJob(
       request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
@@ -1858,7 +1864,7 @@ export class DlpServiceClient {
  */
   createDlpJob(
       request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
           {}|null|undefined>,
@@ -1871,13 +1877,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICreateDlpJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1892,14 +1898,14 @@ export class DlpServiceClient {
   }
   getDlpJob(
       request: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
         protos.google.privacy.dlp.v2.IGetDlpJobRequest|undefined, {}|undefined
       ]>;
   getDlpJob(
       request: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IGetDlpJobRequest|null|undefined,
@@ -1931,7 +1937,7 @@ export class DlpServiceClient {
  */
   getDlpJob(
       request: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IGetDlpJobRequest|null|undefined,
           {}|null|undefined>,
@@ -1944,13 +1950,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IGetDlpJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1965,14 +1971,14 @@ export class DlpServiceClient {
   }
   deleteDlpJob(
       request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|undefined, {}|undefined
       ]>;
   deleteDlpJob(
       request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
@@ -2006,7 +2012,7 @@ export class DlpServiceClient {
  */
   deleteDlpJob(
       request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
           {}|null|undefined>,
@@ -2019,13 +2025,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2040,14 +2046,14 @@ export class DlpServiceClient {
   }
   cancelDlpJob(
       request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.ICancelDlpJobRequest|undefined, {}|undefined
       ]>;
   cancelDlpJob(
       request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
@@ -2081,7 +2087,7 @@ export class DlpServiceClient {
  */
   cancelDlpJob(
       request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
           {}|null|undefined>,
@@ -2094,13 +2100,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICancelDlpJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2115,14 +2121,14 @@ export class DlpServiceClient {
   }
   createStoredInfoType(
       request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
         protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|undefined, {}|undefined
       ]>;
   createStoredInfoType(
       request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
@@ -2165,7 +2171,7 @@ export class DlpServiceClient {
  */
   createStoredInfoType(
       request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
           {}|null|undefined>,
@@ -2178,13 +2184,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2199,14 +2205,14 @@ export class DlpServiceClient {
   }
   updateStoredInfoType(
       request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
         protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|undefined, {}|undefined
       ]>;
   updateStoredInfoType(
       request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
@@ -2247,7 +2253,7 @@ export class DlpServiceClient {
  */
   updateStoredInfoType(
       request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
           {}|null|undefined>,
@@ -2260,13 +2266,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2281,14 +2287,14 @@ export class DlpServiceClient {
   }
   getStoredInfoType(
       request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
         protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|undefined, {}|undefined
       ]>;
   getStoredInfoType(
       request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
@@ -2322,7 +2328,7 @@ export class DlpServiceClient {
  */
   getStoredInfoType(
       request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
           {}|null|undefined>,
@@ -2335,13 +2341,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2356,14 +2362,14 @@ export class DlpServiceClient {
   }
   deleteStoredInfoType(
       request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|undefined, {}|undefined
       ]>;
   deleteStoredInfoType(
       request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
@@ -2397,7 +2403,7 @@ export class DlpServiceClient {
  */
   deleteStoredInfoType(
       request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
           {}|null|undefined>,
@@ -2410,13 +2416,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2432,7 +2438,7 @@ export class DlpServiceClient {
 
   listInspectTemplates(
       request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate[],
         protos.google.privacy.dlp.v2.IListInspectTemplatesRequest|null,
@@ -2440,7 +2446,7 @@ export class DlpServiceClient {
       ]>;
   listInspectTemplates(
       request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
           protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
@@ -2498,7 +2504,7 @@ export class DlpServiceClient {
  */
   listInspectTemplates(
       request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
           protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
           protos.google.privacy.dlp.v2.IInspectTemplate>,
@@ -2512,13 +2518,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListInspectTemplatesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2576,7 +2582,7 @@ export class DlpServiceClient {
  */
   listInspectTemplatesStream(
       request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2646,7 +2652,7 @@ export class DlpServiceClient {
  */
   listInspectTemplatesAsync(
       request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.privacy.dlp.v2.IInspectTemplate>{
     request = request || {};
     options = options || {};
@@ -2668,7 +2674,7 @@ export class DlpServiceClient {
   }
   listDeidentifyTemplates(
       request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate[],
         protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest|null,
@@ -2676,7 +2682,7 @@ export class DlpServiceClient {
       ]>;
   listDeidentifyTemplates(
       request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
@@ -2735,7 +2741,7 @@ export class DlpServiceClient {
  */
   listDeidentifyTemplates(
       request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
           protos.google.privacy.dlp.v2.IDeidentifyTemplate>,
@@ -2749,13 +2755,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2813,7 +2819,7 @@ export class DlpServiceClient {
  */
   listDeidentifyTemplatesStream(
       request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2883,7 +2889,7 @@ export class DlpServiceClient {
  */
   listDeidentifyTemplatesAsync(
       request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.privacy.dlp.v2.IDeidentifyTemplate>{
     request = request || {};
     options = options || {};
@@ -2905,7 +2911,7 @@ export class DlpServiceClient {
   }
   listJobTriggers(
       request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger[],
         protos.google.privacy.dlp.v2.IListJobTriggersRequest|null,
@@ -2913,7 +2919,7 @@ export class DlpServiceClient {
       ]>;
   listJobTriggers(
       request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.privacy.dlp.v2.IListJobTriggersRequest,
           protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
@@ -2997,7 +3003,7 @@ export class DlpServiceClient {
  */
   listJobTriggers(
       request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListJobTriggersRequest,
           protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
           protos.google.privacy.dlp.v2.IJobTrigger>,
@@ -3011,13 +3017,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListJobTriggersResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -3101,7 +3107,7 @@ export class DlpServiceClient {
  */
   listJobTriggersStream(
       request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -3197,7 +3203,7 @@ export class DlpServiceClient {
  */
   listJobTriggersAsync(
       request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.privacy.dlp.v2.IJobTrigger>{
     request = request || {};
     options = options || {};
@@ -3219,7 +3225,7 @@ export class DlpServiceClient {
   }
   listDlpJobs(
       request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob[],
         protos.google.privacy.dlp.v2.IListDlpJobsRequest|null,
@@ -3227,7 +3233,7 @@ export class DlpServiceClient {
       ]>;
   listDlpJobs(
       request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.privacy.dlp.v2.IListDlpJobsRequest,
           protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
@@ -3314,7 +3320,7 @@ export class DlpServiceClient {
  */
   listDlpJobs(
       request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListDlpJobsRequest,
           protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
           protos.google.privacy.dlp.v2.IDlpJob>,
@@ -3328,13 +3334,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListDlpJobsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -3420,7 +3426,7 @@ export class DlpServiceClient {
  */
   listDlpJobsStream(
       request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -3518,7 +3524,7 @@ export class DlpServiceClient {
  */
   listDlpJobsAsync(
       request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.privacy.dlp.v2.IDlpJob>{
     request = request || {};
     options = options || {};
@@ -3540,7 +3546,7 @@ export class DlpServiceClient {
   }
   listStoredInfoTypes(
       request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType[],
         protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest|null,
@@ -3548,7 +3554,7 @@ export class DlpServiceClient {
       ]>;
   listStoredInfoTypes(
       request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
           protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
@@ -3608,7 +3614,7 @@ export class DlpServiceClient {
  */
   listStoredInfoTypes(
       request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
           protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
           protos.google.privacy.dlp.v2.IStoredInfoType>,
@@ -3622,13 +3628,13 @@ export class DlpServiceClient {
         protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -3687,7 +3693,7 @@ export class DlpServiceClient {
  */
   listStoredInfoTypesStream(
       request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -3758,7 +3764,7 @@ export class DlpServiceClient {
  */
   listStoredInfoTypesAsync(
       request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.privacy.dlp.v2.IStoredInfoType>{
     request = request || {};
     options = options || {};

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1/key_management_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './key_management_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -86,9 +91,9 @@ export class KeyManagementServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `key_management_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -100,6 +105,7 @@ export class KeyManagementServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -295,14 +301,14 @@ export class KeyManagementServiceClient {
   // -------------------
   getKeyRing(
       request: protos.google.cloud.kms.v1.IGetKeyRingRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing,
         protos.google.cloud.kms.v1.IGetKeyRingRequest|undefined, {}|undefined
       ]>;
   getKeyRing(
       request: protos.google.cloud.kms.v1.IGetKeyRingRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.IGetKeyRingRequest|null|undefined,
@@ -332,7 +338,7 @@ export class KeyManagementServiceClient {
  */
   getKeyRing(
       request: protos.google.cloud.kms.v1.IGetKeyRingRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.IGetKeyRingRequest|null|undefined,
           {}|null|undefined>,
@@ -345,13 +351,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IGetKeyRingRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -366,14 +372,14 @@ export class KeyManagementServiceClient {
   }
   getCryptoKey(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
         protos.google.cloud.kms.v1.IGetCryptoKeyRequest|undefined, {}|undefined
       ]>;
   getCryptoKey(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IGetCryptoKeyRequest|null|undefined,
@@ -404,7 +410,7 @@ export class KeyManagementServiceClient {
  */
   getCryptoKey(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IGetCryptoKeyRequest|null|undefined,
           {}|null|undefined>,
@@ -417,13 +423,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IGetCryptoKeyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -438,14 +444,14 @@ export class KeyManagementServiceClient {
   }
   getCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   getCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|null|undefined,
@@ -475,7 +481,7 @@ export class KeyManagementServiceClient {
  */
   getCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -488,13 +494,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -509,14 +515,14 @@ export class KeyManagementServiceClient {
   }
   getPublicKey(
       request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IPublicKey,
         protos.google.cloud.kms.v1.IGetPublicKeyRequest|undefined, {}|undefined
       ]>;
   getPublicKey(
       request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IPublicKey,
           protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
@@ -550,7 +556,7 @@ export class KeyManagementServiceClient {
  */
   getPublicKey(
       request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IPublicKey,
           protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
           {}|null|undefined>,
@@ -563,13 +569,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IGetPublicKeyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -584,14 +590,14 @@ export class KeyManagementServiceClient {
   }
   getImportJob(
       request: protos.google.cloud.kms.v1.IGetImportJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob,
         protos.google.cloud.kms.v1.IGetImportJobRequest|undefined, {}|undefined
       ]>;
   getImportJob(
       request: protos.google.cloud.kms.v1.IGetImportJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.IGetImportJobRequest|null|undefined,
@@ -621,7 +627,7 @@ export class KeyManagementServiceClient {
  */
   getImportJob(
       request: protos.google.cloud.kms.v1.IGetImportJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.IGetImportJobRequest|null|undefined,
           {}|null|undefined>,
@@ -634,13 +640,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IGetImportJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -655,14 +661,14 @@ export class KeyManagementServiceClient {
   }
   createKeyRing(
       request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing,
         protos.google.cloud.kms.v1.ICreateKeyRingRequest|undefined, {}|undefined
       ]>;
   createKeyRing(
       request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
@@ -698,7 +704,7 @@ export class KeyManagementServiceClient {
  */
   createKeyRing(
       request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
           {}|null|undefined>,
@@ -711,13 +717,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.ICreateKeyRingRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -732,14 +738,14 @@ export class KeyManagementServiceClient {
   }
   createCryptoKey(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
         protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|undefined, {}|undefined
       ]>;
   createCryptoKey(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
@@ -785,7 +791,7 @@ export class KeyManagementServiceClient {
  */
   createCryptoKey(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
           {}|null|undefined>,
@@ -798,13 +804,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -819,14 +825,14 @@ export class KeyManagementServiceClient {
   }
   createCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   createCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
@@ -863,7 +869,7 @@ export class KeyManagementServiceClient {
  */
   createCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -876,13 +882,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -897,14 +903,14 @@ export class KeyManagementServiceClient {
   }
   importCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   importCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
@@ -966,7 +972,7 @@ export class KeyManagementServiceClient {
  */
   importCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -979,13 +985,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1000,14 +1006,14 @@ export class KeyManagementServiceClient {
   }
   createImportJob(
       request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob,
         protos.google.cloud.kms.v1.ICreateImportJobRequest|undefined, {}|undefined
       ]>;
   createImportJob(
       request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
@@ -1045,7 +1051,7 @@ export class KeyManagementServiceClient {
  */
   createImportJob(
       request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
           {}|null|undefined>,
@@ -1058,13 +1064,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.ICreateImportJobRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1079,14 +1085,14 @@ export class KeyManagementServiceClient {
   }
   updateCryptoKey(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
         protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|undefined, {}|undefined
       ]>;
   updateCryptoKey(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|null|undefined,
@@ -1118,7 +1124,7 @@ export class KeyManagementServiceClient {
  */
   updateCryptoKey(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|null|undefined,
           {}|null|undefined>,
@@ -1131,13 +1137,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1152,14 +1158,14 @@ export class KeyManagementServiceClient {
   }
   updateCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   updateCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
@@ -1197,7 +1203,7 @@ export class KeyManagementServiceClient {
  */
   updateCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -1210,13 +1216,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1231,14 +1237,14 @@ export class KeyManagementServiceClient {
   }
   encrypt(
       request: protos.google.cloud.kms.v1.IEncryptRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IEncryptResponse,
         protos.google.cloud.kms.v1.IEncryptRequest|undefined, {}|undefined
       ]>;
   encrypt(
       request: protos.google.cloud.kms.v1.IEncryptRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IEncryptResponse,
           protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
@@ -1293,7 +1299,7 @@ export class KeyManagementServiceClient {
  */
   encrypt(
       request: protos.google.cloud.kms.v1.IEncryptRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IEncryptResponse,
           protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
           {}|null|undefined>,
@@ -1306,13 +1312,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IEncryptRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1327,14 +1333,14 @@ export class KeyManagementServiceClient {
   }
   decrypt(
       request: protos.google.cloud.kms.v1.IDecryptRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IDecryptResponse,
         protos.google.cloud.kms.v1.IDecryptRequest|undefined, {}|undefined
       ]>;
   decrypt(
       request: protos.google.cloud.kms.v1.IDecryptRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IDecryptResponse,
           protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
@@ -1372,7 +1378,7 @@ export class KeyManagementServiceClient {
  */
   decrypt(
       request: protos.google.cloud.kms.v1.IDecryptRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IDecryptResponse,
           protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
           {}|null|undefined>,
@@ -1385,13 +1391,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IDecryptRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1406,14 +1412,14 @@ export class KeyManagementServiceClient {
   }
   asymmetricSign(
       request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IAsymmetricSignResponse,
         protos.google.cloud.kms.v1.IAsymmetricSignRequest|undefined, {}|undefined
       ]>;
   asymmetricSign(
       request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IAsymmetricSignResponse,
           protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
@@ -1449,7 +1455,7 @@ export class KeyManagementServiceClient {
  */
   asymmetricSign(
       request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IAsymmetricSignResponse,
           protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
           {}|null|undefined>,
@@ -1462,13 +1468,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IAsymmetricSignRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1483,14 +1489,14 @@ export class KeyManagementServiceClient {
   }
   asymmetricDecrypt(
       request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
         protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|undefined, {}|undefined
       ]>;
   asymmetricDecrypt(
       request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
           protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
@@ -1526,7 +1532,7 @@ export class KeyManagementServiceClient {
  */
   asymmetricDecrypt(
       request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
           protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
           {}|null|undefined>,
@@ -1539,13 +1545,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1560,14 +1566,14 @@ export class KeyManagementServiceClient {
   }
   updateCryptoKeyPrimaryVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
         protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|undefined, {}|undefined
       ]>;
   updateCryptoKeyPrimaryVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
@@ -1601,7 +1607,7 @@ export class KeyManagementServiceClient {
  */
   updateCryptoKeyPrimaryVersion(
       request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -1614,13 +1620,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1635,14 +1641,14 @@ export class KeyManagementServiceClient {
   }
   destroyCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   destroyCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
@@ -1683,7 +1689,7 @@ export class KeyManagementServiceClient {
  */
   destroyCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -1696,13 +1702,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1717,14 +1723,14 @@ export class KeyManagementServiceClient {
   }
   restoreCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
         protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|undefined, {}|undefined
       ]>;
   restoreCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
@@ -1760,7 +1766,7 @@ export class KeyManagementServiceClient {
  */
   restoreCryptoKeyVersion(
       request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>,
@@ -1773,13 +1779,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1795,7 +1801,7 @@ export class KeyManagementServiceClient {
 
   listKeyRings(
       request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing[],
         protos.google.cloud.kms.v1.IListKeyRingsRequest|null,
@@ -1803,7 +1809,7 @@ export class KeyManagementServiceClient {
       ]>;
   listKeyRings(
       request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.kms.v1.IListKeyRingsRequest,
           protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
@@ -1850,7 +1856,7 @@ export class KeyManagementServiceClient {
  */
   listKeyRings(
       request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListKeyRingsRequest,
           protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
           protos.google.cloud.kms.v1.IKeyRing>,
@@ -1864,13 +1870,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IListKeyRingsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1918,7 +1924,7 @@ export class KeyManagementServiceClient {
  */
   listKeyRingsStream(
       request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1978,7 +1984,7 @@ export class KeyManagementServiceClient {
  */
   listKeyRingsAsync(
       request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>{
     request = request || {};
     options = options || {};
@@ -2000,7 +2006,7 @@ export class KeyManagementServiceClient {
   }
   listCryptoKeys(
       request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey[],
         protos.google.cloud.kms.v1.IListCryptoKeysRequest|null,
@@ -2008,7 +2014,7 @@ export class KeyManagementServiceClient {
       ]>;
   listCryptoKeys(
       request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeysRequest,
           protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
@@ -2057,7 +2063,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeys(
       request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeysRequest,
           protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
           protos.google.cloud.kms.v1.ICryptoKey>,
@@ -2071,13 +2077,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IListCryptoKeysResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2127,7 +2133,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeysStream(
       request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2189,7 +2195,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeysAsync(
       request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>{
     request = request || {};
     options = options || {};
@@ -2211,7 +2217,7 @@ export class KeyManagementServiceClient {
   }
   listCryptoKeyVersions(
       request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion[],
         protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
@@ -2219,7 +2225,7 @@ export class KeyManagementServiceClient {
       ]>;
   listCryptoKeyVersions(
       request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
@@ -2269,7 +2275,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeyVersions(
       request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
           protos.google.cloud.kms.v1.ICryptoKeyVersion>,
@@ -2283,13 +2289,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2340,7 +2346,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeyVersionsStream(
       request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2403,7 +2409,7 @@ export class KeyManagementServiceClient {
  */
   listCryptoKeyVersionsAsync(
       request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>{
     request = request || {};
     options = options || {};
@@ -2425,7 +2431,7 @@ export class KeyManagementServiceClient {
   }
   listImportJobs(
       request: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob[],
         protos.google.cloud.kms.v1.IListImportJobsRequest|null,
@@ -2433,7 +2439,7 @@ export class KeyManagementServiceClient {
       ]>;
   listImportJobs(
       request: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.kms.v1.IListImportJobsRequest,
           protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
@@ -2480,7 +2486,7 @@ export class KeyManagementServiceClient {
  */
   listImportJobs(
       request: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListImportJobsRequest,
           protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
           protos.google.cloud.kms.v1.IImportJob>,
@@ -2494,13 +2500,13 @@ export class KeyManagementServiceClient {
         protos.google.cloud.kms.v1.IListImportJobsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -2548,7 +2554,7 @@ export class KeyManagementServiceClient {
  */
   listImportJobsStream(
       request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2608,7 +2614,7 @@ export class KeyManagementServiceClient {
  */
   listImportJobsAsync(
       request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.kms.v1.IImportJob>{
     request = request || {};
     options = options || {};

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v2/config_service_v2_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './config_service_v2_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class ConfigServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `config_service_v2_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class ConfigServiceV2Client {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -358,14 +364,14 @@ export class ConfigServiceV2Client {
   // -------------------
   getBucket(
       request: protos.google.logging.v2.IGetBucketRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket,
         protos.google.logging.v2.IGetBucketRequest|undefined, {}|undefined
       ]>;
   getBucket(
       request: protos.google.logging.v2.IGetBucketRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IGetBucketRequest|null|undefined,
@@ -403,7 +409,7 @@ export class ConfigServiceV2Client {
  */
   getBucket(
       request: protos.google.logging.v2.IGetBucketRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IGetBucketRequest|null|undefined,
           {}|null|undefined>,
@@ -416,13 +422,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IGetBucketRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -437,14 +443,14 @@ export class ConfigServiceV2Client {
   }
   updateBucket(
       request: protos.google.logging.v2.IUpdateBucketRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket,
         protos.google.logging.v2.IUpdateBucketRequest|undefined, {}|undefined
       ]>;
   updateBucket(
       request: protos.google.logging.v2.IUpdateBucketRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
@@ -505,7 +511,7 @@ export class ConfigServiceV2Client {
  */
   updateBucket(
       request: protos.google.logging.v2.IUpdateBucketRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
           {}|null|undefined>,
@@ -518,13 +524,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IUpdateBucketRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -539,14 +545,14 @@ export class ConfigServiceV2Client {
   }
   getSink(
       request: protos.google.logging.v2.IGetSinkRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
         protos.google.logging.v2.IGetSinkRequest|undefined, {}|undefined
       ]>;
   getSink(
       request: protos.google.logging.v2.IGetSinkRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IGetSinkRequest|null|undefined,
@@ -583,7 +589,7 @@ export class ConfigServiceV2Client {
  */
   getSink(
       request: protos.google.logging.v2.IGetSinkRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IGetSinkRequest|null|undefined,
           {}|null|undefined>,
@@ -596,13 +602,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IGetSinkRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -617,14 +623,14 @@ export class ConfigServiceV2Client {
   }
   createSink(
       request: protos.google.logging.v2.ICreateSinkRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
         protos.google.logging.v2.ICreateSinkRequest|undefined, {}|undefined
       ]>;
   createSink(
       request: protos.google.logging.v2.ICreateSinkRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.ICreateSinkRequest|null|undefined,
@@ -679,7 +685,7 @@ export class ConfigServiceV2Client {
  */
   createSink(
       request: protos.google.logging.v2.ICreateSinkRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.ICreateSinkRequest|null|undefined,
           {}|null|undefined>,
@@ -692,13 +698,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.ICreateSinkRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -713,14 +719,14 @@ export class ConfigServiceV2Client {
   }
   updateSink(
       request: protos.google.logging.v2.IUpdateSinkRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
         protos.google.logging.v2.IUpdateSinkRequest|undefined, {}|undefined
       ]>;
   updateSink(
       request: protos.google.logging.v2.IUpdateSinkRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
@@ -792,7 +798,7 @@ export class ConfigServiceV2Client {
  */
   updateSink(
       request: protos.google.logging.v2.IUpdateSinkRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
           {}|null|undefined>,
@@ -805,13 +811,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IUpdateSinkRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -826,14 +832,14 @@ export class ConfigServiceV2Client {
   }
   deleteSink(
       request: protos.google.logging.v2.IDeleteSinkRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.logging.v2.IDeleteSinkRequest|undefined, {}|undefined
       ]>;
   deleteSink(
       request: protos.google.logging.v2.IDeleteSinkRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
@@ -872,7 +878,7 @@ export class ConfigServiceV2Client {
  */
   deleteSink(
       request: protos.google.logging.v2.IDeleteSinkRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
           {}|null|undefined>,
@@ -885,13 +891,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IDeleteSinkRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -906,14 +912,14 @@ export class ConfigServiceV2Client {
   }
   getExclusion(
       request: protos.google.logging.v2.IGetExclusionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
         protos.google.logging.v2.IGetExclusionRequest|undefined, {}|undefined
       ]>;
   getExclusion(
       request: protos.google.logging.v2.IGetExclusionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IGetExclusionRequest|null|undefined,
@@ -950,7 +956,7 @@ export class ConfigServiceV2Client {
  */
   getExclusion(
       request: protos.google.logging.v2.IGetExclusionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IGetExclusionRequest|null|undefined,
           {}|null|undefined>,
@@ -963,13 +969,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IGetExclusionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -984,14 +990,14 @@ export class ConfigServiceV2Client {
   }
   createExclusion(
       request: protos.google.logging.v2.ICreateExclusionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
         protos.google.logging.v2.ICreateExclusionRequest|undefined, {}|undefined
       ]>;
   createExclusion(
       request: protos.google.logging.v2.ICreateExclusionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
@@ -1033,7 +1039,7 @@ export class ConfigServiceV2Client {
  */
   createExclusion(
       request: protos.google.logging.v2.ICreateExclusionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
           {}|null|undefined>,
@@ -1046,13 +1052,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.ICreateExclusionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1067,14 +1073,14 @@ export class ConfigServiceV2Client {
   }
   updateExclusion(
       request: protos.google.logging.v2.IUpdateExclusionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
         protos.google.logging.v2.IUpdateExclusionRequest|undefined, {}|undefined
       ]>;
   updateExclusion(
       request: protos.google.logging.v2.IUpdateExclusionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
@@ -1122,7 +1128,7 @@ export class ConfigServiceV2Client {
  */
   updateExclusion(
       request: protos.google.logging.v2.IUpdateExclusionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
           {}|null|undefined>,
@@ -1135,13 +1141,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IUpdateExclusionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1156,14 +1162,14 @@ export class ConfigServiceV2Client {
   }
   deleteExclusion(
       request: protos.google.logging.v2.IDeleteExclusionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.logging.v2.IDeleteExclusionRequest|undefined, {}|undefined
       ]>;
   deleteExclusion(
       request: protos.google.logging.v2.IDeleteExclusionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
@@ -1200,7 +1206,7 @@ export class ConfigServiceV2Client {
  */
   deleteExclusion(
       request: protos.google.logging.v2.IDeleteExclusionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
           {}|null|undefined>,
@@ -1213,13 +1219,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IDeleteExclusionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1234,14 +1240,14 @@ export class ConfigServiceV2Client {
   }
   getCmekSettings(
       request: protos.google.logging.v2.IGetCmekSettingsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ICmekSettings,
         protos.google.logging.v2.IGetCmekSettingsRequest|undefined, {}|undefined
       ]>;
   getCmekSettings(
       request: protos.google.logging.v2.IGetCmekSettingsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
@@ -1289,7 +1295,7 @@ export class ConfigServiceV2Client {
  */
   getCmekSettings(
       request: protos.google.logging.v2.IGetCmekSettingsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
           {}|null|undefined>,
@@ -1302,13 +1308,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IGetCmekSettingsRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1323,14 +1329,14 @@ export class ConfigServiceV2Client {
   }
   updateCmekSettings(
       request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ICmekSettings,
         protos.google.logging.v2.IUpdateCmekSettingsRequest|undefined, {}|undefined
       ]>;
   updateCmekSettings(
       request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
@@ -1397,7 +1403,7 @@ export class ConfigServiceV2Client {
  */
   updateCmekSettings(
       request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
           {}|null|undefined>,
@@ -1410,13 +1416,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IUpdateCmekSettingsRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1432,7 +1438,7 @@ export class ConfigServiceV2Client {
 
   listBuckets(
       request: protos.google.logging.v2.IListBucketsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket[],
         protos.google.logging.v2.IListBucketsRequest|null,
@@ -1440,7 +1446,7 @@ export class ConfigServiceV2Client {
       ]>;
   listBuckets(
       request: protos.google.logging.v2.IListBucketsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListBucketsRequest,
           protos.google.logging.v2.IListBucketsResponse|null|undefined,
@@ -1491,7 +1497,7 @@ export class ConfigServiceV2Client {
  */
   listBuckets(
       request: protos.google.logging.v2.IListBucketsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListBucketsRequest,
           protos.google.logging.v2.IListBucketsResponse|null|undefined,
           protos.google.logging.v2.ILogBucket>,
@@ -1505,13 +1511,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IListBucketsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1563,7 +1569,7 @@ export class ConfigServiceV2Client {
  */
   listBucketsStream(
       request?: protos.google.logging.v2.IListBucketsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1627,7 +1633,7 @@ export class ConfigServiceV2Client {
  */
   listBucketsAsync(
       request?: protos.google.logging.v2.IListBucketsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.logging.v2.ILogBucket>{
     request = request || {};
     options = options || {};
@@ -1649,7 +1655,7 @@ export class ConfigServiceV2Client {
   }
   listSinks(
       request: protos.google.logging.v2.IListSinksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink[],
         protos.google.logging.v2.IListSinksRequest|null,
@@ -1657,7 +1663,7 @@ export class ConfigServiceV2Client {
       ]>;
   listSinks(
       request: protos.google.logging.v2.IListSinksRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListSinksRequest,
           protos.google.logging.v2.IListSinksResponse|null|undefined,
@@ -1704,7 +1710,7 @@ export class ConfigServiceV2Client {
  */
   listSinks(
       request: protos.google.logging.v2.IListSinksRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListSinksRequest,
           protos.google.logging.v2.IListSinksResponse|null|undefined,
           protos.google.logging.v2.ILogSink>,
@@ -1718,13 +1724,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IListSinksResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1772,7 +1778,7 @@ export class ConfigServiceV2Client {
  */
   listSinksStream(
       request?: protos.google.logging.v2.IListSinksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1832,7 +1838,7 @@ export class ConfigServiceV2Client {
  */
   listSinksAsync(
       request?: protos.google.logging.v2.IListSinksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.logging.v2.ILogSink>{
     request = request || {};
     options = options || {};
@@ -1854,7 +1860,7 @@ export class ConfigServiceV2Client {
   }
   listExclusions(
       request: protos.google.logging.v2.IListExclusionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion[],
         protos.google.logging.v2.IListExclusionsRequest|null,
@@ -1862,7 +1868,7 @@ export class ConfigServiceV2Client {
       ]>;
   listExclusions(
       request: protos.google.logging.v2.IListExclusionsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListExclusionsRequest,
           protos.google.logging.v2.IListExclusionsResponse|null|undefined,
@@ -1909,7 +1915,7 @@ export class ConfigServiceV2Client {
  */
   listExclusions(
       request: protos.google.logging.v2.IListExclusionsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListExclusionsRequest,
           protos.google.logging.v2.IListExclusionsResponse|null|undefined,
           protos.google.logging.v2.ILogExclusion>,
@@ -1923,13 +1929,13 @@ export class ConfigServiceV2Client {
         protos.google.logging.v2.IListExclusionsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1977,7 +1983,7 @@ export class ConfigServiceV2Client {
  */
   listExclusionsStream(
       request?: protos.google.logging.v2.IListExclusionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2037,7 +2043,7 @@ export class ConfigServiceV2Client {
  */
   listExclusionsAsync(
       request?: protos.google.logging.v2.IListExclusionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.logging.v2.ILogExclusion>{
     request = request || {};
     options = options || {};

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v2/logging_service_v2_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './logging_service_v2_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class LoggingServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `logging_service_v2_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class LoggingServiceV2Client {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -381,14 +387,14 @@ export class LoggingServiceV2Client {
   // -------------------
   deleteLog(
       request: protos.google.logging.v2.IDeleteLogRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.logging.v2.IDeleteLogRequest|undefined, {}|undefined
       ]>;
   deleteLog(
       request: protos.google.logging.v2.IDeleteLogRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogRequest|null|undefined,
@@ -432,7 +438,7 @@ export class LoggingServiceV2Client {
  */
   deleteLog(
       request: protos.google.logging.v2.IDeleteLogRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogRequest|null|undefined,
           {}|null|undefined>,
@@ -445,13 +451,13 @@ export class LoggingServiceV2Client {
         protos.google.logging.v2.IDeleteLogRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -466,14 +472,14 @@ export class LoggingServiceV2Client {
   }
   writeLogEntries(
       request: protos.google.logging.v2.IWriteLogEntriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.IWriteLogEntriesResponse,
         protos.google.logging.v2.IWriteLogEntriesRequest|undefined, {}|undefined
       ]>;
   writeLogEntries(
       request: protos.google.logging.v2.IWriteLogEntriesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.IWriteLogEntriesResponse,
           protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
@@ -573,7 +579,7 @@ export class LoggingServiceV2Client {
  */
   writeLogEntries(
       request: protos.google.logging.v2.IWriteLogEntriesRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.IWriteLogEntriesResponse,
           protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
           {}|null|undefined>,
@@ -586,13 +592,13 @@ export class LoggingServiceV2Client {
         protos.google.logging.v2.IWriteLogEntriesRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -601,7 +607,7 @@ export class LoggingServiceV2Client {
 
   listLogEntries(
       request: protos.google.logging.v2.IListLogEntriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogEntry[],
         protos.google.logging.v2.IListLogEntriesRequest|null,
@@ -609,7 +615,7 @@ export class LoggingServiceV2Client {
       ]>;
   listLogEntries(
       request: protos.google.logging.v2.IListLogEntriesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListLogEntriesRequest,
           protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
@@ -677,7 +683,7 @@ export class LoggingServiceV2Client {
  */
   listLogEntries(
       request: protos.google.logging.v2.IListLogEntriesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogEntriesRequest,
           protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
           protos.google.logging.v2.ILogEntry>,
@@ -691,13 +697,13 @@ export class LoggingServiceV2Client {
         protos.google.logging.v2.IListLogEntriesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -757,7 +763,7 @@ export class LoggingServiceV2Client {
  */
   listLogEntriesStream(
       request?: protos.google.logging.v2.IListLogEntriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -829,7 +835,7 @@ export class LoggingServiceV2Client {
  */
   listLogEntriesAsync(
       request?: protos.google.logging.v2.IListLogEntriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.logging.v2.ILogEntry>{
     request = request || {};
     options = options || {};
@@ -844,7 +850,7 @@ export class LoggingServiceV2Client {
   }
   listMonitoredResourceDescriptors(
       request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor[],
         protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest|null,
@@ -852,7 +858,7 @@ export class LoggingServiceV2Client {
       ]>;
   listMonitoredResourceDescriptors(
       request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
           protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
@@ -892,7 +898,7 @@ export class LoggingServiceV2Client {
  */
   listMonitoredResourceDescriptors(
       request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
           protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
           protos.google.api.IMonitoredResourceDescriptor>,
@@ -906,13 +912,13 @@ export class LoggingServiceV2Client {
         protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -946,7 +952,7 @@ export class LoggingServiceV2Client {
  */
   listMonitoredResourceDescriptorsStream(
       request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -992,7 +998,7 @@ export class LoggingServiceV2Client {
  */
   listMonitoredResourceDescriptorsAsync(
       request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>{
     request = request || {};
     options = options || {};
@@ -1007,7 +1013,7 @@ export class LoggingServiceV2Client {
   }
   listLogs(
       request: protos.google.logging.v2.IListLogsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         string[],
         protos.google.logging.v2.IListLogsRequest|null,
@@ -1015,7 +1021,7 @@ export class LoggingServiceV2Client {
       ]>;
   listLogs(
       request: protos.google.logging.v2.IListLogsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListLogsRequest,
           protos.google.logging.v2.IListLogsResponse|null|undefined,
@@ -1063,7 +1069,7 @@ export class LoggingServiceV2Client {
  */
   listLogs(
       request: protos.google.logging.v2.IListLogsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogsRequest,
           protos.google.logging.v2.IListLogsResponse|null|undefined,
           string>,
@@ -1077,13 +1083,13 @@ export class LoggingServiceV2Client {
         protos.google.logging.v2.IListLogsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1131,7 +1137,7 @@ export class LoggingServiceV2Client {
  */
   listLogsStream(
       request?: protos.google.logging.v2.IListLogsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1191,7 +1197,7 @@ export class LoggingServiceV2Client {
  */
   listLogsAsync(
       request?: protos.google.logging.v2.IListLogsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<string>{
     request = request || {};
     options = options || {};

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v2/metrics_service_v2_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './metrics_service_v2_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class MetricsServiceV2Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `metrics_service_v2_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class MetricsServiceV2Client {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -352,14 +358,14 @@ export class MetricsServiceV2Client {
   // -------------------
   getLogMetric(
       request: protos.google.logging.v2.IGetLogMetricRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
         protos.google.logging.v2.IGetLogMetricRequest|undefined, {}|undefined
       ]>;
   getLogMetric(
       request: protos.google.logging.v2.IGetLogMetricRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IGetLogMetricRequest|null|undefined,
@@ -391,7 +397,7 @@ export class MetricsServiceV2Client {
  */
   getLogMetric(
       request: protos.google.logging.v2.IGetLogMetricRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IGetLogMetricRequest|null|undefined,
           {}|null|undefined>,
@@ -404,13 +410,13 @@ export class MetricsServiceV2Client {
         protos.google.logging.v2.IGetLogMetricRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -425,14 +431,14 @@ export class MetricsServiceV2Client {
   }
   createLogMetric(
       request: protos.google.logging.v2.ICreateLogMetricRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
         protos.google.logging.v2.ICreateLogMetricRequest|undefined, {}|undefined
       ]>;
   createLogMetric(
       request: protos.google.logging.v2.ICreateLogMetricRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
@@ -469,7 +475,7 @@ export class MetricsServiceV2Client {
  */
   createLogMetric(
       request: protos.google.logging.v2.ICreateLogMetricRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
           {}|null|undefined>,
@@ -482,13 +488,13 @@ export class MetricsServiceV2Client {
         protos.google.logging.v2.ICreateLogMetricRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -503,14 +509,14 @@ export class MetricsServiceV2Client {
   }
   updateLogMetric(
       request: protos.google.logging.v2.IUpdateLogMetricRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
         protos.google.logging.v2.IUpdateLogMetricRequest|undefined, {}|undefined
       ]>;
   updateLogMetric(
       request: protos.google.logging.v2.IUpdateLogMetricRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
@@ -548,7 +554,7 @@ export class MetricsServiceV2Client {
  */
   updateLogMetric(
       request: protos.google.logging.v2.IUpdateLogMetricRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
           {}|null|undefined>,
@@ -561,13 +567,13 @@ export class MetricsServiceV2Client {
         protos.google.logging.v2.IUpdateLogMetricRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -582,14 +588,14 @@ export class MetricsServiceV2Client {
   }
   deleteLogMetric(
       request: protos.google.logging.v2.IDeleteLogMetricRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.logging.v2.IDeleteLogMetricRequest|undefined, {}|undefined
       ]>;
   deleteLogMetric(
       request: protos.google.logging.v2.IDeleteLogMetricRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogMetricRequest|null|undefined,
@@ -621,7 +627,7 @@ export class MetricsServiceV2Client {
  */
   deleteLogMetric(
       request: protos.google.logging.v2.IDeleteLogMetricRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogMetricRequest|null|undefined,
           {}|null|undefined>,
@@ -634,13 +640,13 @@ export class MetricsServiceV2Client {
         protos.google.logging.v2.IDeleteLogMetricRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -656,7 +662,7 @@ export class MetricsServiceV2Client {
 
   listLogMetrics(
       request: protos.google.logging.v2.IListLogMetricsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric[],
         protos.google.logging.v2.IListLogMetricsRequest|null,
@@ -664,7 +670,7 @@ export class MetricsServiceV2Client {
       ]>;
   listLogMetrics(
       request: protos.google.logging.v2.IListLogMetricsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.logging.v2.IListLogMetricsRequest,
           protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
@@ -708,7 +714,7 @@ export class MetricsServiceV2Client {
  */
   listLogMetrics(
       request: protos.google.logging.v2.IListLogMetricsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogMetricsRequest,
           protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
           protos.google.logging.v2.ILogMetric>,
@@ -722,13 +728,13 @@ export class MetricsServiceV2Client {
         protos.google.logging.v2.IListLogMetricsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -773,7 +779,7 @@ export class MetricsServiceV2Client {
  */
   listLogMetricsStream(
       request?: protos.google.logging.v2.IListLogMetricsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -830,7 +836,7 @@ export class MetricsServiceV2Client {
  */
   listLogMetricsAsync(
       request?: protos.google.logging.v2.IListLogMetricsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.logging.v2.ILogMetric>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/alert_policy_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './alert_policy_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -84,9 +89,9 @@ export class AlertPolicyServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `alert_policy_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -98,6 +103,7 @@ export class AlertPolicyServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -364,14 +370,14 @@ export class AlertPolicyServiceClient {
   // -------------------
   getAlertPolicy(
       request: protos.google.monitoring.v3.IGetAlertPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
         protos.google.monitoring.v3.IGetAlertPolicyRequest|undefined, {}|undefined
       ]>;
   getAlertPolicy(
       request: protos.google.monitoring.v3.IGetAlertPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IGetAlertPolicyRequest|null|undefined,
@@ -403,7 +409,7 @@ export class AlertPolicyServiceClient {
  */
   getAlertPolicy(
       request: protos.google.monitoring.v3.IGetAlertPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IGetAlertPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -416,13 +422,13 @@ export class AlertPolicyServiceClient {
         protos.google.monitoring.v3.IGetAlertPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -437,14 +443,14 @@ export class AlertPolicyServiceClient {
   }
   createAlertPolicy(
       request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
         protos.google.monitoring.v3.ICreateAlertPolicyRequest|undefined, {}|undefined
       ]>;
   createAlertPolicy(
       request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
@@ -485,7 +491,7 @@ export class AlertPolicyServiceClient {
  */
   createAlertPolicy(
       request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -498,13 +504,13 @@ export class AlertPolicyServiceClient {
         protos.google.monitoring.v3.ICreateAlertPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -519,14 +525,14 @@ export class AlertPolicyServiceClient {
   }
   deleteAlertPolicy(
       request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteAlertPolicyRequest|undefined, {}|undefined
       ]>;
   deleteAlertPolicy(
       request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
@@ -560,7 +566,7 @@ export class AlertPolicyServiceClient {
  */
   deleteAlertPolicy(
       request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -573,13 +579,13 @@ export class AlertPolicyServiceClient {
         protos.google.monitoring.v3.IDeleteAlertPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -594,14 +600,14 @@ export class AlertPolicyServiceClient {
   }
   updateAlertPolicy(
       request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
         protos.google.monitoring.v3.IUpdateAlertPolicyRequest|undefined, {}|undefined
       ]>;
   updateAlertPolicy(
       request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
@@ -659,7 +665,7 @@ export class AlertPolicyServiceClient {
  */
   updateAlertPolicy(
       request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -672,13 +678,13 @@ export class AlertPolicyServiceClient {
         protos.google.monitoring.v3.IUpdateAlertPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -694,7 +700,7 @@ export class AlertPolicyServiceClient {
 
   listAlertPolicies(
       request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy[],
         protos.google.monitoring.v3.IListAlertPoliciesRequest|null,
@@ -702,7 +708,7 @@ export class AlertPolicyServiceClient {
       ]>;
   listAlertPolicies(
       request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListAlertPoliciesRequest,
           protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
@@ -762,7 +768,7 @@ export class AlertPolicyServiceClient {
  */
   listAlertPolicies(
       request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListAlertPoliciesRequest,
           protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
           protos.google.monitoring.v3.IAlertPolicy>,
@@ -776,13 +782,13 @@ export class AlertPolicyServiceClient {
         protos.google.monitoring.v3.IListAlertPoliciesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -843,7 +849,7 @@ export class AlertPolicyServiceClient {
  */
   listAlertPoliciesStream(
       request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -916,7 +922,7 @@ export class AlertPolicyServiceClient {
  */
   listAlertPoliciesAsync(
       request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IAlertPolicy>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/group_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './group_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -87,9 +92,9 @@ export class GroupServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `group_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -101,6 +106,7 @@ export class GroupServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -369,14 +375,14 @@ export class GroupServiceClient {
   // -------------------
   getGroup(
       request: protos.google.monitoring.v3.IGetGroupRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
         protos.google.monitoring.v3.IGetGroupRequest|undefined, {}|undefined
       ]>;
   getGroup(
       request: protos.google.monitoring.v3.IGetGroupRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IGetGroupRequest|null|undefined,
@@ -407,7 +413,7 @@ export class GroupServiceClient {
  */
   getGroup(
       request: protos.google.monitoring.v3.IGetGroupRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IGetGroupRequest|null|undefined,
           {}|null|undefined>,
@@ -420,13 +426,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.IGetGroupRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -441,14 +447,14 @@ export class GroupServiceClient {
   }
   createGroup(
       request: protos.google.monitoring.v3.ICreateGroupRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
         protos.google.monitoring.v3.ICreateGroupRequest|undefined, {}|undefined
       ]>;
   createGroup(
       request: protos.google.monitoring.v3.ICreateGroupRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
@@ -484,7 +490,7 @@ export class GroupServiceClient {
  */
   createGroup(
       request: protos.google.monitoring.v3.ICreateGroupRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
           {}|null|undefined>,
@@ -497,13 +503,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.ICreateGroupRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -518,14 +524,14 @@ export class GroupServiceClient {
   }
   updateGroup(
       request: protos.google.monitoring.v3.IUpdateGroupRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
         protos.google.monitoring.v3.IUpdateGroupRequest|undefined, {}|undefined
       ]>;
   updateGroup(
       request: protos.google.monitoring.v3.IUpdateGroupRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
@@ -559,7 +565,7 @@ export class GroupServiceClient {
  */
   updateGroup(
       request: protos.google.monitoring.v3.IUpdateGroupRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
           {}|null|undefined>,
@@ -572,13 +578,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.IUpdateGroupRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -593,14 +599,14 @@ export class GroupServiceClient {
   }
   deleteGroup(
       request: protos.google.monitoring.v3.IDeleteGroupRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteGroupRequest|undefined, {}|undefined
       ]>;
   deleteGroup(
       request: protos.google.monitoring.v3.IDeleteGroupRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
@@ -635,7 +641,7 @@ export class GroupServiceClient {
  */
   deleteGroup(
       request: protos.google.monitoring.v3.IDeleteGroupRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
           {}|null|undefined>,
@@ -648,13 +654,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.IDeleteGroupRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -670,7 +676,7 @@ export class GroupServiceClient {
 
   listGroups(
       request: protos.google.monitoring.v3.IListGroupsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup[],
         protos.google.monitoring.v3.IListGroupsRequest|null,
@@ -678,7 +684,7 @@ export class GroupServiceClient {
       ]>;
   listGroups(
       request: protos.google.monitoring.v3.IListGroupsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListGroupsRequest,
           protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
@@ -733,7 +739,7 @@ export class GroupServiceClient {
  */
   listGroups(
       request: protos.google.monitoring.v3.IListGroupsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListGroupsRequest,
           protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
           protos.google.monitoring.v3.IGroup>,
@@ -747,13 +753,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.IListGroupsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -809,7 +815,7 @@ export class GroupServiceClient {
  */
   listGroupsStream(
       request?: protos.google.monitoring.v3.IListGroupsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -877,7 +883,7 @@ export class GroupServiceClient {
  */
   listGroupsAsync(
       request?: protos.google.monitoring.v3.IListGroupsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IGroup>{
     request = request || {};
     options = options || {};
@@ -899,7 +905,7 @@ export class GroupServiceClient {
   }
   listGroupMembers(
       request: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResource[],
         protos.google.monitoring.v3.IListGroupMembersRequest|null,
@@ -907,7 +913,7 @@ export class GroupServiceClient {
       ]>;
   listGroupMembers(
       request: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListGroupMembersRequest,
           protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
@@ -960,7 +966,7 @@ export class GroupServiceClient {
  */
   listGroupMembers(
       request: protos.google.monitoring.v3.IListGroupMembersRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListGroupMembersRequest,
           protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
           protos.google.api.IMonitoredResource>,
@@ -974,13 +980,13 @@ export class GroupServiceClient {
         protos.google.monitoring.v3.IListGroupMembersResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1034,7 +1040,7 @@ export class GroupServiceClient {
  */
   listGroupMembersStream(
       request?: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1100,7 +1106,7 @@ export class GroupServiceClient {
  */
   listGroupMembersAsync(
       request?: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.api.IMonitoredResource>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/metric_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './metric_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class MetricServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `metric_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class MetricServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -380,14 +386,14 @@ export class MetricServiceClient {
   // -------------------
   getMonitoredResourceDescriptor(
       request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor,
         protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|undefined, {}|undefined
       ]>;
   getMonitoredResourceDescriptor(
       request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.api.IMonitoredResourceDescriptor,
           protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
@@ -420,7 +426,7 @@ export class MetricServiceClient {
  */
   getMonitoredResourceDescriptor(
       request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMonitoredResourceDescriptor,
           protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
           {}|null|undefined>,
@@ -433,13 +439,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -454,14 +460,14 @@ export class MetricServiceClient {
   }
   getMetricDescriptor(
       request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor,
         protos.google.monitoring.v3.IGetMetricDescriptorRequest|undefined, {}|undefined
       ]>;
   getMetricDescriptor(
       request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
@@ -494,7 +500,7 @@ export class MetricServiceClient {
  */
   getMetricDescriptor(
       request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
           {}|null|undefined>,
@@ -507,13 +513,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IGetMetricDescriptorRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -528,14 +534,14 @@ export class MetricServiceClient {
   }
   createMetricDescriptor(
       request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor,
         protos.google.monitoring.v3.ICreateMetricDescriptorRequest|undefined, {}|undefined
       ]>;
   createMetricDescriptor(
       request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
@@ -571,7 +577,7 @@ export class MetricServiceClient {
  */
   createMetricDescriptor(
       request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
           {}|null|undefined>,
@@ -584,13 +590,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.ICreateMetricDescriptorRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -605,14 +611,14 @@ export class MetricServiceClient {
   }
   deleteMetricDescriptor(
       request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|undefined, {}|undefined
       ]>;
   deleteMetricDescriptor(
       request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
@@ -646,7 +652,7 @@ export class MetricServiceClient {
  */
   deleteMetricDescriptor(
       request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
           {}|null|undefined>,
@@ -659,13 +665,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -680,14 +686,14 @@ export class MetricServiceClient {
   }
   createTimeSeries(
       request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.ICreateTimeSeriesRequest|undefined, {}|undefined
       ]>;
   createTimeSeries(
       request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
@@ -729,7 +735,7 @@ export class MetricServiceClient {
  */
   createTimeSeries(
       request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
           {}|null|undefined>,
@@ -742,13 +748,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.ICreateTimeSeriesRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -764,7 +770,7 @@ export class MetricServiceClient {
 
   listMonitoredResourceDescriptors(
       request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor[],
         protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest|null,
@@ -772,7 +778,7 @@ export class MetricServiceClient {
       ]>;
   listMonitoredResourceDescriptors(
       request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
@@ -820,7 +826,7 @@ export class MetricServiceClient {
  */
   listMonitoredResourceDescriptors(
       request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
           protos.google.api.IMonitoredResourceDescriptor>,
@@ -834,13 +840,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -889,7 +895,7 @@ export class MetricServiceClient {
  */
   listMonitoredResourceDescriptorsStream(
       request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -950,7 +956,7 @@ export class MetricServiceClient {
  */
   listMonitoredResourceDescriptorsAsync(
       request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>{
     request = request || {};
     options = options || {};
@@ -972,7 +978,7 @@ export class MetricServiceClient {
   }
   listMetricDescriptors(
       request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor[],
         protos.google.monitoring.v3.IListMetricDescriptorsRequest|null,
@@ -980,7 +986,7 @@ export class MetricServiceClient {
       ]>;
   listMetricDescriptors(
       request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListMetricDescriptorsRequest,
           protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
@@ -1029,7 +1035,7 @@ export class MetricServiceClient {
  */
   listMetricDescriptors(
       request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListMetricDescriptorsRequest,
           protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
           protos.google.api.IMetricDescriptor>,
@@ -1043,13 +1049,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IListMetricDescriptorsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1099,7 +1105,7 @@ export class MetricServiceClient {
  */
   listMetricDescriptorsStream(
       request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1161,7 +1167,7 @@ export class MetricServiceClient {
  */
   listMetricDescriptorsAsync(
       request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.api.IMetricDescriptor>{
     request = request || {};
     options = options || {};
@@ -1183,7 +1189,7 @@ export class MetricServiceClient {
   }
   listTimeSeries(
       request: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.ITimeSeries[],
         protos.google.monitoring.v3.IListTimeSeriesRequest|null,
@@ -1191,7 +1197,7 @@ export class MetricServiceClient {
       ]>;
   listTimeSeries(
       request: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListTimeSeriesRequest,
           protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
@@ -1258,7 +1264,7 @@ export class MetricServiceClient {
  */
   listTimeSeries(
       request: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListTimeSeriesRequest,
           protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
           protos.google.monitoring.v3.ITimeSeries>,
@@ -1272,13 +1278,13 @@ export class MetricServiceClient {
         protos.google.monitoring.v3.IListTimeSeriesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1346,7 +1352,7 @@ export class MetricServiceClient {
  */
   listTimeSeriesStream(
       request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1426,7 +1432,7 @@ export class MetricServiceClient {
  */
   listTimeSeriesAsync(
       request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.ITimeSeries>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/notification_channel_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './notification_channel_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class NotificationChannelServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `notification_channel_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class NotificationChannelServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -359,14 +365,14 @@ export class NotificationChannelServiceClient {
   // -------------------
   getNotificationChannelDescriptor(
       request: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannelDescriptor,
         protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|undefined, {}|undefined
       ]>;
   getNotificationChannelDescriptor(
       request: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.INotificationChannelDescriptor,
           protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|null|undefined,
@@ -398,7 +404,7 @@ export class NotificationChannelServiceClient {
  */
   getNotificationChannelDescriptor(
       request: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannelDescriptor,
           protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|null|undefined,
           {}|null|undefined>,
@@ -411,13 +417,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -432,14 +438,14 @@ export class NotificationChannelServiceClient {
   }
   getNotificationChannel(
       request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
         protos.google.monitoring.v3.IGetNotificationChannelRequest|undefined, {}|undefined
       ]>;
   getNotificationChannel(
       request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
@@ -474,7 +480,7 @@ export class NotificationChannelServiceClient {
  */
   getNotificationChannel(
       request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
           {}|null|undefined>,
@@ -487,13 +493,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IGetNotificationChannelRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -508,14 +514,14 @@ export class NotificationChannelServiceClient {
   }
   createNotificationChannel(
       request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
         protos.google.monitoring.v3.ICreateNotificationChannelRequest|undefined, {}|undefined
       ]>;
   createNotificationChannel(
       request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
@@ -555,7 +561,7 @@ export class NotificationChannelServiceClient {
  */
   createNotificationChannel(
       request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
           {}|null|undefined>,
@@ -568,13 +574,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.ICreateNotificationChannelRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -589,14 +595,14 @@ export class NotificationChannelServiceClient {
   }
   updateNotificationChannel(
       request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
         protos.google.monitoring.v3.IUpdateNotificationChannelRequest|undefined, {}|undefined
       ]>;
   updateNotificationChannel(
       request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
@@ -632,7 +638,7 @@ export class NotificationChannelServiceClient {
  */
   updateNotificationChannel(
       request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
           {}|null|undefined>,
@@ -645,13 +651,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IUpdateNotificationChannelRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -666,14 +672,14 @@ export class NotificationChannelServiceClient {
   }
   deleteNotificationChannel(
       request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteNotificationChannelRequest|undefined, {}|undefined
       ]>;
   deleteNotificationChannel(
       request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
@@ -709,7 +715,7 @@ export class NotificationChannelServiceClient {
  */
   deleteNotificationChannel(
       request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
           {}|null|undefined>,
@@ -722,13 +728,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IDeleteNotificationChannelRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -743,14 +749,14 @@ export class NotificationChannelServiceClient {
   }
   sendNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|undefined, {}|undefined
       ]>;
   sendNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|null|undefined,
@@ -781,7 +787,7 @@ export class NotificationChannelServiceClient {
  */
   sendNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|null|undefined,
           {}|null|undefined>,
@@ -794,13 +800,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -815,14 +821,14 @@ export class NotificationChannelServiceClient {
   }
   getNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
         protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|undefined, {}|undefined
       ]>;
   getNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
@@ -884,7 +890,7 @@ export class NotificationChannelServiceClient {
  */
   getNotificationChannelVerificationCode(
       request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
           {}|null|undefined>,
@@ -897,13 +903,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -918,14 +924,14 @@ export class NotificationChannelServiceClient {
   }
   verifyNotificationChannel(
       request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
         protos.google.monitoring.v3.IVerifyNotificationChannelRequest|undefined, {}|undefined
       ]>;
   verifyNotificationChannel(
       request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
@@ -965,7 +971,7 @@ export class NotificationChannelServiceClient {
  */
   verifyNotificationChannel(
       request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
           {}|null|undefined>,
@@ -978,13 +984,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IVerifyNotificationChannelRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1000,7 +1006,7 @@ export class NotificationChannelServiceClient {
 
   listNotificationChannelDescriptors(
       request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannelDescriptor[],
         protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest|null,
@@ -1008,7 +1014,7 @@ export class NotificationChannelServiceClient {
       ]>;
   listNotificationChannelDescriptors(
       request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
@@ -1058,7 +1064,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannelDescriptors(
       request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
           protos.google.monitoring.v3.INotificationChannelDescriptor>,
@@ -1072,13 +1078,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1128,7 +1134,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannelDescriptorsStream(
       request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1190,7 +1196,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannelDescriptorsAsync(
       request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.INotificationChannelDescriptor>{
     request = request || {};
     options = options || {};
@@ -1212,7 +1218,7 @@ export class NotificationChannelServiceClient {
   }
   listNotificationChannels(
       request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel[],
         protos.google.monitoring.v3.IListNotificationChannelsRequest|null,
@@ -1220,7 +1226,7 @@ export class NotificationChannelServiceClient {
       ]>;
   listNotificationChannels(
       request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelsRequest,
           protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
@@ -1280,7 +1286,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannels(
       request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelsRequest,
           protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
           protos.google.monitoring.v3.INotificationChannel>,
@@ -1294,13 +1300,13 @@ export class NotificationChannelServiceClient {
         protos.google.monitoring.v3.IListNotificationChannelsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1361,7 +1367,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannelsStream(
       request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1434,7 +1440,7 @@ export class NotificationChannelServiceClient {
  */
   listNotificationChannelsAsync(
       request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.INotificationChannel>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/service_monitoring_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './service_monitoring_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -79,9 +84,9 @@ export class ServiceMonitoringServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `service_monitoring_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -93,6 +98,7 @@ export class ServiceMonitoringServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -361,14 +367,14 @@ export class ServiceMonitoringServiceClient {
   // -------------------
   createService(
       request: protos.google.monitoring.v3.ICreateServiceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
         protos.google.monitoring.v3.ICreateServiceRequest|undefined, {}|undefined
       ]>;
   createService(
       request: protos.google.monitoring.v3.ICreateServiceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
@@ -404,7 +410,7 @@ export class ServiceMonitoringServiceClient {
  */
   createService(
       request: protos.google.monitoring.v3.ICreateServiceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
           {}|null|undefined>,
@@ -417,13 +423,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.ICreateServiceRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -438,14 +444,14 @@ export class ServiceMonitoringServiceClient {
   }
   getService(
       request: protos.google.monitoring.v3.IGetServiceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
         protos.google.monitoring.v3.IGetServiceRequest|undefined, {}|undefined
       ]>;
   getService(
       request: protos.google.monitoring.v3.IGetServiceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IGetServiceRequest|null|undefined,
@@ -476,7 +482,7 @@ export class ServiceMonitoringServiceClient {
  */
   getService(
       request: protos.google.monitoring.v3.IGetServiceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IGetServiceRequest|null|undefined,
           {}|null|undefined>,
@@ -489,13 +495,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IGetServiceRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -510,14 +516,14 @@ export class ServiceMonitoringServiceClient {
   }
   updateService(
       request: protos.google.monitoring.v3.IUpdateServiceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
         protos.google.monitoring.v3.IUpdateServiceRequest|undefined, {}|undefined
       ]>;
   updateService(
       request: protos.google.monitoring.v3.IUpdateServiceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
@@ -550,7 +556,7 @@ export class ServiceMonitoringServiceClient {
  */
   updateService(
       request: protos.google.monitoring.v3.IUpdateServiceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
           {}|null|undefined>,
@@ -563,13 +569,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IUpdateServiceRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -584,14 +590,14 @@ export class ServiceMonitoringServiceClient {
   }
   deleteService(
       request: protos.google.monitoring.v3.IDeleteServiceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteServiceRequest|undefined, {}|undefined
       ]>;
   deleteService(
       request: protos.google.monitoring.v3.IDeleteServiceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceRequest|null|undefined,
@@ -622,7 +628,7 @@ export class ServiceMonitoringServiceClient {
  */
   deleteService(
       request: protos.google.monitoring.v3.IDeleteServiceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceRequest|null|undefined,
           {}|null|undefined>,
@@ -635,13 +641,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IDeleteServiceRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -656,14 +662,14 @@ export class ServiceMonitoringServiceClient {
   }
   createServiceLevelObjective(
       request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
         protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>;
   createServiceLevelObjective(
       request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
@@ -702,7 +708,7 @@ export class ServiceMonitoringServiceClient {
  */
   createServiceLevelObjective(
       request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
           {}|null|undefined>,
@@ -715,13 +721,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -736,14 +742,14 @@ export class ServiceMonitoringServiceClient {
   }
   getServiceLevelObjective(
       request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
         protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>;
   getServiceLevelObjective(
       request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
@@ -780,7 +786,7 @@ export class ServiceMonitoringServiceClient {
  */
   getServiceLevelObjective(
       request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
           {}|null|undefined>,
@@ -793,13 +799,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -814,14 +820,14 @@ export class ServiceMonitoringServiceClient {
   }
   updateServiceLevelObjective(
       request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
         protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>;
   updateServiceLevelObjective(
       request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
@@ -854,7 +860,7 @@ export class ServiceMonitoringServiceClient {
  */
   updateServiceLevelObjective(
       request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
           {}|null|undefined>,
@@ -867,13 +873,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -888,14 +894,14 @@ export class ServiceMonitoringServiceClient {
   }
   deleteServiceLevelObjective(
       request: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>;
   deleteServiceLevelObjective(
       request: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|null|undefined,
@@ -927,7 +933,7 @@ export class ServiceMonitoringServiceClient {
  */
   deleteServiceLevelObjective(
       request: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|null|undefined,
           {}|null|undefined>,
@@ -940,13 +946,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -962,7 +968,7 @@ export class ServiceMonitoringServiceClient {
 
   listServices(
       request: protos.google.monitoring.v3.IListServicesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService[],
         protos.google.monitoring.v3.IListServicesRequest|null,
@@ -970,7 +976,7 @@ export class ServiceMonitoringServiceClient {
       ]>;
   listServices(
       request: protos.google.monitoring.v3.IListServicesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListServicesRequest,
           protos.google.monitoring.v3.IListServicesResponse|null|undefined,
@@ -1027,7 +1033,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServices(
       request: protos.google.monitoring.v3.IListServicesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListServicesRequest,
           protos.google.monitoring.v3.IListServicesResponse|null|undefined,
           protos.google.monitoring.v3.IService>,
@@ -1041,13 +1047,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IListServicesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1105,7 +1111,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServicesStream(
       request?: protos.google.monitoring.v3.IListServicesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1175,7 +1181,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServicesAsync(
       request?: protos.google.monitoring.v3.IListServicesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IService>{
     request = request || {};
     options = options || {};
@@ -1197,7 +1203,7 @@ export class ServiceMonitoringServiceClient {
   }
   listServiceLevelObjectives(
       request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective[],
         protos.google.monitoring.v3.IListServiceLevelObjectivesRequest|null,
@@ -1205,7 +1211,7 @@ export class ServiceMonitoringServiceClient {
       ]>;
   listServiceLevelObjectives(
       request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
           protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
@@ -1253,7 +1259,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServiceLevelObjectives(
       request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
           protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
           protos.google.monitoring.v3.IServiceLevelObjective>,
@@ -1267,13 +1273,13 @@ export class ServiceMonitoringServiceClient {
         protos.google.monitoring.v3.IListServiceLevelObjectivesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1322,7 +1328,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServiceLevelObjectivesStream(
       request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1383,7 +1389,7 @@ export class ServiceMonitoringServiceClient {
  */
   listServiceLevelObjectivesAsync(
       request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IServiceLevelObjective>{
     request = request || {};
     options = options || {};

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3/uptime_check_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './uptime_check_service_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -83,9 +88,9 @@ export class UptimeCheckServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `uptime_check_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -97,6 +102,7 @@ export class UptimeCheckServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -365,14 +371,14 @@ export class UptimeCheckServiceClient {
   // -------------------
   getUptimeCheckConfig(
       request: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
         protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|undefined, {}|undefined
       ]>;
   getUptimeCheckConfig(
       request: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|null|undefined,
@@ -403,7 +409,7 @@ export class UptimeCheckServiceClient {
  */
   getUptimeCheckConfig(
       request: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|null|undefined,
           {}|null|undefined>,
@@ -416,13 +422,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -437,14 +443,14 @@ export class UptimeCheckServiceClient {
   }
   createUptimeCheckConfig(
       request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
         protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|undefined, {}|undefined
       ]>;
   createUptimeCheckConfig(
       request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
@@ -477,7 +483,7 @@ export class UptimeCheckServiceClient {
  */
   createUptimeCheckConfig(
       request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
           {}|null|undefined>,
@@ -490,13 +496,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -511,14 +517,14 @@ export class UptimeCheckServiceClient {
   }
   updateUptimeCheckConfig(
       request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
         protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|undefined, {}|undefined
       ]>;
   updateUptimeCheckConfig(
       request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
@@ -566,7 +572,7 @@ export class UptimeCheckServiceClient {
  */
   updateUptimeCheckConfig(
       request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
           {}|null|undefined>,
@@ -579,13 +585,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -600,14 +606,14 @@ export class UptimeCheckServiceClient {
   }
   deleteUptimeCheckConfig(
       request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|undefined, {}|undefined
       ]>;
   deleteUptimeCheckConfig(
       request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
@@ -640,7 +646,7 @@ export class UptimeCheckServiceClient {
  */
   deleteUptimeCheckConfig(
       request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
           {}|null|undefined>,
@@ -653,13 +659,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -675,7 +681,7 @@ export class UptimeCheckServiceClient {
 
   listUptimeCheckConfigs(
       request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig[],
         protos.google.monitoring.v3.IListUptimeCheckConfigsRequest|null,
@@ -683,7 +689,7 @@ export class UptimeCheckServiceClient {
       ]>;
   listUptimeCheckConfigs(
       request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
           protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
@@ -727,7 +733,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckConfigs(
       request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
           protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
           protos.google.monitoring.v3.IUptimeCheckConfig>,
@@ -741,13 +747,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.IListUptimeCheckConfigsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -791,7 +797,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckConfigsStream(
       request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -847,7 +853,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckConfigsAsync(
       request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IUptimeCheckConfig>{
     request = request || {};
     options = options || {};
@@ -869,7 +875,7 @@ export class UptimeCheckServiceClient {
   }
   listUptimeCheckIps(
       request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckIp[],
         protos.google.monitoring.v3.IListUptimeCheckIpsRequest|null,
@@ -877,7 +883,7 @@ export class UptimeCheckServiceClient {
       ]>;
   listUptimeCheckIps(
       request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
           protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
@@ -919,7 +925,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckIps(
       request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
           protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
           protos.google.monitoring.v3.IUptimeCheckIp>,
@@ -933,13 +939,13 @@ export class UptimeCheckServiceClient {
         protos.google.monitoring.v3.IListUptimeCheckIpsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -975,7 +981,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckIpsStream(
       request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1023,7 +1029,7 @@ export class UptimeCheckServiceClient {
  */
   listUptimeCheckIpsAsync(
       request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.monitoring.v3.IUptimeCheckIp>{
     request = request || {};
     options = options || {};

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/naming_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './naming_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class NamingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `naming_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class NamingClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath1;
     const port = opts?.port || staticMembers.port1;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -300,14 +306,14 @@ export class NamingClient {
   // -------------------
   paginatedMethodStream(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   paginatedMethodStream(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -334,7 +340,7 @@ export class NamingClient {
  */
   paginatedMethodStream(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -347,13 +353,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -361,14 +367,14 @@ export class NamingClient {
   }
   paginatedMethodAsync(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   paginatedMethodAsync(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -395,7 +401,7 @@ export class NamingClient {
  */
   paginatedMethodAsync(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -408,13 +414,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -422,14 +428,14 @@ export class NamingClient {
   }
   checkLongRunningProgress(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   checkLongRunningProgress(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -456,7 +462,7 @@ export class NamingClient {
  */
   checkLongRunningProgress(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -469,13 +475,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -483,14 +489,14 @@ export class NamingClient {
   }
   initialize(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   initialize(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -518,7 +524,7 @@ export class NamingClient {
  */
   initialize(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -531,13 +537,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -545,14 +551,14 @@ export class NamingClient {
   }
   servicePath(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   servicePath(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -579,7 +585,7 @@ export class NamingClient {
  */
   servicePath(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -592,13 +598,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -606,14 +612,14 @@ export class NamingClient {
   }
   apiEndpoint(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   apiEndpoint(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -640,7 +646,7 @@ export class NamingClient {
  */
   apiEndpoint(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -653,13 +659,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -667,14 +673,14 @@ export class NamingClient {
   }
   port(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   port(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -701,7 +707,7 @@ export class NamingClient {
  */
   port(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -714,13 +720,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -728,14 +734,14 @@ export class NamingClient {
   }
   scopes(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   scopes(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -762,7 +768,7 @@ export class NamingClient {
  */
   scopes(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -775,13 +781,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -789,14 +795,14 @@ export class NamingClient {
   }
   getProjectId(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>;
   getProjectId(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -823,7 +829,7 @@ export class NamingClient {
  */
   getProjectId(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>,
@@ -836,13 +842,13 @@ export class NamingClient {
         protos.google.protobuf.IEmpty|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -851,14 +857,14 @@ export class NamingClient {
 
   longRunning(
       request: protos.google.protobuf.IEmpty,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   longRunning(
       request: protos.google.protobuf.IEmpty,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -889,7 +895,7 @@ export class NamingClient {
  */
   longRunning(
       request: protos.google.protobuf.IEmpty,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -902,13 +908,13 @@ export class NamingClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -937,7 +943,7 @@ export class NamingClient {
   }
   paginatedMethod(
       request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty[],
         protos.google.naming.v1beta1.IPaginatedMethodRequest|null,
@@ -945,7 +951,7 @@ export class NamingClient {
       ]>;
   paginatedMethod(
       request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.naming.v1beta1.IPaginatedMethodRequest,
           protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
@@ -980,7 +986,7 @@ export class NamingClient {
  */
   paginatedMethod(
       request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.naming.v1beta1.IPaginatedMethodRequest,
           protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
           protos.google.protobuf.IEmpty>,
@@ -994,13 +1000,13 @@ export class NamingClient {
         protos.google.naming.v1beta1.IPaginatedMethodResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize1();
@@ -1028,7 +1034,7 @@ export class NamingClient {
  */
   paginatedMethodStream1(
       request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1068,7 +1074,7 @@ export class NamingClient {
  */
   paginatedMethodAsync1(
       request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.protobuf.IEmpty>{
     request = request || {};
     options = options || {};

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/cloud_redis_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './cloud_redis_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -91,9 +96,9 @@ export class CloudRedisClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `cloud_redis_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -105,6 +110,7 @@ export class CloudRedisClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -369,14 +375,14 @@ export class CloudRedisClient {
   // -------------------
   getInstance(
       request: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.redis.v1beta1.IInstance,
         protos.google.cloud.redis.v1beta1.IGetInstanceRequest|undefined, {}|undefined
       ]>;
   getInstance(
       request: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.redis.v1beta1.IInstance,
           protos.google.cloud.redis.v1beta1.IGetInstanceRequest|null|undefined,
@@ -408,7 +414,7 @@ export class CloudRedisClient {
  */
   getInstance(
       request: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.redis.v1beta1.IInstance,
           protos.google.cloud.redis.v1beta1.IGetInstanceRequest|null|undefined,
           {}|null|undefined>,
@@ -421,13 +427,13 @@ export class CloudRedisClient {
         protos.google.cloud.redis.v1beta1.IGetInstanceRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -443,14 +449,14 @@ export class CloudRedisClient {
 
   createInstance(
       request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   createInstance(
       request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -507,7 +513,7 @@ export class CloudRedisClient {
  */
   createInstance(
       request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -520,13 +526,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -562,14 +568,14 @@ export class CloudRedisClient {
   }
   updateInstance(
       request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   updateInstance(
       request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -616,7 +622,7 @@ export class CloudRedisClient {
  */
   updateInstance(
       request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -629,13 +635,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -671,14 +677,14 @@ export class CloudRedisClient {
   }
   importInstance(
       request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   importInstance(
       request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -722,7 +728,7 @@ export class CloudRedisClient {
  */
   importInstance(
       request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -735,13 +741,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -777,14 +783,14 @@ export class CloudRedisClient {
   }
   exportInstance(
       request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   exportInstance(
       request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -826,7 +832,7 @@ export class CloudRedisClient {
  */
   exportInstance(
       request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -839,13 +845,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -881,14 +887,14 @@ export class CloudRedisClient {
   }
   failoverInstance(
       request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   failoverInstance(
       request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -927,7 +933,7 @@ export class CloudRedisClient {
  */
   failoverInstance(
       request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -940,13 +946,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -982,14 +988,14 @@ export class CloudRedisClient {
   }
   deleteInstance(
       request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   deleteInstance(
       request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1025,7 +1031,7 @@ export class CloudRedisClient {
  */
   deleteInstance(
       request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -1038,13 +1044,13 @@ export class CloudRedisClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1080,7 +1086,7 @@ export class CloudRedisClient {
   }
   listInstances(
       request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.redis.v1beta1.IInstance[],
         protos.google.cloud.redis.v1beta1.IListInstancesRequest|null,
@@ -1088,7 +1094,7 @@ export class CloudRedisClient {
       ]>;
   listInstances(
       request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.redis.v1beta1.IListInstancesRequest,
           protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
@@ -1141,7 +1147,7 @@ export class CloudRedisClient {
  */
   listInstances(
       request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.redis.v1beta1.IListInstancesRequest,
           protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
           protos.google.cloud.redis.v1beta1.IInstance>,
@@ -1155,13 +1161,13 @@ export class CloudRedisClient {
         protos.google.cloud.redis.v1beta1.IListInstancesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1208,7 +1214,7 @@ export class CloudRedisClient {
  */
   listInstancesStream(
       request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1267,7 +1273,7 @@ export class CloudRedisClient {
  */
   listInstancesAsync(
       request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.redis.v1beta1.IInstance>{
     request = request || {};
     options = options || {};

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/echo_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './echo_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -81,9 +86,9 @@ export class EchoClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `echo_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -95,6 +100,7 @@ export class EchoClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -347,14 +353,14 @@ export class EchoClient {
   // -------------------
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined
       ]>;
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -384,7 +390,7 @@ export class EchoClient {
  */
   echo(
       request: protos.google.showcase.v1beta1.IEchoRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
           {}|null|undefined>,
@@ -397,13 +403,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IEchoRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -411,14 +417,14 @@ export class EchoClient {
   }
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlockResponse,
         protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
       ]>;
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
@@ -455,7 +461,7 @@ export class EchoClient {
  */
   block(
       request: protos.google.showcase.v1beta1.IBlockRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
           {}|null|undefined>,
@@ -468,13 +474,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -505,7 +511,7 @@ export class EchoClient {
  */
   expand(
       request?: protos.google.showcase.v1beta1.IExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     options = options || {};
@@ -514,7 +520,7 @@ export class EchoClient {
   }
 
   collect(
-      options?: gax.CallOptions,
+      options?: CallOptions,
       callback?: Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -544,7 +550,7 @@ export class EchoClient {
  * stream.end();
  */
   collect(
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
         protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
         {}|null|undefined>,
@@ -557,7 +563,7 @@ export class EchoClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    const options = optionsOrCallback as gax.CallOptions;
+    const options = optionsOrCallback as CallOptions;
     this.initialize();
     return this.innerApiCalls.collect(null, options, callback);
   }
@@ -584,7 +590,7 @@ export class EchoClient {
  * stream.end();
  */
   chat(
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
     return this.innerApiCalls.chat(options);
@@ -592,14 +598,14 @@ export class EchoClient {
 
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -640,7 +646,7 @@ export class EchoClient {
  */
   wait(
       request: protos.google.showcase.v1beta1.IWaitRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -653,13 +659,13 @@ export class EchoClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -688,7 +694,7 @@ export class EchoClient {
   }
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse[],
         protos.google.showcase.v1beta1.IPagedExpandRequest|null,
@@ -696,7 +702,7 @@ export class EchoClient {
       ]>;
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
@@ -734,7 +740,7 @@ export class EchoClient {
  */
   pagedExpand(
       request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
           protos.google.showcase.v1beta1.IEchoResponse>,
@@ -748,13 +754,13 @@ export class EchoClient {
         protos.google.showcase.v1beta1.IPagedExpandResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -785,7 +791,7 @@ export class EchoClient {
  */
   pagedExpandStream(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -828,7 +834,7 @@ export class EchoClient {
  */
   pagedExpandAsync(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>{
     request = request || {};
     options = options || {};

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/identity_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './identity_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -76,9 +81,9 @@ export class IdentityClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `identity_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -90,6 +95,7 @@ export class IdentityClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -307,14 +313,14 @@ export class IdentityClient {
   // -------------------
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.ICreateUserRequest|undefined, {}|undefined
       ]>;
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
@@ -344,7 +350,7 @@ export class IdentityClient {
  */
   createUser(
       request: protos.google.showcase.v1beta1.ICreateUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
           {}|null|undefined>,
@@ -357,13 +363,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.ICreateUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -371,14 +377,14 @@ export class IdentityClient {
   }
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.IGetUserRequest|undefined, {}|undefined
       ]>;
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
@@ -408,7 +414,7 @@ export class IdentityClient {
  */
   getUser(
       request: protos.google.showcase.v1beta1.IGetUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
           {}|null|undefined>,
@@ -421,13 +427,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IGetUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -442,14 +448,14 @@ export class IdentityClient {
   }
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
         protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
       ]>;
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
@@ -482,7 +488,7 @@ export class IdentityClient {
  */
   updateUser(
       request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
           {}|null|undefined>,
@@ -495,13 +501,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -516,14 +522,14 @@ export class IdentityClient {
   }
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteUserRequest|undefined, {}|undefined
       ]>;
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
@@ -553,7 +559,7 @@ export class IdentityClient {
  */
   deleteUser(
       request: protos.google.showcase.v1beta1.IDeleteUserRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
           {}|null|undefined>,
@@ -566,13 +572,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IDeleteUserRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -588,7 +594,7 @@ export class IdentityClient {
 
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser[],
         protos.google.showcase.v1beta1.IListUsersRequest|null,
@@ -596,7 +602,7 @@ export class IdentityClient {
       ]>;
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
@@ -634,7 +640,7 @@ export class IdentityClient {
  */
   listUsers(
       request: protos.google.showcase.v1beta1.IListUsersRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
           protos.google.showcase.v1beta1.IUser>,
@@ -648,13 +654,13 @@ export class IdentityClient {
         protos.google.showcase.v1beta1.IListUsersResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -686,7 +692,7 @@ export class IdentityClient {
  */
   listUsersStream(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -730,7 +736,7 @@ export class IdentityClient {
  */
   listUsersAsync(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IUser>{
     request = request || {};
     options = options || {};

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/messaging_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './messaging_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -80,9 +85,9 @@ export class MessagingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `messaging_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -94,6 +99,7 @@ export class MessagingClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -348,14 +354,14 @@ export class MessagingClient {
   // -------------------
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.ICreateRoomRequest|undefined, {}|undefined
       ]>;
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
@@ -385,7 +391,7 @@ export class MessagingClient {
  */
   createRoom(
       request: protos.google.showcase.v1beta1.ICreateRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -398,13 +404,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.ICreateRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -412,14 +418,14 @@ export class MessagingClient {
   }
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.IGetRoomRequest|undefined, {}|undefined
       ]>;
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
@@ -449,7 +455,7 @@ export class MessagingClient {
  */
   getRoom(
       request: protos.google.showcase.v1beta1.IGetRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -462,13 +468,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IGetRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -483,14 +489,14 @@ export class MessagingClient {
   }
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
         protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
       ]>;
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
@@ -523,7 +529,7 @@ export class MessagingClient {
  */
   updateRoom(
       request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -536,13 +542,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -557,14 +563,14 @@ export class MessagingClient {
   }
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteRoomRequest|undefined, {}|undefined
       ]>;
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
@@ -594,7 +600,7 @@ export class MessagingClient {
  */
   deleteRoom(
       request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
           {}|null|undefined>,
@@ -607,13 +613,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IDeleteRoomRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -628,14 +634,14 @@ export class MessagingClient {
   }
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
       ]>;
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -670,7 +676,7 @@ export class MessagingClient {
  */
   createBlurb(
       request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -683,13 +689,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -704,14 +710,14 @@ export class MessagingClient {
   }
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.IGetBlurbRequest|undefined, {}|undefined
       ]>;
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
@@ -741,7 +747,7 @@ export class MessagingClient {
  */
   getBlurb(
       request: protos.google.showcase.v1beta1.IGetBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -754,13 +760,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IGetBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -775,14 +781,14 @@ export class MessagingClient {
   }
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
         protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
       ]>;
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
@@ -815,7 +821,7 @@ export class MessagingClient {
  */
   updateBlurb(
       request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -828,13 +834,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -849,14 +855,14 @@ export class MessagingClient {
   }
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteBlurbRequest|undefined, {}|undefined
       ]>;
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
@@ -886,7 +892,7 @@ export class MessagingClient {
  */
   deleteBlurb(
       request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
           {}|null|undefined>,
@@ -899,13 +905,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IDeleteBlurbRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -943,7 +949,7 @@ export class MessagingClient {
  */
   streamBlurbs(
       request?: protos.google.showcase.v1beta1.IStreamBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     options = options || {};
@@ -959,7 +965,7 @@ export class MessagingClient {
   }
 
   sendBlurbs(
-      options?: gax.CallOptions,
+      options?: CallOptions,
       callback?: Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -988,7 +994,7 @@ export class MessagingClient {
  * stream.end();
  */
   sendBlurbs(
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
         protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
         {}|null|undefined>,
@@ -1001,7 +1007,7 @@ export class MessagingClient {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    const options = optionsOrCallback as gax.CallOptions;
+    const options = optionsOrCallback as CallOptions;
     this.initialize();
     return this.innerApiCalls.sendBlurbs(null, options, callback);
   }
@@ -1029,7 +1035,7 @@ export class MessagingClient {
  * stream.end();
  */
   connect(
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
     return this.innerApiCalls.connect(options);
@@ -1037,14 +1043,14 @@ export class MessagingClient {
 
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1092,7 +1098,7 @@ export class MessagingClient {
  */
   searchBlurbs(
       request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -1105,13 +1111,13 @@ export class MessagingClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1147,7 +1153,7 @@ export class MessagingClient {
   }
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom[],
         protos.google.showcase.v1beta1.IListRoomsRequest|null,
@@ -1155,7 +1161,7 @@ export class MessagingClient {
       ]>;
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
@@ -1193,7 +1199,7 @@ export class MessagingClient {
  */
   listRooms(
       request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
           protos.google.showcase.v1beta1.IRoom>,
@@ -1207,13 +1213,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IListRoomsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -1245,7 +1251,7 @@ export class MessagingClient {
  */
   listRoomsStream(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1289,7 +1295,7 @@ export class MessagingClient {
  */
   listRoomsAsync(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IRoom>{
     request = request || {};
     options = options || {};
@@ -1304,7 +1310,7 @@ export class MessagingClient {
   }
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb[],
         protos.google.showcase.v1beta1.IListBlurbsRequest|null,
@@ -1312,7 +1318,7 @@ export class MessagingClient {
       ]>;
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
@@ -1354,7 +1360,7 @@ export class MessagingClient {
  */
   listBlurbs(
       request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
           protos.google.showcase.v1beta1.IBlurb>,
@@ -1368,13 +1374,13 @@ export class MessagingClient {
         protos.google.showcase.v1beta1.IListBlurbsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1416,7 +1422,7 @@ export class MessagingClient {
  */
   listBlurbsStream(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1470,7 +1476,7 @@ export class MessagingClient {
  */
   listBlurbsAsync(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.IBlurb>{
     request = request || {};
     options = options || {};

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1beta1/testing_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './testing_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class TestingClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `testing_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class TestingClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -310,14 +316,14 @@ export class TestingClient {
   // -------------------
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
         protos.google.showcase.v1beta1.ICreateSessionRequest|undefined, {}|undefined
       ]>;
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
@@ -349,7 +355,7 @@ export class TestingClient {
  */
   createSession(
       request: protos.google.showcase.v1beta1.ICreateSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -362,13 +368,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.ICreateSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -376,14 +382,14 @@ export class TestingClient {
   }
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
         protos.google.showcase.v1beta1.IGetSessionRequest|undefined, {}|undefined
       ]>;
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
@@ -413,7 +419,7 @@ export class TestingClient {
  */
   getSession(
       request: protos.google.showcase.v1beta1.IGetSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -426,13 +432,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IGetSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -447,14 +453,14 @@ export class TestingClient {
   }
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteSessionRequest|undefined, {}|undefined
       ]>;
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
@@ -484,7 +490,7 @@ export class TestingClient {
  */
   deleteSession(
       request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -497,13 +503,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IDeleteSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -518,14 +524,14 @@ export class TestingClient {
   }
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IReportSessionResponse,
         protos.google.showcase.v1beta1.IReportSessionRequest|undefined, {}|undefined
       ]>;
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
@@ -557,7 +563,7 @@ export class TestingClient {
  */
   reportSession(
       request: protos.google.showcase.v1beta1.IReportSessionRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
           {}|null|undefined>,
@@ -570,13 +576,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IReportSessionRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -591,14 +597,14 @@ export class TestingClient {
   }
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
       ]>;
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
@@ -633,7 +639,7 @@ export class TestingClient {
  */
   deleteTest(
       request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
           {}|null|undefined>,
@@ -646,13 +652,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -667,14 +673,14 @@ export class TestingClient {
   }
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IVerifyTestResponse,
         protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
       ]>;
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
@@ -711,7 +717,7 @@ export class TestingClient {
  */
   verifyTest(
       request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
           {}|null|undefined>,
@@ -724,13 +730,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -746,7 +752,7 @@ export class TestingClient {
 
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession[],
         protos.google.showcase.v1beta1.IListSessionsRequest|null,
@@ -754,7 +760,7 @@ export class TestingClient {
       ]>;
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
@@ -789,7 +795,7 @@ export class TestingClient {
  */
   listSessions(
       request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
           protos.google.showcase.v1beta1.ISession>,
@@ -803,13 +809,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IListSessionsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -838,7 +844,7 @@ export class TestingClient {
  */
   listSessionsStream(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -879,7 +885,7 @@ export class TestingClient {
  */
   listSessionsAsync(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.ISession>{
     request = request || {};
     options = options || {};
@@ -894,7 +900,7 @@ export class TestingClient {
   }
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ITest[],
         protos.google.showcase.v1beta1.IListTestsRequest|null,
@@ -902,7 +908,7 @@ export class TestingClient {
       ]>;
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
@@ -939,7 +945,7 @@ export class TestingClient {
  */
   listTests(
       request: protos.google.showcase.v1beta1.IListTestsRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
           protos.google.showcase.v1beta1.ITest>,
@@ -953,13 +959,13 @@ export class TestingClient {
         protos.google.showcase.v1beta1.IListTestsResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -997,7 +1003,7 @@ export class TestingClient {
  */
   listTestsStream(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1047,7 +1053,7 @@ export class TestingClient {
  */
   listTestsAsync(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.showcase.v1beta1.ITest>{
     request = request || {};
     options = options || {};

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v2/cloud_tasks_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './cloud_tasks_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class CloudTasksClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `cloud_tasks_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class CloudTasksClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -291,14 +297,14 @@ export class CloudTasksClient {
   // -------------------
   getQueue(
       request: protos.google.cloud.tasks.v2.IGetQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.IGetQueueRequest|undefined, {}|undefined
       ]>;
   getQueue(
       request: protos.google.cloud.tasks.v2.IGetQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IGetQueueRequest|null|undefined,
@@ -329,7 +335,7 @@ export class CloudTasksClient {
  */
   getQueue(
       request: protos.google.cloud.tasks.v2.IGetQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IGetQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -342,13 +348,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IGetQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -363,14 +369,14 @@ export class CloudTasksClient {
   }
   createQueue(
       request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.ICreateQueueRequest|undefined, {}|undefined
       ]>;
   createQueue(
       request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
@@ -420,7 +426,7 @@ export class CloudTasksClient {
  */
   createQueue(
       request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -433,13 +439,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.ICreateQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -454,14 +460,14 @@ export class CloudTasksClient {
   }
   updateQueue(
       request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.IUpdateQueueRequest|undefined, {}|undefined
       ]>;
   updateQueue(
       request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
@@ -515,7 +521,7 @@ export class CloudTasksClient {
  */
   updateQueue(
       request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -528,13 +534,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IUpdateQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -549,14 +555,14 @@ export class CloudTasksClient {
   }
   deleteQueue(
       request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.cloud.tasks.v2.IDeleteQueueRequest|undefined, {}|undefined
       ]>;
   deleteQueue(
       request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
@@ -599,7 +605,7 @@ export class CloudTasksClient {
  */
   deleteQueue(
       request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -612,13 +618,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IDeleteQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -633,14 +639,14 @@ export class CloudTasksClient {
   }
   purgeQueue(
       request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.IPurgeQueueRequest|undefined, {}|undefined
       ]>;
   purgeQueue(
       request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
@@ -676,7 +682,7 @@ export class CloudTasksClient {
  */
   purgeQueue(
       request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -689,13 +695,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IPurgeQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -710,14 +716,14 @@ export class CloudTasksClient {
   }
   pauseQueue(
       request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.IPauseQueueRequest|undefined, {}|undefined
       ]>;
   pauseQueue(
       request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
@@ -754,7 +760,7 @@ export class CloudTasksClient {
  */
   pauseQueue(
       request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -767,13 +773,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IPauseQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -788,14 +794,14 @@ export class CloudTasksClient {
   }
   resumeQueue(
       request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
         protos.google.cloud.tasks.v2.IResumeQueueRequest|undefined, {}|undefined
       ]>;
   resumeQueue(
       request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
@@ -838,7 +844,7 @@ export class CloudTasksClient {
  */
   resumeQueue(
       request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
           {}|null|undefined>,
@@ -851,13 +857,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IResumeQueueRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -872,14 +878,14 @@ export class CloudTasksClient {
   }
   getIamPolicy(
       request: protos.google.iam.v1.IGetIamPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.iam.v1.IPolicy,
         protos.google.iam.v1.IGetIamPolicyRequest|undefined, {}|undefined
       ]>;
   getIamPolicy(
       request: protos.google.iam.v1.IGetIamPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
@@ -921,7 +927,7 @@ export class CloudTasksClient {
  */
   getIamPolicy(
       request: protos.google.iam.v1.IGetIamPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -934,13 +940,13 @@ export class CloudTasksClient {
         protos.google.iam.v1.IGetIamPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -955,14 +961,14 @@ export class CloudTasksClient {
   }
   setIamPolicy(
       request: protos.google.iam.v1.ISetIamPolicyRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.iam.v1.IPolicy,
         protos.google.iam.v1.ISetIamPolicyRequest|undefined, {}|undefined
       ]>;
   setIamPolicy(
       request: protos.google.iam.v1.ISetIamPolicyRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
@@ -1008,7 +1014,7 @@ export class CloudTasksClient {
  */
   setIamPolicy(
       request: protos.google.iam.v1.ISetIamPolicyRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
           {}|null|undefined>,
@@ -1021,13 +1027,13 @@ export class CloudTasksClient {
         protos.google.iam.v1.ISetIamPolicyRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1042,14 +1048,14 @@ export class CloudTasksClient {
   }
   testIamPermissions(
       request: protos.google.iam.v1.ITestIamPermissionsRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.iam.v1.ITestIamPermissionsResponse,
         protos.google.iam.v1.ITestIamPermissionsRequest|undefined, {}|undefined
       ]>;
   testIamPermissions(
       request: protos.google.iam.v1.ITestIamPermissionsRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.iam.v1.ITestIamPermissionsResponse,
           protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
@@ -1091,7 +1097,7 @@ export class CloudTasksClient {
  */
   testIamPermissions(
       request: protos.google.iam.v1.ITestIamPermissionsRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.ITestIamPermissionsResponse,
           protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
           {}|null|undefined>,
@@ -1104,13 +1110,13 @@ export class CloudTasksClient {
         protos.google.iam.v1.ITestIamPermissionsRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1125,14 +1131,14 @@ export class CloudTasksClient {
   }
   getTask(
       request: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
         protos.google.cloud.tasks.v2.IGetTaskRequest|undefined, {}|undefined
       ]>;
   getTask(
       request: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
@@ -1176,7 +1182,7 @@ export class CloudTasksClient {
  */
   getTask(
       request: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
           {}|null|undefined>,
@@ -1189,13 +1195,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IGetTaskRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1210,14 +1216,14 @@ export class CloudTasksClient {
   }
   createTask(
       request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
         protos.google.cloud.tasks.v2.ICreateTaskRequest|undefined, {}|undefined
       ]>;
   createTask(
       request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
@@ -1301,7 +1307,7 @@ export class CloudTasksClient {
  */
   createTask(
       request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
           {}|null|undefined>,
@@ -1314,13 +1320,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.ICreateTaskRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1335,14 +1341,14 @@ export class CloudTasksClient {
   }
   deleteTask(
       request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
         protos.google.cloud.tasks.v2.IDeleteTaskRequest|undefined, {}|undefined
       ]>;
   deleteTask(
       request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
@@ -1377,7 +1383,7 @@ export class CloudTasksClient {
  */
   deleteTask(
       request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
           {}|null|undefined>,
@@ -1390,13 +1396,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IDeleteTaskRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1411,14 +1417,14 @@ export class CloudTasksClient {
   }
   runTask(
       request: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
         protos.google.cloud.tasks.v2.IRunTaskRequest|undefined, {}|undefined
       ]>;
   runTask(
       request: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
@@ -1485,7 +1491,7 @@ export class CloudTasksClient {
  */
   runTask(
       request: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
           {}|null|undefined>,
@@ -1498,13 +1504,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IRunTaskRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1520,7 +1526,7 @@ export class CloudTasksClient {
 
   listQueues(
       request: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue[],
         protos.google.cloud.tasks.v2.IListQueuesRequest|null,
@@ -1528,7 +1534,7 @@ export class CloudTasksClient {
       ]>;
   listQueues(
       request: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.tasks.v2.IListQueuesRequest,
           protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
@@ -1593,7 +1599,7 @@ export class CloudTasksClient {
  */
   listQueues(
       request: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.tasks.v2.IListQueuesRequest,
           protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
           protos.google.cloud.tasks.v2.IQueue>,
@@ -1607,13 +1613,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IListQueuesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1677,7 +1683,7 @@ export class CloudTasksClient {
  */
   listQueuesStream(
       request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1753,7 +1759,7 @@ export class CloudTasksClient {
  */
   listQueuesAsync(
       request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.tasks.v2.IQueue>{
     request = request || {};
     options = options || {};
@@ -1775,7 +1781,7 @@ export class CloudTasksClient {
   }
   listTasks(
       request: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask[],
         protos.google.cloud.tasks.v2.IListTasksRequest|null,
@@ -1783,7 +1789,7 @@ export class CloudTasksClient {
       ]>;
   listTasks(
       request: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.tasks.v2.IListTasksRequest,
           protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
@@ -1857,7 +1863,7 @@ export class CloudTasksClient {
  */
   listTasks(
       request: protos.google.cloud.tasks.v2.IListTasksRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.tasks.v2.IListTasksRequest,
           protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
           protos.google.cloud.tasks.v2.ITask>,
@@ -1871,13 +1877,13 @@ export class CloudTasksClient {
         protos.google.cloud.tasks.v2.IListTasksResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1944,7 +1950,7 @@ export class CloudTasksClient {
  */
   listTasksStream(
       request?: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -2023,7 +2029,7 @@ export class CloudTasksClient {
  */
   listTasksAsync(
       request?: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.tasks.v2.ITask>{
     request = request || {};
     options = options || {};

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -21,6 +21,11 @@ import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 import * as path from 'path';
 
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1/text_to_speech_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './text_to_speech_client_config.json';
 
 const version = require('../../../package.json').version;
@@ -73,9 +78,9 @@ export class TextToSpeechClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `text_to_speech_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -87,6 +92,7 @@ export class TextToSpeechClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -264,14 +270,14 @@ export class TextToSpeechClient {
   // -------------------
   listVoices(
       request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.texttospeech.v1.IListVoicesResponse,
         protos.google.cloud.texttospeech.v1.IListVoicesRequest|undefined, {}|undefined
       ]>;
   listVoices(
       request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.texttospeech.v1.IListVoicesResponse,
           protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
@@ -308,7 +314,7 @@ export class TextToSpeechClient {
  */
   listVoices(
       request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.texttospeech.v1.IListVoicesResponse,
           protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
           {}|null|undefined>,
@@ -321,13 +327,13 @@ export class TextToSpeechClient {
         protos.google.cloud.texttospeech.v1.IListVoicesRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();
@@ -335,14 +341,14 @@ export class TextToSpeechClient {
   }
   synthesizeSpeech(
       request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
         protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|undefined, {}|undefined
       ]>;
   synthesizeSpeech(
       request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
@@ -377,7 +383,7 @@ export class TextToSpeechClient {
  */
   synthesizeSpeech(
       request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
           {}|null|undefined>,
@@ -390,13 +396,13 @@ export class TextToSpeechClient {
         protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -23,6 +23,11 @@ import * as path from 'path';
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v3beta1/translation_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './translation_service_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -77,9 +82,9 @@ export class TranslationServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `translation_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -91,6 +96,7 @@ export class TranslationServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -332,14 +338,14 @@ export class TranslationServiceClient {
   // -------------------
   translateText(
       request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
         protos.google.cloud.translation.v3beta1.ITranslateTextRequest|undefined, {}|undefined
       ]>;
   translateText(
       request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
           protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
@@ -429,7 +435,7 @@ export class TranslationServiceClient {
  */
   translateText(
       request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
           protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
           {}|null|undefined>,
@@ -442,13 +448,13 @@ export class TranslationServiceClient {
         protos.google.cloud.translation.v3beta1.ITranslateTextRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -463,14 +469,14 @@ export class TranslationServiceClient {
   }
   detectLanguage(
       request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
         protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|undefined, {}|undefined
       ]>;
   detectLanguage(
       request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
           protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
@@ -534,7 +540,7 @@ export class TranslationServiceClient {
  */
   detectLanguage(
       request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
           protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
           {}|null|undefined>,
@@ -547,13 +553,13 @@ export class TranslationServiceClient {
         protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -568,14 +574,14 @@ export class TranslationServiceClient {
   }
   getSupportedLanguages(
       request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.ISupportedLanguages,
         protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|undefined, {}|undefined
       ]>;
   getSupportedLanguages(
       request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.translation.v3beta1.ISupportedLanguages,
           protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
@@ -636,7 +642,7 @@ export class TranslationServiceClient {
  */
   getSupportedLanguages(
       request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ISupportedLanguages,
           protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
           {}|null|undefined>,
@@ -649,13 +655,13 @@ export class TranslationServiceClient {
         protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -670,14 +676,14 @@ export class TranslationServiceClient {
   }
   getGlossary(
       request: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IGlossary,
         protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|undefined, {}|undefined
       ]>;
   getGlossary(
       request: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           protos.google.cloud.translation.v3beta1.IGlossary,
           protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|null|undefined,
@@ -708,7 +714,7 @@ export class TranslationServiceClient {
  */
   getGlossary(
       request: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.IGlossary,
           protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|null|undefined,
           {}|null|undefined>,
@@ -721,13 +727,13 @@ export class TranslationServiceClient {
         protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -743,14 +749,14 @@ export class TranslationServiceClient {
 
   batchTranslateText(
       request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   batchTranslateText(
       request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -839,7 +845,7 @@ export class TranslationServiceClient {
  */
   batchTranslateText(
       request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -852,13 +858,13 @@ export class TranslationServiceClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -894,14 +900,14 @@ export class TranslationServiceClient {
   }
   createGlossary(
       request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   createGlossary(
       request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -937,7 +943,7 @@ export class TranslationServiceClient {
  */
   createGlossary(
       request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -950,13 +956,13 @@ export class TranslationServiceClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -992,14 +998,14 @@ export class TranslationServiceClient {
   }
   deleteGlossary(
       request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   deleteGlossary(
       request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1034,7 +1040,7 @@ export class TranslationServiceClient {
  */
   deleteGlossary(
       request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -1047,13 +1053,13 @@ export class TranslationServiceClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1089,7 +1095,7 @@ export class TranslationServiceClient {
   }
   listGlossaries(
       request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IGlossary[],
         protos.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
@@ -1097,7 +1103,7 @@ export class TranslationServiceClient {
       ]>;
   listGlossaries(
       request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
           protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
@@ -1143,7 +1149,7 @@ export class TranslationServiceClient {
  */
   listGlossaries(
       request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
           protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
           protos.google.cloud.translation.v3beta1.IGlossary>,
@@ -1157,13 +1163,13 @@ export class TranslationServiceClient {
         protos.google.cloud.translation.v3beta1.IListGlossariesResponse
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
@@ -1209,7 +1215,7 @@ export class TranslationServiceClient {
  */
   listGlossariesStream(
       request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     options = options || {};
@@ -1267,7 +1273,7 @@ export class TranslationServiceClient {
  */
   listGlossariesAsync(
       request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<protos.google.cloud.translation.v3beta1.IGlossary>{
     request = request || {};
     options = options || {};

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -21,6 +21,11 @@ import {Callback, CallOptions, Descriptors, ClientOptions, LROperation} from 'go
 import * as path from 'path';
 
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/v1/video_intelligence_service_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './video_intelligence_service_client_config.json';
 import { operationsProtos } from 'google-gax';
 const version = require('../../../package.json').version;
@@ -74,9 +79,9 @@ export class VideoIntelligenceServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `video_intelligence_service_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -88,6 +93,7 @@ export class VideoIntelligenceServiceClient {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -292,14 +298,14 @@ export class VideoIntelligenceServiceClient {
 
   annotateVideo(
       request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>;
   annotateVideo(
       request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -363,7 +369,7 @@ export class VideoIntelligenceServiceClient {
  */
   annotateVideo(
       request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>,
@@ -376,13 +382,13 @@ export class VideoIntelligenceServiceClient {
         protos.google.longrunning.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     options = options || {};
     this.initialize();

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -35,10 +35,6 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().rejects(error) : sinon.stub().resolves([response]);
 }
 
-function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error?: Error) {
-    return error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);
-}
-
 function stubLongRunningCall<ResponseType>(response?: ResponseType, callError?: Error, lroError?: Error) {
     const innerStub = lroError ? sinon.stub().rejects(lroError) : sinon.stub().resolves([response]);
     const mockOperation = {

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -33,6 +33,11 @@ import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 {%- endif %}
 import * as protos from '../../protos/protos';
+/**
+ * Client JSON configuration object, loaded from
+ * `src/{{ api.naming.version }}/{{ service.name.toSnakeCase() }}_client_config.json`.
+ * This file defines retry strategy and timeouts for all API methods in this library.
+ */
 import * as gapicConfig from './{{ service.name.toSnakeCase() }}_client_config.json';
 {% if service.longRunning.length > 0 -%}
 import { operationsProtos } from 'google-gax';
@@ -96,9 +101,9 @@ export class {{ service.name }}Client {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
-   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
-   *     Follows the structure of `{{ service.name.toSnakeCase() }}_client_config.json`.
-   * @param {boolean} fallback - Use HTTP fallback mode.
+   * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
+   *     Follows the structure of {@link gapicConfig}.
+   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
    *     In fallback mode, a special browser-compatible transport implementation is used
    *     instead of gRPC transport. In browser context (if the `window` object is defined)
    *     the fallback mode is enabled automatically; set `options.fallback` to `false`
@@ -110,6 +115,7 @@ export class {{ service.name }}Client {
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
     const port = opts?.port || staticMembers.{{ id.get("port") }};
     const clientConfig = opts?.clientConfig ?? {};
+    // eslint-disable-next-line no-undef
     const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window.fetch !== 'undefined');
     opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
@@ -423,14 +429,14 @@ export class {{ service.name }}Client {
 {%- for method in service.simpleMethods %}
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           {{ util.toInterface(method.outputInterface) }},
           {{ util.toInterface(method.inputInterface) }}|null|undefined,
@@ -446,7 +452,7 @@ export class {{ service.name }}Client {
  */
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           {{ util.toInterface(method.outputInterface) }},
           {{ util.toInterface(method.inputInterface) }}|null|undefined,
           {}|null|undefined>,
@@ -459,13 +465,13 @@ export class {{ service.name }}Client {
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
@@ -478,7 +484,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream {
     this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(options);
@@ -489,7 +495,7 @@ export class {{ service.name }}Client {
  */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
     gax.CancellableStream{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
@@ -498,7 +504,7 @@ export class {{ service.name }}Client {
   }
 {%- elif method.clientStreaming %}
   {{ method.name.toCamelCase() }}(
-      options?: gax.CallOptions,
+      options?: CallOptions,
       callback?: Callback<
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|null|undefined,
@@ -514,7 +520,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|null|undefined,
         {}|null|undefined>,
@@ -527,7 +533,7 @@ export class {{ service.name }}Client {
         callback = optionsOrCallback;
         optionsOrCallback = {};
     }
-    const options = optionsOrCallback as gax.CallOptions;
+    const options = optionsOrCallback as CallOptions;
     this.{{ id.get("initialize") }}();
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(null, options, callback);
   }
@@ -536,14 +542,14 @@ export class {{ service.name }}Client {
 {%- for method in service.longRunning %}
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType) }}>,
         {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>;
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: Callback<
           LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
@@ -559,7 +565,7 @@ export class {{ service.name }}Client {
  */
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      optionsOrCallback?: gax.CallOptions|Callback<
+      optionsOrCallback?: CallOptions|Callback<
           LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType)}}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
           {}|null|undefined>,
@@ -572,13 +578,13 @@ export class {{ service.name }}Client {
         {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
@@ -598,7 +604,7 @@ export class {{ service.name }}Client {
 {%- for method in service.paging %}
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
       Promise<[
         {{ util.toInterface(method.pagingResponseType) }}[],
         {{ util.toInterface(method.inputInterface) }}|null,
@@ -606,7 +612,7 @@ export class {{ service.name }}Client {
       ]>;
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      options: gax.CallOptions,
+      options: CallOptions,
       callback: PaginationCallback<
           {{ util.toInterface(method.inputInterface) }},
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
@@ -622,7 +628,7 @@ export class {{ service.name }}Client {
  */
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
-      optionsOrCallback?: gax.CallOptions|PaginationCallback<
+      optionsOrCallback?: CallOptions|PaginationCallback<
           {{ util.toInterface(method.inputInterface) }},
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
           {{ util.toInterface(method.pagingResponseType) }}>,
@@ -636,13 +642,13 @@ export class {{ service.name }}Client {
         {{ util.toInterface(method.outputInterface) }}
       ]>|void {
     request = request || {};
-    let options: gax.CallOptions;
+    let options: CallOptions;
     if (typeof optionsOrCallback === 'function' && callback === undefined) {
       callback = optionsOrCallback;
       options = {};
     }
     else {
-      options = optionsOrCallback as gax.CallOptions;
+      options = optionsOrCallback as CallOptions;
     }
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
@@ -654,7 +660,7 @@ export class {{ service.name }}Client {
  */
   {{ id.get(method.name.toCamelCase() + "Stream") }}(
       request?: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
     Transform{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
@@ -672,7 +678,7 @@ export class {{ service.name }}Client {
  */
   {{ id.get(method.name.toCamelCase() + "Async") }}(
       request?: {{ util.toInterface(method.inputInterface) }},
-      options?: gax.CallOptions):
+      options?: CallOptions):
     AsyncIterable<{{ util.toInterface(method.pagingResponseType) }}>{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -46,6 +46,8 @@ function generateSampleMessage<T extends object>(instance: T) {
 function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().rejects(error) : sinon.stub().resolves([response]);
 }
+{%- endif %}
+{%- if (service.simpleMethods.length > 0) %}
 
 function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);


### PR DESCRIPTION
Fixes https://github.com/googleapis/synthtool/issues/853. 

Fixing several linting errors. Making JSON config reference in JSDoc more readable (I'm unable to make it point to the file since we don't include the copy of the source code to JSDoc, so documenting the global and referencing it is likely the best I can do).