### PR TITLE
fix: fixing naming resolution for IAM v1

### DIFF
--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -38,10 +38,9 @@ export class Naming {
   ) {
     let rootPackage = '';
     const mainServiceName = options ? options.mainServiceName : '';
-    const protoPackages = fileDescriptors
-      .filter(fd => fd.service && fd.service.length > 0)
-      .filter(fd => !API.isIgnoredService(fd))
-      .map(fd => fd.package || '');
+    const protoPackages = API.filterOutIgnoredServices(
+      fileDescriptors.filter(fd => fd.service && fd.service.length > 0)
+    ).map(fd => fd.package || '');
     const prefix = commonPrefix(protoPackages);
     // common prefix must either end with `.`, or be equal to at least one of
     // the packages' prefix

--- a/typescript/test/unit/naming.ts
+++ b/typescript/test/unit/naming.ts
@@ -101,6 +101,33 @@ describe('src/schema/naming.ts', () => {
     assert.strictEqual(naming.protoPackage, 'google.namespace.service.v1beta1');
   });
 
+  it('ignores IAM files when determining package name', () => {
+    const descriptor1 = new protos.google.protobuf.FileDescriptorProto();
+    const descriptor2 = new protos.google.protobuf.FileDescriptorProto();
+    descriptor1.package = 'google.namespace.service.v1beta1';
+    descriptor1.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    descriptor2.package = 'google.iam.v1';
+    descriptor2.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    const naming = new Naming([descriptor1, descriptor2]);
+    assert.strictEqual(naming.name, 'Service');
+    assert.strictEqual(naming.productName, 'Service');
+    assert.deepStrictEqual(naming.namespace, ['google', 'namespace']);
+    assert.strictEqual(naming.version, 'v1beta1');
+    assert.strictEqual(naming.protoPackage, 'google.namespace.service.v1beta1');
+  });
+
+  it('determines package name for IAM alone', () => {
+    const descriptor = new protos.google.protobuf.FileDescriptorProto();
+    descriptor.package = 'google.iam.v1';
+    descriptor.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    const naming = new Naming([descriptor]);
+    assert.strictEqual(naming.name, 'Iam');
+    assert.strictEqual(naming.productName, 'Iam');
+    assert.deepStrictEqual(naming.namespace, ['google']);
+    assert.strictEqual(naming.version, 'v1');
+    assert.strictEqual(naming.protoPackage, 'google.iam.v1');
+  });
+
   it('fails on bad package name 1', () => {
     const descriptor = new protos.google.protobuf.FileDescriptorProto();
     descriptor.package = 'nonamespace';


### PR DESCRIPTION
Expanding #827 to the naming logic. Avoiding code duplication (I missed this piece of logic when I worked on #827, and the problem was caught on the pre-submit CI).