### PR TITLE
fix: (diregapic)missing error from ads

### DIFF
--- a/baselines/asset/src/v1/asset_service_proto_list.json.baseline
+++ b/baselines/asset/src/v1/asset_service_proto_list.json.baseline
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1/assets.proto"
+  "../../protos/google/cloud/asset/v1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/baselines/logging/src/v2/config_service_v2_proto_list.json.baseline
+++ b/baselines/logging/src/v2/config_service_v2_proto_list.json.baseline
@@ -1,4 +1,6 @@
 [
+  "../../protos/google/logging/type/http_request.proto",
+  "../../protos/google/logging/type/log_severity.proto",
   "../../protos/google/logging/v2/log_entry.proto",
   "../../protos/google/logging/v2/logging.proto",
   "../../protos/google/logging/v2/logging_config.proto",

--- a/baselines/logging/src/v2/logging_service_v2_proto_list.json.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_proto_list.json.baseline
@@ -1,4 +1,6 @@
 [
+  "../../protos/google/logging/type/http_request.proto",
+  "../../protos/google/logging/type/log_severity.proto",
   "../../protos/google/logging/v2/log_entry.proto",
   "../../protos/google/logging/v2/logging.proto",
   "../../protos/google/logging/v2/logging_config.proto",

--- a/baselines/logging/src/v2/metrics_service_v2_proto_list.json.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_proto_list.json.baseline
@@ -1,4 +1,6 @@
 [
+  "../../protos/google/logging/type/http_request.proto",
+  "../../protos/google/logging/type/log_severity.proto",
   "../../protos/google/logging/v2/log_entry.proto",
   "../../protos/google/logging/v2/logging.proto",
   "../../protos/google/logging/v2/logging_config.proto",

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -658,7 +658,13 @@ export class Proto {
         return map;
       }, {} as MessagesMap);
     const protopackage = parameters.fd.package;
-    if (!protopackage || !protopackage.startsWith(parameters.packageName)) {
+    // Allow to generate if a proto has no service and its package name is differ from its service's.
+    if (
+      !protopackage ||
+      (!protopackage.startsWith(parameters.packageName) &&
+        parameters.fd.service &&
+        parameters.fd.service.length > 0)
+    ) {
       this.fileToGenerate = false;
     }
     if (this.fileToGenerate) {

--- a/typescript/test/unit/api.ts
+++ b/typescript/test/unit/api.ts
@@ -123,6 +123,28 @@ describe('src/schema/api.ts', () => {
     ]);
   });
 
+  it('should include the protos has no service and different package name', () => {
+    const fd1 = new protos.google.protobuf.FileDescriptorProto();
+    fd1.name = 'google/cloud/example/v1/test.proto';
+    fd1.package = 'google.cloud.example.v1';
+
+    fd1.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+    fd1.service[0].name = 'Service';
+    fd1.service[0].options = {
+      '.google.api.defaultHost': 'hostname.example.com:443',
+    };
+    const fd2 = new protos.google.protobuf.FileDescriptorProto();
+    fd2.name = 'google/cloud/example/v1/error.proto';
+    fd2.package = 'google.cloud.example.v1.errors';
+    const api = new API([fd1, fd2], 'google.cloud.example.v1', {
+      grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
+    });
+    assert.deepStrictEqual(JSON.parse(api.protoFilesToGenerateJSON), [
+      '../../protos/google/cloud/example/v1/error.proto',
+      '../../protos/google/cloud/example/v1/test.proto',
+    ]);
+  });
+
   it('should return lexicographically first service name as mainServiceName', () => {
     const fd1 = new protos.google.protobuf.FileDescriptorProto();
     fd1.name = 'google/cloud/test/v1/test.proto';

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -177,6 +177,65 @@ describe('src/schema/proto.ts', () => {
         'next_page_token'
       );
     });
+    it("should allow generate a proto has no service and its package name differ from service's", () => {
+      const fd = new protos.google.protobuf.FileDescriptorProto();
+      fd.name = 'google/cloud/showcase/v1beta1/test.proto';
+      fd.package = 'google.cloud.showcase.v1beta1.errors';
+      const allMessages: MessagesMap = {};
+      fd.messageType
+        .filter(message => message.name)
+        .forEach(message => {
+          allMessages['.' + fd.package! + '.' + message.name!] = message;
+        });
+      const options: Options = {
+        grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
+      };
+      const commentsMap = new CommentsMap([fd]);
+      const proto = new Proto({
+        fd,
+        packageName: 'google.cloud.talent.v4beta1',
+        allMessages,
+        allResourceDatabase: new ResourceDatabase(),
+        resourceDatabase: new ResourceDatabase(),
+        options,
+        commentsMap,
+      });
+      assert.deepStrictEqual(proto.fileToGenerate, true);
+    });
+    it("should not allow generate a service proto with package name differ from the param's pakage name", () => {
+      const fd = new protos.google.protobuf.FileDescriptorProto();
+      fd.name = 'google/cloud/showcase/v1beta1/test.proto';
+      fd.package = 'google.cloud.showcase.v1beta1.TestService';
+      fd.service = [new protos.google.protobuf.ServiceDescriptorProto()];
+      fd.service[0].name = 'service';
+      fd.service[0].method = [
+        new protos.google.protobuf.MethodDescriptorProto(),
+      ];
+      fd.service[0].method[0] = new protos.google.protobuf.MethodDescriptorProto();
+      fd.service[0].method[0].name = 'Test';
+      fd.service[0].method[0].outputType =
+        '.google.cloud.showcase.v1beta1.TestOutput';
+      const options: Options = {
+        grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
+      };
+      const allMessages: MessagesMap = {};
+      fd.messageType
+        .filter(message => message.name)
+        .forEach(message => {
+          allMessages['.' + fd.package! + '.' + message.name!] = message;
+        });
+      const commentsMap = new CommentsMap([fd]);
+      const proto = new Proto({
+        fd,
+        packageName: 'google.cloud.showcase.v1beta1.MainService',
+        allMessages,
+        allResourceDatabase: new ResourceDatabase(),
+        resourceDatabase: new ResourceDatabase(),
+        options,
+        commentsMap,
+      });
+      assert.deepStrictEqual(proto.fileToGenerate, false);
+    });
   });
   describe('throw error for misconfigured LRO', () => {
     it('throw error if method returns Operation, but without operation_info option', () => {


### PR DESCRIPTION
fix googleapis/google-cloud-node-core#617 : googleads protos are different than most other apis.
It has multiple packages, like 
```
package google.ads.googleads.v7.services;
package google.ads.googleads.v7.errors;
```
And errors.proto has no service.

Fix: we should allow package'name which has no service differ from service package name.

Local Test: generate googleads
```
$ bazel build //google/ads/googleads/v7:googleads-nodejs
$ cd .../bazel-bin/google/ads/googleads/v7
$ tar -xf googleads-nodejs.tar.gz
$ grep errors.proto googleads-nodejs/src/v7/*json | wc -l
```
>>>
Results: `126`