### PR TITLE
feat: allow optional label for proto3

### DIFF
--- a/typescript/src/gapic-generator-typescript.ts
+++ b/typescript/src/gapic-generator-typescript.ts
@@ -147,6 +147,8 @@ if (metadata) {
 protocCommand.push(...protoDirsArg);
 protocCommand.push(...protoFiles);
 protocCommand.push(`-I${commonProtoPath}`);
+// Enable `optional` presence tracking for proto3 messages. This flag is available in protobuf release >=3.12.
+protocCommand.push('--experimental_allow_proto3_optional');
 
 execFileSync(protoc, protocCommand, {stdio: 'inherit'});
 


### PR DESCRIPTION
Enable `optional` presence tracking for proto3 messages. This flag is available in protobuf release >=3.12.
See more at [field_presence.md](https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md)