### PR TITLE
fix: include test method for paginated calls

### DIFF
--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -47,7 +47,7 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().rejects(error) : sinon.stub().resolves([response]);
 }
 {%- endif %}
-{%- if (service.simpleMethods.length > 0) %}
+{%- if (service.simpleMethods.length + service.paging.length > 0) %}
 
 function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-ai-platform/issues/13.

Apparently, the fix I previously made to please the linter fails in a rare case when a library has paginated methods, but no simple methods (since this method inside `if` block, `stubSimpleCallWithCallback`, is used for simple _and_ for paginated methods). Changing that back.  (we don't have baseline coverage for this change, I need to extend it later)