### PR TITLE
fix: un-blocklist some common package names

### DIFF
--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -226,7 +226,7 @@ export class Generator {
       const api = this.buildAPIObject();
       await this.processTemplates(api);
     } catch (err) {
-      this.response.error = err.toString();
+      this.response.error = err instanceof Error ? err.message : err.toString();
     }
 
     const outputBuffer = protos.google.protobuf.compiler.CodeGeneratorResponse.encode(

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -110,7 +110,9 @@ export class API {
       }, [] as protos.google.protobuf.IServiceDescriptorProto[])
       .filter(service => {
         if (!service.options || !service.options['.google.api.defaultHost']) {
-          throw new Error(`service "${packageName}.${service.name}" is missing option google.api.default_host`);
+          throw new Error(
+            `service "${packageName}.${service.name}" is missing option google.api.default_host`
+          );
         }
         const defaultHost = service!.options!['.google.api.defaultHost']!;
         if (defaultHost.length === 0) {

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -105,7 +105,9 @@ function longrunning(
     method.outputType === '.google.longrunning.Operation'
   ) {
     if (!method.options?.['.google.longrunning.operationInfo']) {
-      throw `rpc "${service.packageName}.${service.name}.${method.name}" returns google.longrunning.Operation but is missing option google.longrunning.operation_info`;
+      throw new Error(
+        `rpc "${service.packageName}.${service.name}.${method.name}" returns google.longrunning.Operation but is missing option google.longrunning.operation_info`
+      );
     } else {
       return method.options!['.google.longrunning.operationInfo']!;
     }
@@ -352,9 +354,13 @@ function augmentMethod(
   ) as MethodDescriptorProto;
   if (method.longRunning) {
     if (!method.longRunningMetadataType) {
-      throw `rpc "${parameters.service.packageName}.${method.name}" has google.longrunning.operation_info but is missing option google.longrunning.operation_info.metadata_type`;
+      throw new Error(
+        `rpc "${parameters.service.packageName}.${method.name}" has google.longrunning.operation_info but is missing option google.longrunning.operation_info.metadata_type`
+      );
     } else if (!method.longRunningResponseType) {
-      throw `rpc "${parameters.service.packageName}.${method.name}" has google.longrunning.operation_info but is missing option google.longrunning.operation_info.response_type`;
+      throw new Error(
+        `rpc "${parameters.service.packageName}.${method.name}" has google.longrunning.operation_info but is missing option google.longrunning.operation_info.response_type`
+      );
     }
   }
   const bundleConfigs = parameters.service.bundleConfigs;

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -649,7 +649,7 @@ export class Proto {
     }
     if (this.fileToGenerate) {
       for (const commonProto of COMMON_PROTO_LIST) {
-        if (protopackage?.startsWith(commonProto)) {
+        if (protopackage === commonProto) {
           this.fileToGenerate = false;
         }
       }

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -75,6 +75,23 @@ describe('src/schema/api.ts', () => {
     ]);
   });
 
+  it('should be able to generate google.iam.v1 alone', () => {
+    const fd = new protos.google.protobuf.FileDescriptorProto();
+    fd.name = 'google/iam/v1/iam_policy.proto';
+    fd.package = 'google.iam.v1';
+    fd.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    fd.service[0].name = 'IAMPolicy';
+    fd.service[0].options = {
+      '.google.api.defaultHost': 'iam.googleapis.com',
+    };
+    const api = new API([fd], 'google.iam.v1', {
+      grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
+    });
+    assert.deepStrictEqual(api.filesToGenerate, [
+      'google/iam/v1/iam_policy.proto',
+    ]);
+  });
+
   it('should not return common protos in the proto list', () => {
     const fd1 = new protos.google.protobuf.FileDescriptorProto();
     fd1.name = 'google/cloud/test/v1/test.proto';
@@ -93,12 +110,16 @@ describe('src/schema/api.ts', () => {
     const fd4 = new protos.google.protobuf.FileDescriptorProto();
     fd4.name = 'google/cloud/common_resources.proto';
     fd4.package = 'google.cloud';
-    const api = new API([fd1, fd2, fd3, fd4], 'google', {
+    const fd5 = new protos.google.protobuf.FileDescriptorProto();
+    fd5.name = 'google/api/servicemanagement/v1/servicemanager.proto';
+    fd5.package = 'google.api.servicemanager.v1';
+    const api = new API([fd1, fd2, fd3, fd4, fd5], 'google', {
       grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
     });
     assert.deepStrictEqual(api.filesToGenerate, [
       'google/cloud/test/v1/test.proto',
       'google/orgpolicy/v1/orgpolicy.proto',
+      'google/api/servicemanagement/v1/servicemanager.proto',
     ]);
   });
 


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#626. Allows generating `google.iam.v1` when it's the only service to be generated (so it will still ignore it when it's coming as a dependency of Pub/Sub or anything else). Also, allowing `google.api.*` (making sure we only disallow `google.api` itself, not its nested packages).

Minor refactor included: throw instances of `Error` instead of just strings.

@sofisl This took some time to figure out! Sorry for delay with this fix.