### PR TITLE
fix: do not import path

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation} from 'google-gax';
-import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
-import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
-import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-import * as path from 'path';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -19,7 +19,6 @@
 /* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation} from 'google-gax';
-import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -28,7 +28,6 @@ import {Callback, CallOptions, Descriptors, ClientOptions
 {%- if service.paging.length > 0 %}, PaginationCallback, GaxCall{%- endif -%}
 {%- if service.iamService > 0 %}, IamClient, IamProtos{%- endif -%}
 } from 'google-gax';
-import * as path from 'path';
 {% if (service.paging.length > 0) %}
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';


### PR DESCRIPTION
We don't need to import `path` in the generated client anymore.