### PR TITLE
chore: run tests on Node 14 instead of 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         # Test on the oldest and the newest supported version just in case
-        node-version: [10.x, 15.x]
+        node-version: [10.x, 14.x]
         test: [js, ts]
 
     steps:


### PR DESCRIPTION
`grpc` does not publish pre-built binaries for Node 15.