### PR TITLE
fix: filter out all common packages

### DIFF
--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -40,7 +40,14 @@ export class API {
   ): boolean {
     // Some common proto files define common services which we don't want to generate.
     // List them here.
-    return fd.package === 'google.longrunning' || fd.package === 'google.cloud';
+    return (
+      fd.package === 'google.longrunning' ||
+      fd.package === 'google.cloud' ||
+      fd.package === 'google.protobuf' ||
+      fd.package === 'google.type' ||
+      fd.package === 'google.rpc' ||
+      fd.package === 'google.api'
+    );
   }
 
   static filterOutIgnoredServices(


### PR DESCRIPTION
Previous PRs #832, #827 introduced a new logic: IAM v1 protos are ignored in all generator invocations except those which do not have any other proto packages given. This logic allows generating client library for IAM v1 if it's what the user wants to do, otherwise (if IAM is a dependency) it will be ignored.

For the logic to work properly, IAM must indeed be the only non-common package to be generated.

This PR updates the list of common known packages (those that we will always skip). Checked that it actually makes IAM work by running on a pending IAM change locally.