### PR TITLE
fix(bazel): Remove monolith Bazel rule deps [typescript]

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -20,6 +20,14 @@ def gapic_generator_typescript_repositories():
       ],
   )
 
+  _rules_gapic_version = "0.5.4"
+  maybe(
+      http_archive,
+      name = "rules_gapic",
+      strip_prefix = "rules_gapic-%s" % _rules_gapic_version,
+      urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
+  )
+ 
   maybe(
       http_archive,
       name = "com_google_protobuf",

--- a/rules_typescript_gapic/typescript_gapic.bzl
+++ b/rules_typescript_gapic/typescript_gapic.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library", "unzipped_srcjar")
+load("@rules_gapic//:gapic.bzl", "proto_custom_library", "unzipped_srcjar")
 
 def typescript_gapic_library(
   name,

--- a/rules_typescript_gapic/typescript_gapic_pkg.bzl
+++ b/rules_typescript_gapic/typescript_gapic_pkg.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_api_codegen//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
+load("@rules_gapic//:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _typescript_gapic_src_pkg_impl(ctx):
     proto_srcs = []


### PR DESCRIPTION
This is needed for the preliminary removal of the monolith rules from googleapis' `switched_rules_by_language`.