### PR TITLE
fix: use proper joiner in GAPIC metadata JSON template

### DIFF
--- a/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
+++ b/templates/typescript_gapic_metadata/src/$version/gapic_metadata.json.njk
@@ -90,13 +90,13 @@ limitations under the License.
             }
   {%- endfor -%}
   {%- for method in service.longRunning -%}
-            {{- grpcMethodJoiner() -}}
+            {{- fallbackMethodJoiner() -}}
             "{{ method.name }}": {
               "methods": ["{{ method.name.toCamelCase() }}"]
             }
   {%- endfor -%}
   {%- for method in service.paging %}
-            {{- grpcMethodJoiner() -}}
+            {{- fallbackMethodJoiner() -}}
             "{{ method.name }}": {
               "methods": [
                             "{{ method.name.toCamelCase() }}",


### PR DESCRIPTION
I had a typo in the template. Using the wrong joiner affected just one JSON file ([this one](https://github.com/googleapis/nodejs-asset/pull/439/files#diff-41a56e9347b78eda8877d6268d6aaf44c903723df563575dd88336d12947adce) in `nodejs-asset` `v1p1beta1`). Still need to fix it :)