### PR TITLE
fix: make request optional in all cases

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -302,7 +302,7 @@ export class AssetServiceClient {
   // -- Service calls --
   // -------------------
   batchGetAssetsHistory(
-      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
+      request?: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
@@ -367,7 +367,7 @@ export class AssetServiceClient {
  * const [response] = await client.batchGetAssetsHistory(request);
  */
   batchGetAssetsHistory(
-      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
+      request?: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
@@ -401,7 +401,7 @@ export class AssetServiceClient {
     return this.innerApiCalls.batchGetAssetsHistory(request, options, callback);
   }
   createFeed(
-      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
+      request?: protos.google.cloud.asset.v1.ICreateFeedRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
@@ -452,7 +452,7 @@ export class AssetServiceClient {
  * const [response] = await client.createFeed(request);
  */
   createFeed(
-      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
+      request?: protos.google.cloud.asset.v1.ICreateFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
@@ -486,7 +486,7 @@ export class AssetServiceClient {
     return this.innerApiCalls.createFeed(request, options, callback);
   }
   getFeed(
-      request: protos.google.cloud.asset.v1.IGetFeedRequest,
+      request?: protos.google.cloud.asset.v1.IGetFeedRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
@@ -526,7 +526,7 @@ export class AssetServiceClient {
  * const [response] = await client.getFeed(request);
  */
   getFeed(
-      request: protos.google.cloud.asset.v1.IGetFeedRequest,
+      request?: protos.google.cloud.asset.v1.IGetFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
@@ -560,7 +560,7 @@ export class AssetServiceClient {
     return this.innerApiCalls.getFeed(request, options, callback);
   }
   listFeeds(
-      request: protos.google.cloud.asset.v1.IListFeedsRequest,
+      request?: protos.google.cloud.asset.v1.IListFeedsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IListFeedsResponse,
@@ -599,7 +599,7 @@ export class AssetServiceClient {
  * const [response] = await client.listFeeds(request);
  */
   listFeeds(
-      request: protos.google.cloud.asset.v1.IListFeedsRequest,
+      request?: protos.google.cloud.asset.v1.IListFeedsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IListFeedsResponse,
           protos.google.cloud.asset.v1.IListFeedsRequest|null|undefined,
@@ -633,7 +633,7 @@ export class AssetServiceClient {
     return this.innerApiCalls.listFeeds(request, options, callback);
   }
   updateFeed(
-      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
+      request?: protos.google.cloud.asset.v1.IUpdateFeedRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.asset.v1.IFeed,
@@ -678,7 +678,7 @@ export class AssetServiceClient {
  * const [response] = await client.updateFeed(request);
  */
   updateFeed(
-      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
+      request?: protos.google.cloud.asset.v1.IUpdateFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IFeed,
           protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
@@ -712,7 +712,7 @@ export class AssetServiceClient {
     return this.innerApiCalls.updateFeed(request, options, callback);
   }
   deleteFeed(
-      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
+      request?: protos.google.cloud.asset.v1.IDeleteFeedRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -752,7 +752,7 @@ export class AssetServiceClient {
  * const [response] = await client.deleteFeed(request);
  */
   deleteFeed(
-      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
+      request?: protos.google.cloud.asset.v1.IDeleteFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
@@ -787,7 +787,7 @@ export class AssetServiceClient {
   }
 
   exportAssets(
-      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
+      request?: protos.google.cloud.asset.v1.IExportAssetsRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
@@ -851,7 +851,7 @@ export class AssetServiceClient {
  * const [response] = await operation.promise();
  */
   exportAssets(
-      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
+      request?: protos.google.cloud.asset.v1.IExportAssetsRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
           protos.google.longrunning.IOperation|null|undefined,

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -286,7 +286,7 @@ export class BigQueryStorageClient {
   // -- Service calls --
   // -------------------
   createReadSession(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
@@ -355,7 +355,7 @@ export class BigQueryStorageClient {
  * const [response] = await client.createReadSession(request);
  */
   createReadSession(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
           protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
@@ -390,7 +390,7 @@ export class BigQueryStorageClient {
     return this.innerApiCalls.createReadSession(request, options, callback);
   }
   batchCreateReadSessionStreams(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
@@ -434,7 +434,7 @@ export class BigQueryStorageClient {
  * const [response] = await client.batchCreateReadSessionStreams(request);
  */
   batchCreateReadSessionStreams(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
           protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
@@ -468,7 +468,7 @@ export class BigQueryStorageClient {
     return this.innerApiCalls.batchCreateReadSessionStreams(request, options, callback);
   }
   finalizeStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -518,7 +518,7 @@ export class BigQueryStorageClient {
  * const [response] = await client.finalizeStream(request);
  */
   finalizeStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
@@ -552,7 +552,7 @@ export class BigQueryStorageClient {
     return this.innerApiCalls.finalizeStream(request, options, callback);
   }
   splitReadStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
@@ -609,7 +609,7 @@ export class BigQueryStorageClient {
  * const [response] = await client.splitReadStream(request);
  */
   splitReadStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
           protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -342,7 +342,7 @@ export class EchoClient {
   // -- Service calls --
   // -------------------
   echo(
-      request: protos.google.showcase.v1beta1.IEchoRequest,
+      request?: protos.google.showcase.v1beta1.IEchoRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse,
@@ -379,7 +379,7 @@ export class EchoClient {
  * const [response] = await client.echo(request);
  */
   echo(
-      request: protos.google.showcase.v1beta1.IEchoRequest,
+      request?: protos.google.showcase.v1beta1.IEchoRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -406,7 +406,7 @@ export class EchoClient {
     return this.innerApiCalls.echo(request, options, callback);
   }
   block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlockResponse,
@@ -450,7 +450,7 @@ export class EchoClient {
  * const [response] = await client.block(request);
  */
   block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
@@ -587,7 +587,7 @@ export class EchoClient {
   }
 
   wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
@@ -635,7 +635,7 @@ export class EchoClient {
  * const [response] = await operation.promise();
  */
   wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -683,7 +683,7 @@ export class EchoClient {
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
   pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse[],
@@ -729,7 +729,7 @@ export class EchoClient {
  *   for more details and examples.
  */
   pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -305,7 +305,7 @@ export class IdentityClient {
   // -- Service calls --
   // -------------------
   createUser(
-      request: protos.google.showcase.v1beta1.ICreateUserRequest,
+      request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -342,7 +342,7 @@ export class IdentityClient {
  * const [response] = await client.createUser(request);
  */
   createUser(
-      request: protos.google.showcase.v1beta1.ICreateUserRequest,
+      request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
@@ -369,7 +369,7 @@ export class IdentityClient {
     return this.innerApiCalls.createUser(request, options, callback);
   }
   getUser(
-      request: protos.google.showcase.v1beta1.IGetUserRequest,
+      request?: protos.google.showcase.v1beta1.IGetUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -406,7 +406,7 @@ export class IdentityClient {
  * const [response] = await client.getUser(request);
  */
   getUser(
-      request: protos.google.showcase.v1beta1.IGetUserRequest,
+      request?: protos.google.showcase.v1beta1.IGetUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
@@ -440,7 +440,7 @@ export class IdentityClient {
     return this.innerApiCalls.getUser(request, options, callback);
   }
   updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -480,7 +480,7 @@ export class IdentityClient {
  * const [response] = await client.updateUser(request);
  */
   updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
@@ -514,7 +514,7 @@ export class IdentityClient {
     return this.innerApiCalls.updateUser(request, options, callback);
   }
   deleteUser(
-      request: protos.google.showcase.v1beta1.IDeleteUserRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -551,7 +551,7 @@ export class IdentityClient {
  * const [response] = await client.deleteUser(request);
  */
   deleteUser(
-      request: protos.google.showcase.v1beta1.IDeleteUserRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
@@ -586,7 +586,7 @@ export class IdentityClient {
   }
 
   listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser[],
@@ -632,7 +632,7 @@ export class IdentityClient {
  *   for more details and examples.
  */
   listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -343,7 +343,7 @@ export class MessagingClient {
   // -- Service calls --
   // -------------------
   createRoom(
-      request: protos.google.showcase.v1beta1.ICreateRoomRequest,
+      request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -380,7 +380,7 @@ export class MessagingClient {
  * const [response] = await client.createRoom(request);
  */
   createRoom(
-      request: protos.google.showcase.v1beta1.ICreateRoomRequest,
+      request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
@@ -407,7 +407,7 @@ export class MessagingClient {
     return this.innerApiCalls.createRoom(request, options, callback);
   }
   getRoom(
-      request: protos.google.showcase.v1beta1.IGetRoomRequest,
+      request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -444,7 +444,7 @@ export class MessagingClient {
  * const [response] = await client.getRoom(request);
  */
   getRoom(
-      request: protos.google.showcase.v1beta1.IGetRoomRequest,
+      request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
@@ -478,7 +478,7 @@ export class MessagingClient {
     return this.innerApiCalls.getRoom(request, options, callback);
   }
   updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -518,7 +518,7 @@ export class MessagingClient {
  * const [response] = await client.updateRoom(request);
  */
   updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
@@ -552,7 +552,7 @@ export class MessagingClient {
     return this.innerApiCalls.updateRoom(request, options, callback);
   }
   deleteRoom(
-      request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -589,7 +589,7 @@ export class MessagingClient {
  * const [response] = await client.deleteRoom(request);
  */
   deleteRoom(
-      request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
@@ -623,7 +623,7 @@ export class MessagingClient {
     return this.innerApiCalls.deleteRoom(request, options, callback);
   }
   createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -665,7 +665,7 @@ export class MessagingClient {
  * const [response] = await client.createBlurb(request);
  */
   createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -699,7 +699,7 @@ export class MessagingClient {
     return this.innerApiCalls.createBlurb(request, options, callback);
   }
   getBlurb(
-      request: protos.google.showcase.v1beta1.IGetBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -736,7 +736,7 @@ export class MessagingClient {
  * const [response] = await client.getBlurb(request);
  */
   getBlurb(
-      request: protos.google.showcase.v1beta1.IGetBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
@@ -770,7 +770,7 @@ export class MessagingClient {
     return this.innerApiCalls.getBlurb(request, options, callback);
   }
   updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -810,7 +810,7 @@ export class MessagingClient {
  * const [response] = await client.updateBlurb(request);
  */
   updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
@@ -844,7 +844,7 @@ export class MessagingClient {
     return this.innerApiCalls.updateBlurb(request, options, callback);
   }
   deleteBlurb(
-      request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -881,7 +881,7 @@ export class MessagingClient {
  * const [response] = await client.deleteBlurb(request);
  */
   deleteBlurb(
-      request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
@@ -1032,7 +1032,7 @@ export class MessagingClient {
   }
 
   searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
@@ -1087,7 +1087,7 @@ export class MessagingClient {
  * const [response] = await operation.promise();
  */
   searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1142,7 +1142,7 @@ export class MessagingClient {
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
   listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom[],
@@ -1188,7 +1188,7 @@ export class MessagingClient {
  *   for more details and examples.
  */
   listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
@@ -1299,7 +1299,7 @@ export class MessagingClient {
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
   listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb[],
@@ -1349,7 +1349,7 @@ export class MessagingClient {
  *   for more details and examples.
  */
   listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -308,7 +308,7 @@ export class TestingClient {
   // -- Service calls --
   // -------------------
   createSession(
-      request: protos.google.showcase.v1beta1.ICreateSessionRequest,
+      request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
@@ -347,7 +347,7 @@ export class TestingClient {
  * const [response] = await client.createSession(request);
  */
   createSession(
-      request: protos.google.showcase.v1beta1.ICreateSessionRequest,
+      request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
@@ -374,7 +374,7 @@ export class TestingClient {
     return this.innerApiCalls.createSession(request, options, callback);
   }
   getSession(
-      request: protos.google.showcase.v1beta1.IGetSessionRequest,
+      request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
@@ -411,7 +411,7 @@ export class TestingClient {
  * const [response] = await client.getSession(request);
  */
   getSession(
-      request: protos.google.showcase.v1beta1.IGetSessionRequest,
+      request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
@@ -445,7 +445,7 @@ export class TestingClient {
     return this.innerApiCalls.getSession(request, options, callback);
   }
   deleteSession(
-      request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -482,7 +482,7 @@ export class TestingClient {
  * const [response] = await client.deleteSession(request);
  */
   deleteSession(
-      request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
@@ -516,7 +516,7 @@ export class TestingClient {
     return this.innerApiCalls.deleteSession(request, options, callback);
   }
   reportSession(
-      request: protos.google.showcase.v1beta1.IReportSessionRequest,
+      request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IReportSessionResponse,
@@ -555,7 +555,7 @@ export class TestingClient {
  * const [response] = await client.reportSession(request);
  */
   reportSession(
-      request: protos.google.showcase.v1beta1.IReportSessionRequest,
+      request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
@@ -589,7 +589,7 @@ export class TestingClient {
     return this.innerApiCalls.reportSession(request, options, callback);
   }
   deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -631,7 +631,7 @@ export class TestingClient {
  * const [response] = await client.deleteTest(request);
  */
   deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
@@ -665,7 +665,7 @@ export class TestingClient {
     return this.innerApiCalls.deleteTest(request, options, callback);
   }
   verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IVerifyTestResponse,
@@ -709,7 +709,7 @@ export class TestingClient {
  * const [response] = await client.verifyTest(request);
  */
   verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
@@ -744,7 +744,7 @@ export class TestingClient {
   }
 
   listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession[],
@@ -787,7 +787,7 @@ export class TestingClient {
  *   for more details and examples.
  */
   listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
@@ -892,7 +892,7 @@ export class TestingClient {
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
   listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ITest[],
@@ -937,7 +937,7 @@ export class TestingClient {
  *   for more details and examples.
  */
   listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -326,7 +326,7 @@ export class DlpServiceClient {
   // -- Service calls --
   // -------------------
   inspectContent(
-      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
+      request?: protos.google.privacy.dlp.v2.IInspectContentRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectContentResponse,
@@ -385,7 +385,7 @@ export class DlpServiceClient {
  * const [response] = await client.inspectContent(request);
  */
   inspectContent(
-      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
+      request?: protos.google.privacy.dlp.v2.IInspectContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectContentResponse,
           protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
@@ -419,7 +419,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.inspectContent(request, options, callback);
   }
   redactImage(
-      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
+      request?: protos.google.privacy.dlp.v2.IRedactImageRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IRedactImageResponse,
@@ -475,7 +475,7 @@ export class DlpServiceClient {
  * const [response] = await client.redactImage(request);
  */
   redactImage(
-      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
+      request?: protos.google.privacy.dlp.v2.IRedactImageRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IRedactImageResponse,
           protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
@@ -509,7 +509,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.redactImage(request, options, callback);
   }
   deidentifyContent(
-      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
+      request?: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
@@ -578,7 +578,7 @@ export class DlpServiceClient {
  * const [response] = await client.deidentifyContent(request);
  */
   deidentifyContent(
-      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
+      request?: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
           protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
@@ -612,7 +612,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deidentifyContent(request, options, callback);
   }
   reidentifyContent(
-      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
+      request?: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IReidentifyContentResponse,
@@ -683,7 +683,7 @@ export class DlpServiceClient {
  * const [response] = await client.reidentifyContent(request);
  */
   reidentifyContent(
-      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
+      request?: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IReidentifyContentResponse,
           protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
@@ -717,7 +717,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.reidentifyContent(request, options, callback);
   }
   listInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
+      request?: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IListInfoTypesResponse,
@@ -764,7 +764,7 @@ export class DlpServiceClient {
  * const [response] = await client.listInfoTypes(request);
  */
   listInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
+      request?: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IListInfoTypesResponse,
           protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
@@ -798,7 +798,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.listInfoTypes(request, options, callback);
   }
   createInspectTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
@@ -848,7 +848,7 @@ export class DlpServiceClient {
  * const [response] = await client.createInspectTemplate(request);
  */
   createInspectTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
@@ -882,7 +882,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.createInspectTemplate(request, options, callback);
   }
   updateInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
@@ -926,7 +926,7 @@ export class DlpServiceClient {
  * const [response] = await client.updateInspectTemplate(request);
  */
   updateInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
@@ -960,7 +960,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.updateInspectTemplate(request, options, callback);
   }
   getInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate,
@@ -1000,7 +1000,7 @@ export class DlpServiceClient {
  * const [response] = await client.getInspectTemplate(request);
  */
   getInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectTemplate,
           protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
@@ -1034,7 +1034,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.getInspectTemplate(request, options, callback);
   }
   deleteInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -1074,7 +1074,7 @@ export class DlpServiceClient {
  * const [response] = await client.deleteInspectTemplate(request);
  */
   deleteInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
@@ -1108,7 +1108,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deleteInspectTemplate(request, options, callback);
   }
   createDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
@@ -1159,7 +1159,7 @@ export class DlpServiceClient {
  * const [response] = await client.createDeidentifyTemplate(request);
  */
   createDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
@@ -1193,7 +1193,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.createDeidentifyTemplate(request, options, callback);
   }
   updateDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
@@ -1238,7 +1238,7 @@ export class DlpServiceClient {
  * const [response] = await client.updateDeidentifyTemplate(request);
  */
   updateDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
@@ -1272,7 +1272,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.updateDeidentifyTemplate(request, options, callback);
   }
   getDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate,
@@ -1313,7 +1313,7 @@ export class DlpServiceClient {
  * const [response] = await client.getDeidentifyTemplate(request);
  */
   getDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyTemplate,
           protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
@@ -1347,7 +1347,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.getDeidentifyTemplate(request, options, callback);
   }
   deleteDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -1388,7 +1388,7 @@ export class DlpServiceClient {
  * const [response] = await client.deleteDeidentifyTemplate(request);
  */
   deleteDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
@@ -1422,7 +1422,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deleteDeidentifyTemplate(request, options, callback);
   }
   createJobTrigger(
-      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
@@ -1471,7 +1471,7 @@ export class DlpServiceClient {
  * const [response] = await client.createJobTrigger(request);
  */
   createJobTrigger(
-      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
@@ -1505,7 +1505,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.createJobTrigger(request, options, callback);
   }
   updateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
@@ -1548,7 +1548,7 @@ export class DlpServiceClient {
  * const [response] = await client.updateJobTrigger(request);
  */
   updateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
@@ -1582,7 +1582,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.updateJobTrigger(request, options, callback);
   }
   getJobTrigger(
-      request: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger,
@@ -1621,7 +1621,7 @@ export class DlpServiceClient {
  * const [response] = await client.getJobTrigger(request);
  */
   getJobTrigger(
-      request: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IGetJobTriggerRequest|null|undefined,
@@ -1655,7 +1655,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.getJobTrigger(request, options, callback);
   }
   deleteJobTrigger(
-      request: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -1694,7 +1694,7 @@ export class DlpServiceClient {
  * const [response] = await client.deleteJobTrigger(request);
  */
   deleteJobTrigger(
-      request: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|null|undefined,
@@ -1728,7 +1728,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deleteJobTrigger(request, options, callback);
   }
   activateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
@@ -1767,7 +1767,7 @@ export class DlpServiceClient {
  * const [response] = await client.activateJobTrigger(request);
  */
   activateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
+      request?: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|null|undefined,
@@ -1801,7 +1801,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.activateJobTrigger(request, options, callback);
   }
   createDlpJob(
-      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
@@ -1856,7 +1856,7 @@ export class DlpServiceClient {
  * const [response] = await client.createDlpJob(request);
  */
   createDlpJob(
-      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
@@ -1890,7 +1890,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.createDlpJob(request, options, callback);
   }
   getDlpJob(
-      request: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob,
@@ -1929,7 +1929,7 @@ export class DlpServiceClient {
  * const [response] = await client.getDlpJob(request);
  */
   getDlpJob(
-      request: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IGetDlpJobRequest|null|undefined,
@@ -1963,7 +1963,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.getDlpJob(request, options, callback);
   }
   deleteDlpJob(
-      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -2004,7 +2004,7 @@ export class DlpServiceClient {
  * const [response] = await client.deleteDlpJob(request);
  */
   deleteDlpJob(
-      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
@@ -2038,7 +2038,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deleteDlpJob(request, options, callback);
   }
   cancelDlpJob(
-      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -2079,7 +2079,7 @@ export class DlpServiceClient {
  * const [response] = await client.cancelDlpJob(request);
  */
   cancelDlpJob(
-      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
+      request?: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
@@ -2113,7 +2113,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.cancelDlpJob(request, options, callback);
   }
   createStoredInfoType(
-      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
@@ -2163,7 +2163,7 @@ export class DlpServiceClient {
  * const [response] = await client.createStoredInfoType(request);
  */
   createStoredInfoType(
-      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
@@ -2197,7 +2197,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.createStoredInfoType(request, options, callback);
   }
   updateStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
@@ -2245,7 +2245,7 @@ export class DlpServiceClient {
  * const [response] = await client.updateStoredInfoType(request);
  */
   updateStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
@@ -2279,7 +2279,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.updateStoredInfoType(request, options, callback);
   }
   getStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType,
@@ -2320,7 +2320,7 @@ export class DlpServiceClient {
  * const [response] = await client.getStoredInfoType(request);
  */
   getStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IStoredInfoType,
           protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
@@ -2354,7 +2354,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.getStoredInfoType(request, options, callback);
   }
   deleteStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -2395,7 +2395,7 @@ export class DlpServiceClient {
  * const [response] = await client.deleteStoredInfoType(request);
  */
   deleteStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
+      request?: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
@@ -2430,7 +2430,7 @@ export class DlpServiceClient {
   }
 
   listInspectTemplates(
-      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+      request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IInspectTemplate[],
@@ -2496,7 +2496,7 @@ export class DlpServiceClient {
  *   for more details and examples.
  */
   listInspectTemplates(
-      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+      request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
           protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
@@ -2666,7 +2666,7 @@ export class DlpServiceClient {
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IInspectTemplate>;
   }
   listDeidentifyTemplates(
-      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+      request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDeidentifyTemplate[],
@@ -2733,7 +2733,7 @@ export class DlpServiceClient {
  *   for more details and examples.
  */
   listDeidentifyTemplates(
-      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+      request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
           protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
@@ -2903,7 +2903,7 @@ export class DlpServiceClient {
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDeidentifyTemplate>;
   }
   listJobTriggers(
-      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+      request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IJobTrigger[],
@@ -2995,7 +2995,7 @@ export class DlpServiceClient {
  *   for more details and examples.
  */
   listJobTriggers(
-      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+      request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListJobTriggersRequest,
           protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
@@ -3217,7 +3217,7 @@ export class DlpServiceClient {
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IJobTrigger>;
   }
   listDlpJobs(
-      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+      request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IDlpJob[],
@@ -3312,7 +3312,7 @@ export class DlpServiceClient {
  *   for more details and examples.
  */
   listDlpJobs(
-      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+      request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListDlpJobsRequest,
           protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
@@ -3538,7 +3538,7 @@ export class DlpServiceClient {
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDlpJob>;
   }
   listStoredInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+      request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.privacy.dlp.v2.IStoredInfoType[],
@@ -3606,7 +3606,7 @@ export class DlpServiceClient {
  *   for more details and examples.
  */
   listStoredInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+      request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
           protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -293,7 +293,7 @@ export class KeyManagementServiceClient {
   // -- Service calls --
   // -------------------
   getKeyRing(
-      request: protos.google.cloud.kms.v1.IGetKeyRingRequest,
+      request?: protos.google.cloud.kms.v1.IGetKeyRingRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing,
@@ -330,7 +330,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.getKeyRing(request);
  */
   getKeyRing(
-      request: protos.google.cloud.kms.v1.IGetKeyRingRequest,
+      request?: protos.google.cloud.kms.v1.IGetKeyRingRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.IGetKeyRingRequest|null|undefined,
@@ -364,7 +364,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getKeyRing(request, options, callback);
   }
   getCryptoKey(
-      request: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
@@ -402,7 +402,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.getCryptoKey(request);
  */
   getCryptoKey(
-      request: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IGetCryptoKeyRequest|null|undefined,
@@ -436,7 +436,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getCryptoKey(request, options, callback);
   }
   getCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -473,7 +473,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.getCryptoKeyVersion(request);
  */
   getCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|null|undefined,
@@ -507,7 +507,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getCryptoKeyVersion(request, options, callback);
   }
   getPublicKey(
-      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
+      request?: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IPublicKey,
@@ -548,7 +548,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.getPublicKey(request);
  */
   getPublicKey(
-      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
+      request?: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IPublicKey,
           protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
@@ -582,7 +582,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getPublicKey(request, options, callback);
   }
   getImportJob(
-      request: protos.google.cloud.kms.v1.IGetImportJobRequest,
+      request?: protos.google.cloud.kms.v1.IGetImportJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob,
@@ -619,7 +619,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.getImportJob(request);
  */
   getImportJob(
-      request: protos.google.cloud.kms.v1.IGetImportJobRequest,
+      request?: protos.google.cloud.kms.v1.IGetImportJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.IGetImportJobRequest|null|undefined,
@@ -653,7 +653,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getImportJob(request, options, callback);
   }
   createKeyRing(
-      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
+      request?: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing,
@@ -696,7 +696,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.createKeyRing(request);
  */
   createKeyRing(
-      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
+      request?: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
@@ -730,7 +730,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createKeyRing(request, options, callback);
   }
   createCryptoKey(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
@@ -783,7 +783,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.createCryptoKey(request);
  */
   createCryptoKey(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
@@ -817,7 +817,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createCryptoKey(request, options, callback);
   }
   createCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -861,7 +861,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.createCryptoKeyVersion(request);
  */
   createCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
@@ -895,7 +895,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createCryptoKeyVersion(request, options, callback);
   }
   importCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -964,7 +964,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.importCryptoKeyVersion(request);
  */
   importCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
@@ -998,7 +998,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.importCryptoKeyVersion(request, options, callback);
   }
   createImportJob(
-      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
+      request?: protos.google.cloud.kms.v1.ICreateImportJobRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob,
@@ -1043,7 +1043,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.createImportJob(request);
  */
   createImportJob(
-      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
+      request?: protos.google.cloud.kms.v1.ICreateImportJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
@@ -1077,7 +1077,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createImportJob(request, options, callback);
   }
   updateCryptoKey(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
@@ -1116,7 +1116,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.updateCryptoKey(request);
  */
   updateCryptoKey(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|null|undefined,
@@ -1150,7 +1150,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKey(request, options, callback);
   }
   updateCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -1195,7 +1195,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.updateCryptoKeyVersion(request);
  */
   updateCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
@@ -1229,7 +1229,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }
   encrypt(
-      request: protos.google.cloud.kms.v1.IEncryptRequest,
+      request?: protos.google.cloud.kms.v1.IEncryptRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IEncryptResponse,
@@ -1291,7 +1291,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.encrypt(request);
  */
   encrypt(
-      request: protos.google.cloud.kms.v1.IEncryptRequest,
+      request?: protos.google.cloud.kms.v1.IEncryptRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IEncryptResponse,
           protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
@@ -1325,7 +1325,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.encrypt(request, options, callback);
   }
   decrypt(
-      request: protos.google.cloud.kms.v1.IDecryptRequest,
+      request?: protos.google.cloud.kms.v1.IDecryptRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IDecryptResponse,
@@ -1370,7 +1370,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.decrypt(request);
  */
   decrypt(
-      request: protos.google.cloud.kms.v1.IDecryptRequest,
+      request?: protos.google.cloud.kms.v1.IDecryptRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IDecryptResponse,
           protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
@@ -1404,7 +1404,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.decrypt(request, options, callback);
   }
   asymmetricSign(
-      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
+      request?: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IAsymmetricSignResponse,
@@ -1447,7 +1447,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.asymmetricSign(request);
  */
   asymmetricSign(
-      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
+      request?: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IAsymmetricSignResponse,
           protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
@@ -1481,7 +1481,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.asymmetricSign(request, options, callback);
   }
   asymmetricDecrypt(
-      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
+      request?: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
@@ -1524,7 +1524,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.asymmetricDecrypt(request);
  */
   asymmetricDecrypt(
-      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
+      request?: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
           protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
@@ -1558,7 +1558,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.asymmetricDecrypt(request, options, callback);
   }
   updateCryptoKeyPrimaryVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey,
@@ -1599,7 +1599,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.updateCryptoKeyPrimaryVersion(request);
  */
   updateCryptoKeyPrimaryVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
@@ -1633,7 +1633,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKeyPrimaryVersion(request, options, callback);
   }
   destroyCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -1681,7 +1681,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.destroyCryptoKeyVersion(request);
  */
   destroyCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
@@ -1715,7 +1715,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.destroyCryptoKeyVersion(request, options, callback);
   }
   restoreCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion,
@@ -1758,7 +1758,7 @@ export class KeyManagementServiceClient {
  * const [response] = await client.restoreCryptoKeyVersion(request);
  */
   restoreCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
+      request?: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
@@ -1793,7 +1793,7 @@ export class KeyManagementServiceClient {
   }
 
   listKeyRings(
-      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
+      request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IKeyRing[],
@@ -1848,7 +1848,7 @@ export class KeyManagementServiceClient {
  *   for more details and examples.
  */
   listKeyRings(
-      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
+      request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListKeyRingsRequest,
           protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
@@ -1998,7 +1998,7 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>;
   }
   listCryptoKeys(
-      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+      request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKey[],
@@ -2055,7 +2055,7 @@ export class KeyManagementServiceClient {
  *   for more details and examples.
  */
   listCryptoKeys(
-      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+      request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeysRequest,
           protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
@@ -2209,7 +2209,7 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>;
   }
   listCryptoKeyVersions(
-      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+      request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.ICryptoKeyVersion[],
@@ -2267,7 +2267,7 @@ export class KeyManagementServiceClient {
  *   for more details and examples.
  */
   listCryptoKeyVersions(
-      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+      request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
           protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
@@ -2423,7 +2423,7 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>;
   }
   listImportJobs(
-      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
+      request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.kms.v1.IImportJob[],
@@ -2478,7 +2478,7 @@ export class KeyManagementServiceClient {
  *   for more details and examples.
  */
   listImportJobs(
-      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
+      request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.kms.v1.IListImportJobsRequest,
           protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -356,7 +356,7 @@ export class ConfigServiceV2Client {
   // -- Service calls --
   // -------------------
   getBucket(
-      request: protos.google.logging.v2.IGetBucketRequest,
+      request?: protos.google.logging.v2.IGetBucketRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket,
@@ -401,7 +401,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.getBucket(request);
  */
   getBucket(
-      request: protos.google.logging.v2.IGetBucketRequest,
+      request?: protos.google.logging.v2.IGetBucketRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IGetBucketRequest|null|undefined,
@@ -435,7 +435,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getBucket(request, options, callback);
   }
   updateBucket(
-      request: protos.google.logging.v2.IUpdateBucketRequest,
+      request?: protos.google.logging.v2.IUpdateBucketRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket,
@@ -503,7 +503,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.updateBucket(request);
  */
   updateBucket(
-      request: protos.google.logging.v2.IUpdateBucketRequest,
+      request?: protos.google.logging.v2.IUpdateBucketRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
@@ -537,7 +537,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateBucket(request, options, callback);
   }
   getSink(
-      request: protos.google.logging.v2.IGetSinkRequest,
+      request?: protos.google.logging.v2.IGetSinkRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
@@ -581,7 +581,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.getSink(request);
  */
   getSink(
-      request: protos.google.logging.v2.IGetSinkRequest,
+      request?: protos.google.logging.v2.IGetSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IGetSinkRequest|null|undefined,
@@ -615,7 +615,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getSink(request, options, callback);
   }
   createSink(
-      request: protos.google.logging.v2.ICreateSinkRequest,
+      request?: protos.google.logging.v2.ICreateSinkRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
@@ -677,7 +677,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.createSink(request);
  */
   createSink(
-      request: protos.google.logging.v2.ICreateSinkRequest,
+      request?: protos.google.logging.v2.ICreateSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.ICreateSinkRequest|null|undefined,
@@ -711,7 +711,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.createSink(request, options, callback);
   }
   updateSink(
-      request: protos.google.logging.v2.IUpdateSinkRequest,
+      request?: protos.google.logging.v2.IUpdateSinkRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink,
@@ -790,7 +790,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.updateSink(request);
  */
   updateSink(
-      request: protos.google.logging.v2.IUpdateSinkRequest,
+      request?: protos.google.logging.v2.IUpdateSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
@@ -824,7 +824,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateSink(request, options, callback);
   }
   deleteSink(
-      request: protos.google.logging.v2.IDeleteSinkRequest,
+      request?: protos.google.logging.v2.IDeleteSinkRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -870,7 +870,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.deleteSink(request);
  */
   deleteSink(
-      request: protos.google.logging.v2.IDeleteSinkRequest,
+      request?: protos.google.logging.v2.IDeleteSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
@@ -904,7 +904,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.deleteSink(request, options, callback);
   }
   getExclusion(
-      request: protos.google.logging.v2.IGetExclusionRequest,
+      request?: protos.google.logging.v2.IGetExclusionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
@@ -948,7 +948,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.getExclusion(request);
  */
   getExclusion(
-      request: protos.google.logging.v2.IGetExclusionRequest,
+      request?: protos.google.logging.v2.IGetExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IGetExclusionRequest|null|undefined,
@@ -982,7 +982,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getExclusion(request, options, callback);
   }
   createExclusion(
-      request: protos.google.logging.v2.ICreateExclusionRequest,
+      request?: protos.google.logging.v2.ICreateExclusionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
@@ -1031,7 +1031,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.createExclusion(request);
  */
   createExclusion(
-      request: protos.google.logging.v2.ICreateExclusionRequest,
+      request?: protos.google.logging.v2.ICreateExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
@@ -1065,7 +1065,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.createExclusion(request, options, callback);
   }
   updateExclusion(
-      request: protos.google.logging.v2.IUpdateExclusionRequest,
+      request?: protos.google.logging.v2.IUpdateExclusionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion,
@@ -1120,7 +1120,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.updateExclusion(request);
  */
   updateExclusion(
-      request: protos.google.logging.v2.IUpdateExclusionRequest,
+      request?: protos.google.logging.v2.IUpdateExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
@@ -1154,7 +1154,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateExclusion(request, options, callback);
   }
   deleteExclusion(
-      request: protos.google.logging.v2.IDeleteExclusionRequest,
+      request?: protos.google.logging.v2.IDeleteExclusionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -1198,7 +1198,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.deleteExclusion(request);
  */
   deleteExclusion(
-      request: protos.google.logging.v2.IDeleteExclusionRequest,
+      request?: protos.google.logging.v2.IDeleteExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
@@ -1232,7 +1232,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.deleteExclusion(request, options, callback);
   }
   getCmekSettings(
-      request: protos.google.logging.v2.IGetCmekSettingsRequest,
+      request?: protos.google.logging.v2.IGetCmekSettingsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ICmekSettings,
@@ -1287,7 +1287,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.getCmekSettings(request);
  */
   getCmekSettings(
-      request: protos.google.logging.v2.IGetCmekSettingsRequest,
+      request?: protos.google.logging.v2.IGetCmekSettingsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
@@ -1321,7 +1321,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getCmekSettings(request, options, callback);
   }
   updateCmekSettings(
-      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
+      request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ICmekSettings,
@@ -1395,7 +1395,7 @@ export class ConfigServiceV2Client {
  * const [response] = await client.updateCmekSettings(request);
  */
   updateCmekSettings(
-      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
+      request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
@@ -1430,7 +1430,7 @@ export class ConfigServiceV2Client {
   }
 
   listBuckets(
-      request: protos.google.logging.v2.IListBucketsRequest,
+      request?: protos.google.logging.v2.IListBucketsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogBucket[],
@@ -1489,7 +1489,7 @@ export class ConfigServiceV2Client {
  *   for more details and examples.
  */
   listBuckets(
-      request: protos.google.logging.v2.IListBucketsRequest,
+      request?: protos.google.logging.v2.IListBucketsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListBucketsRequest,
           protos.google.logging.v2.IListBucketsResponse|null|undefined,
@@ -1647,7 +1647,7 @@ export class ConfigServiceV2Client {
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
   }
   listSinks(
-      request: protos.google.logging.v2.IListSinksRequest,
+      request?: protos.google.logging.v2.IListSinksRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogSink[],
@@ -1702,7 +1702,7 @@ export class ConfigServiceV2Client {
  *   for more details and examples.
  */
   listSinks(
-      request: protos.google.logging.v2.IListSinksRequest,
+      request?: protos.google.logging.v2.IListSinksRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListSinksRequest,
           protos.google.logging.v2.IListSinksResponse|null|undefined,
@@ -1852,7 +1852,7 @@ export class ConfigServiceV2Client {
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
   listExclusions(
-      request: protos.google.logging.v2.IListExclusionsRequest,
+      request?: protos.google.logging.v2.IListExclusionsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogExclusion[],
@@ -1907,7 +1907,7 @@ export class ConfigServiceV2Client {
  *   for more details and examples.
  */
   listExclusions(
-      request: protos.google.logging.v2.IListExclusionsRequest,
+      request?: protos.google.logging.v2.IListExclusionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListExclusionsRequest,
           protos.google.logging.v2.IListExclusionsResponse|null|undefined,

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -372,7 +372,7 @@ export class LoggingServiceV2Client {
   // -- Service calls --
   // -------------------
   deleteLog(
-      request: protos.google.logging.v2.IDeleteLogRequest,
+      request?: protos.google.logging.v2.IDeleteLogRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -423,7 +423,7 @@ export class LoggingServiceV2Client {
  * const [response] = await client.deleteLog(request);
  */
   deleteLog(
-      request: protos.google.logging.v2.IDeleteLogRequest,
+      request?: protos.google.logging.v2.IDeleteLogRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogRequest|null|undefined,
@@ -457,7 +457,7 @@ export class LoggingServiceV2Client {
     return this.innerApiCalls.deleteLog(request, options, callback);
   }
   writeLogEntries(
-      request: protos.google.logging.v2.IWriteLogEntriesRequest,
+      request?: protos.google.logging.v2.IWriteLogEntriesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.IWriteLogEntriesResponse,
@@ -564,7 +564,7 @@ export class LoggingServiceV2Client {
  * const [response] = await client.writeLogEntries(request);
  */
   writeLogEntries(
-      request: protos.google.logging.v2.IWriteLogEntriesRequest,
+      request?: protos.google.logging.v2.IWriteLogEntriesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.IWriteLogEntriesResponse,
           protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
@@ -592,7 +592,7 @@ export class LoggingServiceV2Client {
   }
 
   listLogEntries(
-      request: protos.google.logging.v2.IListLogEntriesRequest,
+      request?: protos.google.logging.v2.IListLogEntriesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogEntry[],
@@ -668,7 +668,7 @@ export class LoggingServiceV2Client {
  *   for more details and examples.
  */
   listLogEntries(
-      request: protos.google.logging.v2.IListLogEntriesRequest,
+      request?: protos.google.logging.v2.IListLogEntriesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogEntriesRequest,
           protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
@@ -835,7 +835,7 @@ export class LoggingServiceV2Client {
     ) as AsyncIterable<protos.google.logging.v2.ILogEntry>;
   }
   listMonitoredResourceDescriptors(
-      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+      request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor[],
@@ -883,7 +883,7 @@ export class LoggingServiceV2Client {
  *   for more details and examples.
  */
   listMonitoredResourceDescriptors(
-      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+      request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
           protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
@@ -998,7 +998,7 @@ export class LoggingServiceV2Client {
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
   listLogs(
-      request: protos.google.logging.v2.IListLogsRequest,
+      request?: protos.google.logging.v2.IListLogsRequest,
       options?: CallOptions):
       Promise<[
         string[],
@@ -1054,7 +1054,7 @@ export class LoggingServiceV2Client {
  *   for more details and examples.
  */
   listLogs(
-      request: protos.google.logging.v2.IListLogsRequest,
+      request?: protos.google.logging.v2.IListLogsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogsRequest,
           protos.google.logging.v2.IListLogsResponse|null|undefined,

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -350,7 +350,7 @@ export class MetricsServiceV2Client {
   // -- Service calls --
   // -------------------
   getLogMetric(
-      request: protos.google.logging.v2.IGetLogMetricRequest,
+      request?: protos.google.logging.v2.IGetLogMetricRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
@@ -389,7 +389,7 @@ export class MetricsServiceV2Client {
  * const [response] = await client.getLogMetric(request);
  */
   getLogMetric(
-      request: protos.google.logging.v2.IGetLogMetricRequest,
+      request?: protos.google.logging.v2.IGetLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IGetLogMetricRequest|null|undefined,
@@ -423,7 +423,7 @@ export class MetricsServiceV2Client {
     return this.innerApiCalls.getLogMetric(request, options, callback);
   }
   createLogMetric(
-      request: protos.google.logging.v2.ICreateLogMetricRequest,
+      request?: protos.google.logging.v2.ICreateLogMetricRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
@@ -467,7 +467,7 @@ export class MetricsServiceV2Client {
  * const [response] = await client.createLogMetric(request);
  */
   createLogMetric(
-      request: protos.google.logging.v2.ICreateLogMetricRequest,
+      request?: protos.google.logging.v2.ICreateLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
@@ -501,7 +501,7 @@ export class MetricsServiceV2Client {
     return this.innerApiCalls.createLogMetric(request, options, callback);
   }
   updateLogMetric(
-      request: protos.google.logging.v2.IUpdateLogMetricRequest,
+      request?: protos.google.logging.v2.IUpdateLogMetricRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric,
@@ -546,7 +546,7 @@ export class MetricsServiceV2Client {
  * const [response] = await client.updateLogMetric(request);
  */
   updateLogMetric(
-      request: protos.google.logging.v2.IUpdateLogMetricRequest,
+      request?: protos.google.logging.v2.IUpdateLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
@@ -580,7 +580,7 @@ export class MetricsServiceV2Client {
     return this.innerApiCalls.updateLogMetric(request, options, callback);
   }
   deleteLogMetric(
-      request: protos.google.logging.v2.IDeleteLogMetricRequest,
+      request?: protos.google.logging.v2.IDeleteLogMetricRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -619,7 +619,7 @@ export class MetricsServiceV2Client {
  * const [response] = await client.deleteLogMetric(request);
  */
   deleteLogMetric(
-      request: protos.google.logging.v2.IDeleteLogMetricRequest,
+      request?: protos.google.logging.v2.IDeleteLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogMetricRequest|null|undefined,
@@ -654,7 +654,7 @@ export class MetricsServiceV2Client {
   }
 
   listLogMetrics(
-      request: protos.google.logging.v2.IListLogMetricsRequest,
+      request?: protos.google.logging.v2.IListLogMetricsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.logging.v2.ILogMetric[],
@@ -706,7 +706,7 @@ export class MetricsServiceV2Client {
  *   for more details and examples.
  */
   listLogMetrics(
-      request: protos.google.logging.v2.IListLogMetricsRequest,
+      request?: protos.google.logging.v2.IListLogMetricsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.logging.v2.IListLogMetricsRequest,
           protos.google.logging.v2.IListLogMetricsResponse|null|undefined,

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -362,7 +362,7 @@ export class AlertPolicyServiceClient {
   // -- Service calls --
   // -------------------
   getAlertPolicy(
-      request: protos.google.monitoring.v3.IGetAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IGetAlertPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
@@ -401,7 +401,7 @@ export class AlertPolicyServiceClient {
  * const [response] = await client.getAlertPolicy(request);
  */
   getAlertPolicy(
-      request: protos.google.monitoring.v3.IGetAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IGetAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IGetAlertPolicyRequest|null|undefined,
@@ -435,7 +435,7 @@ export class AlertPolicyServiceClient {
     return this.innerApiCalls.getAlertPolicy(request, options, callback);
   }
   createAlertPolicy(
-      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
@@ -483,7 +483,7 @@ export class AlertPolicyServiceClient {
  * const [response] = await client.createAlertPolicy(request);
  */
   createAlertPolicy(
-      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
@@ -517,7 +517,7 @@ export class AlertPolicyServiceClient {
     return this.innerApiCalls.createAlertPolicy(request, options, callback);
   }
   deleteAlertPolicy(
-      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -558,7 +558,7 @@ export class AlertPolicyServiceClient {
  * const [response] = await client.deleteAlertPolicy(request);
  */
   deleteAlertPolicy(
-      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
@@ -592,7 +592,7 @@ export class AlertPolicyServiceClient {
     return this.innerApiCalls.deleteAlertPolicy(request, options, callback);
   }
   updateAlertPolicy(
-      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy,
@@ -657,7 +657,7 @@ export class AlertPolicyServiceClient {
  * const [response] = await client.updateAlertPolicy(request);
  */
   updateAlertPolicy(
-      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
+      request?: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
@@ -692,7 +692,7 @@ export class AlertPolicyServiceClient {
   }
 
   listAlertPolicies(
-      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
+      request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IAlertPolicy[],
@@ -760,7 +760,7 @@ export class AlertPolicyServiceClient {
  *   for more details and examples.
  */
   listAlertPolicies(
-      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
+      request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListAlertPoliciesRequest,
           protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -367,7 +367,7 @@ export class GroupServiceClient {
   // -- Service calls --
   // -------------------
   getGroup(
-      request: protos.google.monitoring.v3.IGetGroupRequest,
+      request?: protos.google.monitoring.v3.IGetGroupRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
@@ -405,7 +405,7 @@ export class GroupServiceClient {
  * const [response] = await client.getGroup(request);
  */
   getGroup(
-      request: protos.google.monitoring.v3.IGetGroupRequest,
+      request?: protos.google.monitoring.v3.IGetGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IGetGroupRequest|null|undefined,
@@ -439,7 +439,7 @@ export class GroupServiceClient {
     return this.innerApiCalls.getGroup(request, options, callback);
   }
   createGroup(
-      request: protos.google.monitoring.v3.ICreateGroupRequest,
+      request?: protos.google.monitoring.v3.ICreateGroupRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
@@ -482,7 +482,7 @@ export class GroupServiceClient {
  * const [response] = await client.createGroup(request);
  */
   createGroup(
-      request: protos.google.monitoring.v3.ICreateGroupRequest,
+      request?: protos.google.monitoring.v3.ICreateGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
@@ -516,7 +516,7 @@ export class GroupServiceClient {
     return this.innerApiCalls.createGroup(request, options, callback);
   }
   updateGroup(
-      request: protos.google.monitoring.v3.IUpdateGroupRequest,
+      request?: protos.google.monitoring.v3.IUpdateGroupRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup,
@@ -557,7 +557,7 @@ export class GroupServiceClient {
  * const [response] = await client.updateGroup(request);
  */
   updateGroup(
-      request: protos.google.monitoring.v3.IUpdateGroupRequest,
+      request?: protos.google.monitoring.v3.IUpdateGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
@@ -591,7 +591,7 @@ export class GroupServiceClient {
     return this.innerApiCalls.updateGroup(request, options, callback);
   }
   deleteGroup(
-      request: protos.google.monitoring.v3.IDeleteGroupRequest,
+      request?: protos.google.monitoring.v3.IDeleteGroupRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -633,7 +633,7 @@ export class GroupServiceClient {
  * const [response] = await client.deleteGroup(request);
  */
   deleteGroup(
-      request: protos.google.monitoring.v3.IDeleteGroupRequest,
+      request?: protos.google.monitoring.v3.IDeleteGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
@@ -668,7 +668,7 @@ export class GroupServiceClient {
   }
 
   listGroups(
-      request: protos.google.monitoring.v3.IListGroupsRequest,
+      request?: protos.google.monitoring.v3.IListGroupsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGroup[],
@@ -731,7 +731,7 @@ export class GroupServiceClient {
  *   for more details and examples.
  */
   listGroups(
-      request: protos.google.monitoring.v3.IListGroupsRequest,
+      request?: protos.google.monitoring.v3.IListGroupsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListGroupsRequest,
           protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
@@ -897,7 +897,7 @@ export class GroupServiceClient {
     ) as AsyncIterable<protos.google.monitoring.v3.IGroup>;
   }
   listGroupMembers(
-      request: protos.google.monitoring.v3.IListGroupMembersRequest,
+      request?: protos.google.monitoring.v3.IListGroupMembersRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResource[],
@@ -958,7 +958,7 @@ export class GroupServiceClient {
  *   for more details and examples.
  */
   listGroupMembers(
-      request: protos.google.monitoring.v3.IListGroupMembersRequest,
+      request?: protos.google.monitoring.v3.IListGroupMembersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListGroupMembersRequest,
           protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -378,7 +378,7 @@ export class MetricServiceClient {
   // -- Service calls --
   // -------------------
   getMonitoredResourceDescriptor(
-      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor,
@@ -418,7 +418,7 @@ export class MetricServiceClient {
  * const [response] = await client.getMonitoredResourceDescriptor(request);
  */
   getMonitoredResourceDescriptor(
-      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMonitoredResourceDescriptor,
           protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
@@ -452,7 +452,7 @@ export class MetricServiceClient {
     return this.innerApiCalls.getMonitoredResourceDescriptor(request, options, callback);
   }
   getMetricDescriptor(
-      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor,
@@ -492,7 +492,7 @@ export class MetricServiceClient {
  * const [response] = await client.getMetricDescriptor(request);
  */
   getMetricDescriptor(
-      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
@@ -526,7 +526,7 @@ export class MetricServiceClient {
     return this.innerApiCalls.getMetricDescriptor(request, options, callback);
   }
   createMetricDescriptor(
-      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor,
@@ -569,7 +569,7 @@ export class MetricServiceClient {
  * const [response] = await client.createMetricDescriptor(request);
  */
   createMetricDescriptor(
-      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.api.IMetricDescriptor,
           protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
@@ -603,7 +603,7 @@ export class MetricServiceClient {
     return this.innerApiCalls.createMetricDescriptor(request, options, callback);
   }
   deleteMetricDescriptor(
-      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -644,7 +644,7 @@ export class MetricServiceClient {
  * const [response] = await client.deleteMetricDescriptor(request);
  */
   deleteMetricDescriptor(
-      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
+      request?: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
@@ -678,7 +678,7 @@ export class MetricServiceClient {
     return this.innerApiCalls.deleteMetricDescriptor(request, options, callback);
   }
   createTimeSeries(
-      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
+      request?: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -727,7 +727,7 @@ export class MetricServiceClient {
  * const [response] = await client.createTimeSeries(request);
  */
   createTimeSeries(
-      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
+      request?: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
@@ -762,7 +762,7 @@ export class MetricServiceClient {
   }
 
   listMonitoredResourceDescriptors(
-      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMonitoredResourceDescriptor[],
@@ -818,7 +818,7 @@ export class MetricServiceClient {
  *   for more details and examples.
  */
   listMonitoredResourceDescriptors(
-      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
           protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
@@ -970,7 +970,7 @@ export class MetricServiceClient {
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
   listMetricDescriptors(
-      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.api.IMetricDescriptor[],
@@ -1027,7 +1027,7 @@ export class MetricServiceClient {
  *   for more details and examples.
  */
   listMetricDescriptors(
-      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListMetricDescriptorsRequest,
           protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
@@ -1181,7 +1181,7 @@ export class MetricServiceClient {
     ) as AsyncIterable<protos.google.api.IMetricDescriptor>;
   }
   listTimeSeries(
-      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
+      request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.ITimeSeries[],
@@ -1256,7 +1256,7 @@ export class MetricServiceClient {
  *   for more details and examples.
  */
   listTimeSeries(
-      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
+      request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListTimeSeriesRequest,
           protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -357,7 +357,7 @@ export class NotificationChannelServiceClient {
   // -- Service calls --
   // -------------------
   getNotificationChannelDescriptor(
-      request: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannelDescriptor,
@@ -396,7 +396,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.getNotificationChannelDescriptor(request);
  */
   getNotificationChannelDescriptor(
-      request: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannelDescriptor,
           protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|null|undefined,
@@ -430,7 +430,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.getNotificationChannelDescriptor(request, options, callback);
   }
   getNotificationChannel(
-      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
@@ -472,7 +472,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.getNotificationChannel(request);
  */
   getNotificationChannel(
-      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
@@ -506,7 +506,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.getNotificationChannel(request, options, callback);
   }
   createNotificationChannel(
-      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
@@ -553,7 +553,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.createNotificationChannel(request);
  */
   createNotificationChannel(
-      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
@@ -587,7 +587,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.createNotificationChannel(request, options, callback);
   }
   updateNotificationChannel(
-      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
@@ -630,7 +630,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.updateNotificationChannel(request);
  */
   updateNotificationChannel(
-      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
@@ -664,7 +664,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.updateNotificationChannel(request, options, callback);
   }
   deleteNotificationChannel(
-      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -707,7 +707,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.deleteNotificationChannel(request);
  */
   deleteNotificationChannel(
-      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
@@ -741,7 +741,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.deleteNotificationChannel(request, options, callback);
   }
   sendNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
+      request?: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -779,7 +779,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.sendNotificationChannelVerificationCode(request);
  */
   sendNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
+      request?: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|null|undefined,
@@ -813,7 +813,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.sendNotificationChannelVerificationCode(request, options, callback);
   }
   getNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
@@ -882,7 +882,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.getNotificationChannelVerificationCode(request);
  */
   getNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
+      request?: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
@@ -916,7 +916,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.getNotificationChannelVerificationCode(request, options, callback);
   }
   verifyNotificationChannel(
-      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel,
@@ -963,7 +963,7 @@ export class NotificationChannelServiceClient {
  * const [response] = await client.verifyNotificationChannel(request);
  */
   verifyNotificationChannel(
-      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
+      request?: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.INotificationChannel,
           protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
@@ -998,7 +998,7 @@ export class NotificationChannelServiceClient {
   }
 
   listNotificationChannelDescriptors(
-      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannelDescriptor[],
@@ -1056,7 +1056,7 @@ export class NotificationChannelServiceClient {
  *   for more details and examples.
  */
   listNotificationChannelDescriptors(
-      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+      request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
           protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
@@ -1210,7 +1210,7 @@ export class NotificationChannelServiceClient {
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannelDescriptor>;
   }
   listNotificationChannels(
-      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
+      request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.INotificationChannel[],
@@ -1278,7 +1278,7 @@ export class NotificationChannelServiceClient {
  *   for more details and examples.
  */
   listNotificationChannels(
-      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
+      request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListNotificationChannelsRequest,
           protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -359,7 +359,7 @@ export class ServiceMonitoringServiceClient {
   // -- Service calls --
   // -------------------
   createService(
-      request: protos.google.monitoring.v3.ICreateServiceRequest,
+      request?: protos.google.monitoring.v3.ICreateServiceRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
@@ -402,7 +402,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.createService(request);
  */
   createService(
-      request: protos.google.monitoring.v3.ICreateServiceRequest,
+      request?: protos.google.monitoring.v3.ICreateServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
@@ -436,7 +436,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.createService(request, options, callback);
   }
   getService(
-      request: protos.google.monitoring.v3.IGetServiceRequest,
+      request?: protos.google.monitoring.v3.IGetServiceRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
@@ -474,7 +474,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.getService(request);
  */
   getService(
-      request: protos.google.monitoring.v3.IGetServiceRequest,
+      request?: protos.google.monitoring.v3.IGetServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IGetServiceRequest|null|undefined,
@@ -508,7 +508,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.getService(request, options, callback);
   }
   updateService(
-      request: protos.google.monitoring.v3.IUpdateServiceRequest,
+      request?: protos.google.monitoring.v3.IUpdateServiceRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService,
@@ -548,7 +548,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.updateService(request);
  */
   updateService(
-      request: protos.google.monitoring.v3.IUpdateServiceRequest,
+      request?: protos.google.monitoring.v3.IUpdateServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
@@ -582,7 +582,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.updateService(request, options, callback);
   }
   deleteService(
-      request: protos.google.monitoring.v3.IDeleteServiceRequest,
+      request?: protos.google.monitoring.v3.IDeleteServiceRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -620,7 +620,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.deleteService(request);
  */
   deleteService(
-      request: protos.google.monitoring.v3.IDeleteServiceRequest,
+      request?: protos.google.monitoring.v3.IDeleteServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceRequest|null|undefined,
@@ -654,7 +654,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.deleteService(request, options, callback);
   }
   createServiceLevelObjective(
-      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
@@ -700,7 +700,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.createServiceLevelObjective(request);
  */
   createServiceLevelObjective(
-      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
@@ -734,7 +734,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.createServiceLevelObjective(request, options, callback);
   }
   getServiceLevelObjective(
-      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
@@ -778,7 +778,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.getServiceLevelObjective(request);
  */
   getServiceLevelObjective(
-      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
@@ -812,7 +812,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.getServiceLevelObjective(request, options, callback);
   }
   updateServiceLevelObjective(
-      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective,
@@ -852,7 +852,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.updateServiceLevelObjective(request);
  */
   updateServiceLevelObjective(
-      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IServiceLevelObjective,
           protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
@@ -886,7 +886,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.updateServiceLevelObjective(request, options, callback);
   }
   deleteServiceLevelObjective(
-      request: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -925,7 +925,7 @@ export class ServiceMonitoringServiceClient {
  * const [response] = await client.deleteServiceLevelObjective(request);
  */
   deleteServiceLevelObjective(
-      request: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
+      request?: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|null|undefined,
@@ -960,7 +960,7 @@ export class ServiceMonitoringServiceClient {
   }
 
   listServices(
-      request: protos.google.monitoring.v3.IListServicesRequest,
+      request?: protos.google.monitoring.v3.IListServicesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IService[],
@@ -1025,7 +1025,7 @@ export class ServiceMonitoringServiceClient {
  *   for more details and examples.
  */
   listServices(
-      request: protos.google.monitoring.v3.IListServicesRequest,
+      request?: protos.google.monitoring.v3.IListServicesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListServicesRequest,
           protos.google.monitoring.v3.IListServicesResponse|null|undefined,
@@ -1195,7 +1195,7 @@ export class ServiceMonitoringServiceClient {
     ) as AsyncIterable<protos.google.monitoring.v3.IService>;
   }
   listServiceLevelObjectives(
-      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+      request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IServiceLevelObjective[],
@@ -1251,7 +1251,7 @@ export class ServiceMonitoringServiceClient {
  *   for more details and examples.
  */
   listServiceLevelObjectives(
-      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+      request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
           protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -363,7 +363,7 @@ export class UptimeCheckServiceClient {
   // -- Service calls --
   // -------------------
   getUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
@@ -401,7 +401,7 @@ export class UptimeCheckServiceClient {
  * const [response] = await client.getUptimeCheckConfig(request);
  */
   getUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|null|undefined,
@@ -435,7 +435,7 @@ export class UptimeCheckServiceClient {
     return this.innerApiCalls.getUptimeCheckConfig(request, options, callback);
   }
   createUptimeCheckConfig(
-      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
@@ -475,7 +475,7 @@ export class UptimeCheckServiceClient {
  * const [response] = await client.createUptimeCheckConfig(request);
  */
   createUptimeCheckConfig(
-      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
@@ -509,7 +509,7 @@ export class UptimeCheckServiceClient {
     return this.innerApiCalls.createUptimeCheckConfig(request, options, callback);
   }
   updateUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig,
@@ -564,7 +564,7 @@ export class UptimeCheckServiceClient {
  * const [response] = await client.updateUptimeCheckConfig(request);
  */
   updateUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
@@ -598,7 +598,7 @@ export class UptimeCheckServiceClient {
     return this.innerApiCalls.updateUptimeCheckConfig(request, options, callback);
   }
   deleteUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -638,7 +638,7 @@ export class UptimeCheckServiceClient {
  * const [response] = await client.deleteUptimeCheckConfig(request);
  */
   deleteUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
+      request?: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
@@ -673,7 +673,7 @@ export class UptimeCheckServiceClient {
   }
 
   listUptimeCheckConfigs(
-      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+      request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckConfig[],
@@ -725,7 +725,7 @@ export class UptimeCheckServiceClient {
  *   for more details and examples.
  */
   listUptimeCheckConfigs(
-      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+      request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
           protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
@@ -867,7 +867,7 @@ export class UptimeCheckServiceClient {
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckConfig>;
   }
   listUptimeCheckIps(
-      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+      request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.monitoring.v3.IUptimeCheckIp[],
@@ -917,7 +917,7 @@ export class UptimeCheckServiceClient {
  *   for more details and examples.
  */
   listUptimeCheckIps(
-      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+      request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
           protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -295,7 +295,7 @@ export class NamingClient {
   // -- Service calls --
   // -------------------
   paginatedMethodStream(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -329,7 +329,7 @@ export class NamingClient {
  * const [response] = await client.paginatedMethodStream(request);
  */
   paginatedMethodStream(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -356,7 +356,7 @@ export class NamingClient {
     return this.innerApiCalls.paginatedMethodStream(request, options, callback);
   }
   paginatedMethodAsync(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -390,7 +390,7 @@ export class NamingClient {
  * const [response] = await client.paginatedMethodAsync(request);
  */
   paginatedMethodAsync(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -417,7 +417,7 @@ export class NamingClient {
     return this.innerApiCalls.paginatedMethodAsync(request, options, callback);
   }
   checkLongRunningProgress(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -451,7 +451,7 @@ export class NamingClient {
  * const [response] = await client.checkLongRunningProgress(request);
  */
   checkLongRunningProgress(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -478,7 +478,7 @@ export class NamingClient {
     return this.innerApiCalls.checkLongRunningProgress(request, options, callback);
   }
   initialize(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -513,7 +513,7 @@ export class NamingClient {
  * const [response] = await client.initialize(request);
  */
   initialize(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -540,7 +540,7 @@ export class NamingClient {
     return this.innerApiCalls.initialize(request, options, callback);
   }
   servicePath(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -574,7 +574,7 @@ export class NamingClient {
  * const [response] = await client.servicePath(request);
  */
   servicePath(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -601,7 +601,7 @@ export class NamingClient {
     return this.innerApiCalls.servicePath(request, options, callback);
   }
   apiEndpoint(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -635,7 +635,7 @@ export class NamingClient {
  * const [response] = await client.apiEndpoint(request);
  */
   apiEndpoint(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -662,7 +662,7 @@ export class NamingClient {
     return this.innerApiCalls.apiEndpoint(request, options, callback);
   }
   port(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -696,7 +696,7 @@ export class NamingClient {
  * const [response] = await client.port(request);
  */
   port(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -723,7 +723,7 @@ export class NamingClient {
     return this.innerApiCalls.port(request, options, callback);
   }
   scopes(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -757,7 +757,7 @@ export class NamingClient {
  * const [response] = await client.scopes(request);
  */
   scopes(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -784,7 +784,7 @@ export class NamingClient {
     return this.innerApiCalls.scopes(request, options, callback);
   }
   getProjectId(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -818,7 +818,7 @@ export class NamingClient {
  * const [response] = await client.getProjectId(request);
  */
   getProjectId(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
@@ -846,7 +846,7 @@ export class NamingClient {
   }
 
   longRunning(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
@@ -884,7 +884,7 @@ export class NamingClient {
  * const [response] = await operation.promise();
  */
   longRunning(
-      request: protos.google.protobuf.IEmpty,
+      request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -932,7 +932,7 @@ export class NamingClient {
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>;
   }
   paginatedMethod(
-      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
+      request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty[],
@@ -975,7 +975,7 @@ export class NamingClient {
  *   for more details and examples.
  */
   paginatedMethod(
-      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
+      request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.naming.v1beta1.IPaginatedMethodRequest,
           protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -364,7 +364,7 @@ export class CloudRedisClient {
   // -- Service calls --
   // -------------------
   getInstance(
-      request: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.redis.v1beta1.IInstance,
@@ -403,7 +403,7 @@ export class CloudRedisClient {
  * const [response] = await client.getInstance(request);
  */
   getInstance(
-      request: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.redis.v1beta1.IInstance,
           protos.google.cloud.redis.v1beta1.IGetInstanceRequest|null|undefined,
@@ -438,7 +438,7 @@ export class CloudRedisClient {
   }
 
   createInstance(
-      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
@@ -502,7 +502,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   createInstance(
-      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -557,7 +557,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
   updateInstance(
-      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
@@ -611,7 +611,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   updateInstance(
-      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -666,7 +666,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
   importInstance(
-      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
@@ -717,7 +717,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   importInstance(
-      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -772,7 +772,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
   exportInstance(
-      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
@@ -821,7 +821,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   exportInstance(
-      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -876,7 +876,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
   failoverInstance(
-      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
@@ -922,7 +922,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   failoverInstance(
-      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -977,7 +977,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
   deleteInstance(
-      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
@@ -1020,7 +1020,7 @@ export class CloudRedisClient {
  * const [response] = await operation.promise();
  */
   deleteInstance(
-      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
+      request?: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1075,7 +1075,7 @@ export class CloudRedisClient {
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>;
   }
   listInstances(
-      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+      request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.redis.v1beta1.IInstance[],
@@ -1136,7 +1136,7 @@ export class CloudRedisClient {
  *   for more details and examples.
  */
   listInstances(
-      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+      request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.redis.v1beta1.IListInstancesRequest,
           protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -342,7 +342,7 @@ export class EchoClient {
   // -- Service calls --
   // -------------------
   echo(
-      request: protos.google.showcase.v1beta1.IEchoRequest,
+      request?: protos.google.showcase.v1beta1.IEchoRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse,
@@ -379,7 +379,7 @@ export class EchoClient {
  * const [response] = await client.echo(request);
  */
   echo(
-      request: protos.google.showcase.v1beta1.IEchoRequest,
+      request?: protos.google.showcase.v1beta1.IEchoRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
@@ -406,7 +406,7 @@ export class EchoClient {
     return this.innerApiCalls.echo(request, options, callback);
   }
   block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlockResponse,
@@ -450,7 +450,7 @@ export class EchoClient {
  * const [response] = await client.block(request);
  */
   block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlockResponse,
           protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
@@ -587,7 +587,7 @@ export class EchoClient {
   }
 
   wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
@@ -635,7 +635,7 @@ export class EchoClient {
  * const [response] = await operation.promise();
  */
   wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -683,7 +683,7 @@ export class EchoClient {
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
   pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IEchoResponse[],
@@ -729,7 +729,7 @@ export class EchoClient {
  *   for more details and examples.
  */
   pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IPagedExpandRequest,
           protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -305,7 +305,7 @@ export class IdentityClient {
   // -- Service calls --
   // -------------------
   createUser(
-      request: protos.google.showcase.v1beta1.ICreateUserRequest,
+      request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -342,7 +342,7 @@ export class IdentityClient {
  * const [response] = await client.createUser(request);
  */
   createUser(
-      request: protos.google.showcase.v1beta1.ICreateUserRequest,
+      request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
@@ -369,7 +369,7 @@ export class IdentityClient {
     return this.innerApiCalls.createUser(request, options, callback);
   }
   getUser(
-      request: protos.google.showcase.v1beta1.IGetUserRequest,
+      request?: protos.google.showcase.v1beta1.IGetUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -406,7 +406,7 @@ export class IdentityClient {
  * const [response] = await client.getUser(request);
  */
   getUser(
-      request: protos.google.showcase.v1beta1.IGetUserRequest,
+      request?: protos.google.showcase.v1beta1.IGetUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
@@ -440,7 +440,7 @@ export class IdentityClient {
     return this.innerApiCalls.getUser(request, options, callback);
   }
   updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser,
@@ -480,7 +480,7 @@ export class IdentityClient {
  * const [response] = await client.updateUser(request);
  */
   updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
@@ -514,7 +514,7 @@ export class IdentityClient {
     return this.innerApiCalls.updateUser(request, options, callback);
   }
   deleteUser(
-      request: protos.google.showcase.v1beta1.IDeleteUserRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -551,7 +551,7 @@ export class IdentityClient {
  * const [response] = await client.deleteUser(request);
  */
   deleteUser(
-      request: protos.google.showcase.v1beta1.IDeleteUserRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
@@ -586,7 +586,7 @@ export class IdentityClient {
   }
 
   listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IUser[],
@@ -632,7 +632,7 @@ export class IdentityClient {
  *   for more details and examples.
  */
   listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListUsersRequest,
           protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -343,7 +343,7 @@ export class MessagingClient {
   // -- Service calls --
   // -------------------
   createRoom(
-      request: protos.google.showcase.v1beta1.ICreateRoomRequest,
+      request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -380,7 +380,7 @@ export class MessagingClient {
  * const [response] = await client.createRoom(request);
  */
   createRoom(
-      request: protos.google.showcase.v1beta1.ICreateRoomRequest,
+      request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
@@ -407,7 +407,7 @@ export class MessagingClient {
     return this.innerApiCalls.createRoom(request, options, callback);
   }
   getRoom(
-      request: protos.google.showcase.v1beta1.IGetRoomRequest,
+      request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -444,7 +444,7 @@ export class MessagingClient {
  * const [response] = await client.getRoom(request);
  */
   getRoom(
-      request: protos.google.showcase.v1beta1.IGetRoomRequest,
+      request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
@@ -478,7 +478,7 @@ export class MessagingClient {
     return this.innerApiCalls.getRoom(request, options, callback);
   }
   updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom,
@@ -518,7 +518,7 @@ export class MessagingClient {
  * const [response] = await client.updateRoom(request);
  */
   updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
@@ -552,7 +552,7 @@ export class MessagingClient {
     return this.innerApiCalls.updateRoom(request, options, callback);
   }
   deleteRoom(
-      request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -589,7 +589,7 @@ export class MessagingClient {
  * const [response] = await client.deleteRoom(request);
  */
   deleteRoom(
-      request: protos.google.showcase.v1beta1.IDeleteRoomRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
@@ -623,7 +623,7 @@ export class MessagingClient {
     return this.innerApiCalls.deleteRoom(request, options, callback);
   }
   createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -665,7 +665,7 @@ export class MessagingClient {
  * const [response] = await client.createBlurb(request);
  */
   createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
@@ -699,7 +699,7 @@ export class MessagingClient {
     return this.innerApiCalls.createBlurb(request, options, callback);
   }
   getBlurb(
-      request: protos.google.showcase.v1beta1.IGetBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -736,7 +736,7 @@ export class MessagingClient {
  * const [response] = await client.getBlurb(request);
  */
   getBlurb(
-      request: protos.google.showcase.v1beta1.IGetBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
@@ -770,7 +770,7 @@ export class MessagingClient {
     return this.innerApiCalls.getBlurb(request, options, callback);
   }
   updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb,
@@ -810,7 +810,7 @@ export class MessagingClient {
  * const [response] = await client.updateBlurb(request);
  */
   updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
@@ -844,7 +844,7 @@ export class MessagingClient {
     return this.innerApiCalls.updateBlurb(request, options, callback);
   }
   deleteBlurb(
-      request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -881,7 +881,7 @@ export class MessagingClient {
  * const [response] = await client.deleteBlurb(request);
  */
   deleteBlurb(
-      request: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
@@ -1032,7 +1032,7 @@ export class MessagingClient {
   }
 
   searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
@@ -1087,7 +1087,7 @@ export class MessagingClient {
  * const [response] = await operation.promise();
  */
   searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1142,7 +1142,7 @@ export class MessagingClient {
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
   listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IRoom[],
@@ -1188,7 +1188,7 @@ export class MessagingClient {
  *   for more details and examples.
  */
   listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListRoomsRequest,
           protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
@@ -1299,7 +1299,7 @@ export class MessagingClient {
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
   listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IBlurb[],
@@ -1349,7 +1349,7 @@ export class MessagingClient {
  *   for more details and examples.
  */
   listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListBlurbsRequest,
           protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -308,7 +308,7 @@ export class TestingClient {
   // -- Service calls --
   // -------------------
   createSession(
-      request: protos.google.showcase.v1beta1.ICreateSessionRequest,
+      request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
@@ -347,7 +347,7 @@ export class TestingClient {
  * const [response] = await client.createSession(request);
  */
   createSession(
-      request: protos.google.showcase.v1beta1.ICreateSessionRequest,
+      request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
@@ -374,7 +374,7 @@ export class TestingClient {
     return this.innerApiCalls.createSession(request, options, callback);
   }
   getSession(
-      request: protos.google.showcase.v1beta1.IGetSessionRequest,
+      request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession,
@@ -411,7 +411,7 @@ export class TestingClient {
  * const [response] = await client.getSession(request);
  */
   getSession(
-      request: protos.google.showcase.v1beta1.IGetSessionRequest,
+      request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
@@ -445,7 +445,7 @@ export class TestingClient {
     return this.innerApiCalls.getSession(request, options, callback);
   }
   deleteSession(
-      request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -482,7 +482,7 @@ export class TestingClient {
  * const [response] = await client.deleteSession(request);
  */
   deleteSession(
-      request: protos.google.showcase.v1beta1.IDeleteSessionRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
@@ -516,7 +516,7 @@ export class TestingClient {
     return this.innerApiCalls.deleteSession(request, options, callback);
   }
   reportSession(
-      request: protos.google.showcase.v1beta1.IReportSessionRequest,
+      request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IReportSessionResponse,
@@ -555,7 +555,7 @@ export class TestingClient {
  * const [response] = await client.reportSession(request);
  */
   reportSession(
-      request: protos.google.showcase.v1beta1.IReportSessionRequest,
+      request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
@@ -589,7 +589,7 @@ export class TestingClient {
     return this.innerApiCalls.reportSession(request, options, callback);
   }
   deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -631,7 +631,7 @@ export class TestingClient {
  * const [response] = await client.deleteTest(request);
  */
   deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
@@ -665,7 +665,7 @@ export class TestingClient {
     return this.innerApiCalls.deleteTest(request, options, callback);
   }
   verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.IVerifyTestResponse,
@@ -709,7 +709,7 @@ export class TestingClient {
  * const [response] = await client.verifyTest(request);
  */
   verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.showcase.v1beta1.IVerifyTestResponse,
           protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
@@ -744,7 +744,7 @@ export class TestingClient {
   }
 
   listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ISession[],
@@ -787,7 +787,7 @@ export class TestingClient {
  *   for more details and examples.
  */
   listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListSessionsRequest,
           protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
@@ -892,7 +892,7 @@ export class TestingClient {
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
   listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.showcase.v1beta1.ITest[],
@@ -937,7 +937,7 @@ export class TestingClient {
  *   for more details and examples.
  */
   listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.showcase.v1beta1.IListTestsRequest,
           protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -289,7 +289,7 @@ export class CloudTasksClient {
   // -- Service calls --
   // -------------------
   getQueue(
-      request: protos.google.cloud.tasks.v2.IGetQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IGetQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -327,7 +327,7 @@ export class CloudTasksClient {
  * const [response] = await client.getQueue(request);
  */
   getQueue(
-      request: protos.google.cloud.tasks.v2.IGetQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IGetQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IGetQueueRequest|null|undefined,
@@ -361,7 +361,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.getQueue(request, options, callback);
   }
   createQueue(
-      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
+      request?: protos.google.cloud.tasks.v2.ICreateQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -418,7 +418,7 @@ export class CloudTasksClient {
  * const [response] = await client.createQueue(request);
  */
   createQueue(
-      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
+      request?: protos.google.cloud.tasks.v2.ICreateQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
@@ -452,7 +452,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.createQueue(request, options, callback);
   }
   updateQueue(
-      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -513,7 +513,7 @@ export class CloudTasksClient {
  * const [response] = await client.updateQueue(request);
  */
   updateQueue(
-      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
@@ -547,7 +547,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.updateQueue(request, options, callback);
   }
   deleteQueue(
-      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -597,7 +597,7 @@ export class CloudTasksClient {
  * const [response] = await client.deleteQueue(request);
  */
   deleteQueue(
-      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
@@ -631,7 +631,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.deleteQueue(request, options, callback);
   }
   purgeQueue(
-      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -674,7 +674,7 @@ export class CloudTasksClient {
  * const [response] = await client.purgeQueue(request);
  */
   purgeQueue(
-      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
@@ -708,7 +708,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.purgeQueue(request, options, callback);
   }
   pauseQueue(
-      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IPauseQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -752,7 +752,7 @@ export class CloudTasksClient {
  * const [response] = await client.pauseQueue(request);
  */
   pauseQueue(
-      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IPauseQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
@@ -786,7 +786,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.pauseQueue(request, options, callback);
   }
   resumeQueue(
-      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IResumeQueueRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue,
@@ -836,7 +836,7 @@ export class CloudTasksClient {
  * const [response] = await client.resumeQueue(request);
  */
   resumeQueue(
-      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
+      request?: protos.google.cloud.tasks.v2.IResumeQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
@@ -870,7 +870,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.resumeQueue(request, options, callback);
   }
   getIamPolicy(
-      request: protos.google.iam.v1.IGetIamPolicyRequest,
+      request?: protos.google.iam.v1.IGetIamPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.iam.v1.IPolicy,
@@ -919,7 +919,7 @@ export class CloudTasksClient {
  * const [response] = await client.getIamPolicy(request);
  */
   getIamPolicy(
-      request: protos.google.iam.v1.IGetIamPolicyRequest,
+      request?: protos.google.iam.v1.IGetIamPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
@@ -953,7 +953,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.getIamPolicy(request, options, callback);
   }
   setIamPolicy(
-      request: protos.google.iam.v1.ISetIamPolicyRequest,
+      request?: protos.google.iam.v1.ISetIamPolicyRequest,
       options?: CallOptions):
       Promise<[
         protos.google.iam.v1.IPolicy,
@@ -1006,7 +1006,7 @@ export class CloudTasksClient {
  * const [response] = await client.setIamPolicy(request);
  */
   setIamPolicy(
-      request: protos.google.iam.v1.ISetIamPolicyRequest,
+      request?: protos.google.iam.v1.ISetIamPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
@@ -1040,7 +1040,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.setIamPolicy(request, options, callback);
   }
   testIamPermissions(
-      request: protos.google.iam.v1.ITestIamPermissionsRequest,
+      request?: protos.google.iam.v1.ITestIamPermissionsRequest,
       options?: CallOptions):
       Promise<[
         protos.google.iam.v1.ITestIamPermissionsResponse,
@@ -1089,7 +1089,7 @@ export class CloudTasksClient {
  * const [response] = await client.testIamPermissions(request);
  */
   testIamPermissions(
-      request: protos.google.iam.v1.ITestIamPermissionsRequest,
+      request?: protos.google.iam.v1.ITestIamPermissionsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.ITestIamPermissionsResponse,
           protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
@@ -1123,7 +1123,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.testIamPermissions(request, options, callback);
   }
   getTask(
-      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IGetTaskRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
@@ -1174,7 +1174,7 @@ export class CloudTasksClient {
  * const [response] = await client.getTask(request);
  */
   getTask(
-      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IGetTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
@@ -1208,7 +1208,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.getTask(request, options, callback);
   }
   createTask(
-      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
+      request?: protos.google.cloud.tasks.v2.ICreateTaskRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
@@ -1299,7 +1299,7 @@ export class CloudTasksClient {
  * const [response] = await client.createTask(request);
  */
   createTask(
-      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
+      request?: protos.google.cloud.tasks.v2.ICreateTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
@@ -1333,7 +1333,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.createTask(request, options, callback);
   }
   deleteTask(
-      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
       options?: CallOptions):
       Promise<[
         protos.google.protobuf.IEmpty,
@@ -1375,7 +1375,7 @@ export class CloudTasksClient {
  * const [response] = await client.deleteTask(request);
  */
   deleteTask(
-      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.protobuf.IEmpty,
           protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
@@ -1409,7 +1409,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.deleteTask(request, options, callback);
   }
   runTask(
-      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IRunTaskRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask,
@@ -1483,7 +1483,7 @@ export class CloudTasksClient {
  * const [response] = await client.runTask(request);
  */
   runTask(
-      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
+      request?: protos.google.cloud.tasks.v2.IRunTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
@@ -1518,7 +1518,7 @@ export class CloudTasksClient {
   }
 
   listQueues(
-      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
+      request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.IQueue[],
@@ -1591,7 +1591,7 @@ export class CloudTasksClient {
  *   for more details and examples.
  */
   listQueues(
-      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
+      request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.tasks.v2.IListQueuesRequest,
           protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
@@ -1773,7 +1773,7 @@ export class CloudTasksClient {
     ) as AsyncIterable<protos.google.cloud.tasks.v2.IQueue>;
   }
   listTasks(
-      request: protos.google.cloud.tasks.v2.IListTasksRequest,
+      request?: protos.google.cloud.tasks.v2.IListTasksRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.tasks.v2.ITask[],
@@ -1855,7 +1855,7 @@ export class CloudTasksClient {
  *   for more details and examples.
  */
   listTasks(
-      request: protos.google.cloud.tasks.v2.IListTasksRequest,
+      request?: protos.google.cloud.tasks.v2.IListTasksRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.tasks.v2.IListTasksRequest,
           protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -262,7 +262,7 @@ export class TextToSpeechClient {
   // -- Service calls --
   // -------------------
   listVoices(
-      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
+      request?: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.texttospeech.v1.IListVoicesResponse,
@@ -306,7 +306,7 @@ export class TextToSpeechClient {
  * const [response] = await client.listVoices(request);
  */
   listVoices(
-      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
+      request?: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.texttospeech.v1.IListVoicesResponse,
           protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
@@ -333,7 +333,7 @@ export class TextToSpeechClient {
     return this.innerApiCalls.listVoices(request, options, callback);
   }
   synthesizeSpeech(
-      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
+      request?: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
@@ -375,7 +375,7 @@ export class TextToSpeechClient {
  * const [response] = await client.synthesizeSpeech(request);
  */
   synthesizeSpeech(
-      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
+      request?: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
           protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -327,7 +327,7 @@ export class TranslationServiceClient {
   // -- Service calls --
   // -------------------
   translateText(
-      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
+      request?: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
@@ -424,7 +424,7 @@ export class TranslationServiceClient {
  * const [response] = await client.translateText(request);
  */
   translateText(
-      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
+      request?: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
           protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
@@ -458,7 +458,7 @@ export class TranslationServiceClient {
     return this.innerApiCalls.translateText(request, options, callback);
   }
   detectLanguage(
-      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
+      request?: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
@@ -529,7 +529,7 @@ export class TranslationServiceClient {
  * const [response] = await client.detectLanguage(request);
  */
   detectLanguage(
-      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
+      request?: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
           protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
@@ -563,7 +563,7 @@ export class TranslationServiceClient {
     return this.innerApiCalls.detectLanguage(request, options, callback);
   }
   getSupportedLanguages(
-      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
+      request?: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.ISupportedLanguages,
@@ -631,7 +631,7 @@ export class TranslationServiceClient {
  * const [response] = await client.getSupportedLanguages(request);
  */
   getSupportedLanguages(
-      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
+      request?: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ISupportedLanguages,
           protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
@@ -665,7 +665,7 @@ export class TranslationServiceClient {
     return this.innerApiCalls.getSupportedLanguages(request, options, callback);
   }
   getGlossary(
-      request: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IGlossary,
@@ -703,7 +703,7 @@ export class TranslationServiceClient {
  * const [response] = await client.getGlossary(request);
  */
   getGlossary(
-      request: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.IGlossary,
           protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|null|undefined,
@@ -738,7 +738,7 @@ export class TranslationServiceClient {
   }
 
   batchTranslateText(
-      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
+      request?: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
@@ -834,7 +834,7 @@ export class TranslationServiceClient {
  * const [response] = await operation.promise();
  */
   batchTranslateText(
-      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
+      request?: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -889,7 +889,7 @@ export class TranslationServiceClient {
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>;
   }
   createGlossary(
-      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
@@ -932,7 +932,7 @@ export class TranslationServiceClient {
  * const [response] = await operation.promise();
  */
   createGlossary(
-      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -987,7 +987,7 @@ export class TranslationServiceClient {
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>;
   }
   deleteGlossary(
-      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
@@ -1029,7 +1029,7 @@ export class TranslationServiceClient {
  * const [response] = await operation.promise();
  */
   deleteGlossary(
-      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
+      request?: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -1084,7 +1084,7 @@ export class TranslationServiceClient {
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>;
   }
   listGlossaries(
-      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+      request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
       options?: CallOptions):
       Promise<[
         protos.google.cloud.translation.v3beta1.IGlossary[],
@@ -1138,7 +1138,7 @@ export class TranslationServiceClient {
  *   for more details and examples.
  */
   listGlossaries(
-      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+      request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
           protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
           protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -287,7 +287,7 @@ export class VideoIntelligenceServiceClient {
   // -------------------
 
   annotateVideo(
-      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
+      request?: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
       options?: CallOptions):
       Promise<[
         LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
@@ -358,7 +358,7 @@ export class VideoIntelligenceServiceClient {
  * const [response] = await operation.promise();
  */
   annotateVideo(
-      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
+      request?: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
           protos.google.longrunning.IOperation|null|undefined,

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -419,7 +419,7 @@ export class {{ service.name }}Client {
 
 {%- for method in service.simpleMethods %}
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
       Promise<[
         {{ util.toInterface(method.outputInterface) }},
@@ -442,7 +442,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|Callback<
           {{ util.toInterface(method.outputInterface) }},
           {{ util.toInterface(method.inputInterface) }}|null|undefined,
@@ -532,7 +532,7 @@ export class {{ service.name }}Client {
 {% endfor %}
 {%- for method in service.longRunning %}
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
       Promise<[
         LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType) }}>,
@@ -555,7 +555,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|Callback<
           LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType)}}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
@@ -594,7 +594,7 @@ export class {{ service.name }}Client {
 {%- endfor %}
 {%- for method in service.paging %}
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
       Promise<[
         {{ util.toInterface(method.pagingResponseType) }}[],
@@ -618,7 +618,7 @@ export class {{ service.name }}Client {
 {{- util.printComments(method, service, id.get(method.name.toCamelCase() + "Async")) }}
  */
   {{ method.name.toCamelCase() }}(
-      request: {{ util.toInterface(method.inputInterface) }},
+      request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|PaginationCallback<
           {{ util.toInterface(method.inputInterface) }},
           {{ util.toInterface(method.outputInterface) }}|null|undefined,


### PR DESCRIPTION
We do `request = request || {}` to allow this but apparently not all methods properly mark `request` as optional for TypeScript users.