### PR TITLE
fix: name generation when multiple packages are involved

### DIFF
--- a/baselines/asset/src/v1/asset_service_client_config.json.baseline
+++ b/baselines/asset/src/v1/asset_service_client_config.json.baseline
@@ -21,11 +21,13 @@
       },
       "methods": {
         "ExportAssets": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "BatchGetAssetsHistory": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "CreateFeed": {

--- a/baselines/asset/src/v1/asset_service_proto_list.json.baseline
+++ b/baselines/asset/src/v1/asset_service_proto_list.json.baseline
@@ -1,9 +1,4 @@
 [
   "../../protos/google/cloud/asset/v1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1/assets.proto",
-  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
-  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
-  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
-  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
-  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
+  "../../protos/google/cloud/asset/v1/assets.proto"
 ]

--- a/baselines/pubsub-api-dump/api.json.baseline
+++ b/baselines/pubsub-api-dump/api.json.baseline
@@ -1,5 +1,5 @@
 {
-  "packageName": "google",
+  "packageName": "google.pubsub.v1",
   "publishName": "pubsub",
   "naming": {
     "name": "Pubsub",
@@ -494,7 +494,7 @@
         ".google.api.defaultHost": "pubsub.googleapis.com",
         ".google.api.oauthScopes": "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/pubsub"
       },
-      "packageName": "google",
+      "packageName": "google.pubsub.v1",
       "iamService": false,
       "comments": [
         " The service that an application uses to manipulate topics, and to send",
@@ -4664,7 +4664,7 @@
         ".google.api.defaultHost": "pubsub.googleapis.com",
         ".google.api.oauthScopes": "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/pubsub"
       },
-      "packageName": "google",
+      "packageName": "google.pubsub.v1",
       "iamService": false,
       "comments": [
         " Service for doing schema-related operations."
@@ -9462,7 +9462,7 @@
         ".google.api.defaultHost": "pubsub.googleapis.com",
         ".google.api.oauthScopes": "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/pubsub"
       },
-      "packageName": "google",
+      "packageName": "google.pubsub.v1",
       "iamService": false,
       "comments": [
         " The service that an application uses to manipulate subscriptions and to",

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -190,7 +190,6 @@ export class Generator {
           fd.service.length > 0
       )
     ).forEach(fd => protoPackagesToGenerate.add(fd.package || ''));
-    console.warn(protoPackagesToGenerate);
     const packageNamesToGenerate = Array.from(protoPackagesToGenerate);
     const packageName = commonPrefix(packageNamesToGenerate).replace(/\.$/, '');
     if (packageName === '') {

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -181,15 +181,17 @@ export class Generator {
   }
 
   private buildAPIObject(): API {
-    const protoFilesToGenerate = this.request.protoFile.filter(
-      pf =>
-        pf.name &&
-        this.request.fileToGenerate.includes(pf.name) &&
-        !API.isIgnoredService(pf)
-    );
-    const packageNamesToGenerate = protoFilesToGenerate.map(
-      pf => pf.package || ''
-    );
+    const protoPackagesToGenerate = new Set<string>();
+    API.filterOutIgnoredServices(
+      this.request.protoFile.filter(
+        fd =>
+          this.request.fileToGenerate.includes(fd.name!) &&
+          fd.service &&
+          fd.service.length > 0
+      )
+    ).forEach(fd => protoPackagesToGenerate.add(fd.package || ''));
+    console.warn(protoPackagesToGenerate);
+    const packageNamesToGenerate = Array.from(protoPackagesToGenerate);
     const packageName = commonPrefix(packageNamesToGenerate).replace(/\.$/, '');
     if (packageName === '') {
       throw new Error('Cannot get package name to generate.');


### PR DESCRIPTION
Fixes the problem with incorrect package name in Pub/Sub library (and possibly others), now with the test coverage (hence the API JSON change). After this is released, it should generate a proper config JSON.