### PR TITLE
feat: use stub for warn method in test

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -50,6 +50,7 @@ export class AssetServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -187,6 +188,9 @@ export class AssetServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -140,6 +140,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -164,6 +165,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -199,6 +201,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -224,6 +227,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -248,6 +252,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -283,6 +288,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -308,6 +314,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -332,6 +339,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -367,6 +375,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -392,6 +401,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -416,6 +426,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -451,6 +462,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -476,6 +488,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -501,6 +514,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -537,6 +551,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -563,6 +578,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -587,6 +603,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -622,6 +639,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -647,6 +665,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -672,6 +691,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -710,6 +730,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -733,6 +754,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -757,6 +779,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -775,6 +798,7 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -52,6 +52,7 @@ export class BigQueryStorageClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   bigQueryStorageStub?: Promise<{[name: string]: Function}>;
@@ -169,6 +170,9 @@ export class BigQueryStorageClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -138,6 +138,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -165,6 +166,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -203,6 +205,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -231,6 +234,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -256,6 +260,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -292,6 +297,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -318,6 +324,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -343,6 +350,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -379,6 +387,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -405,6 +414,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -430,6 +440,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -466,6 +477,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -492,6 +504,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
             request.readPosition = {};
@@ -527,6 +540,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
             request.readPosition = {};

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -52,6 +52,7 @@ export class DeprecatedServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   deprecatedServiceStub?: Promise<{[name: string]: Function}>;
 
@@ -150,6 +151,9 @@ export class DeprecatedServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**
@@ -166,7 +170,7 @@ export class DeprecatedServiceClient {
   initialize() {
     // If the client stub promise is already initialized, return immediately.
     if (this.deprecatedServiceStub) {
-      gax.warn('DEP$DeprecatedService', 'DeprecatedService is deprecated and may be removed in a future version.', 'DeprecationWarning');
+      this.warn('DEP$DeprecatedService', 'DeprecatedService is deprecated and may be removed in a future version.', 'DeprecationWarning');
       return this.deprecatedServiceStub;
     }
 
@@ -206,7 +210,7 @@ export class DeprecatedServiceClient {
 
       this.innerApiCalls[methodName] = apiCall;
     }
-    gax.warn('DEP$DeprecatedService', 'DeprecatedService is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP$DeprecatedService', 'DeprecatedService is deprecated and may be removed in a future version.', 'DeprecationWarning');
 
     return this.deprecatedServiceStub;
   }
@@ -392,7 +396,7 @@ export class DeprecatedServiceClient {
     }
     options = options || {};
     this.initialize();
-    gax.warn('DEP$DeprecatedService-$SlowFibonacci','SlowFibonacci is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP$DeprecatedService-$SlowFibonacci','SlowFibonacci is deprecated and may be removed in a future version.', 'DeprecationWarning');
     return this.innerApiCalls.slowFibonacci(request, options, callback);
   }
 

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -124,6 +124,7 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -140,6 +141,7 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -167,6 +169,7 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -184,12 +187,14 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
             client.innerApiCalls.slowFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.slowFibonacci(request);
+            assert(stub.calledOnce);
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.slowFibonacci as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
@@ -200,6 +205,7 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -217,6 +223,7 @@ describe('v1.DeprecatedServiceClient', () => {
                     });
             });
             const response = await promise;
+            assert(stub.calledOnce);
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.slowFibonacci as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
@@ -227,12 +234,14 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
             const expectedError = new Error('expected');
             client.innerApiCalls.slowFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.slowFibonacci(request), expectedError);
+            assert(stub.calledOnce);
             assert((client.innerApiCalls.slowFibonacci as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -56,6 +56,7 @@ export class EchoClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -227,6 +228,9 @@ export class EchoClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -52,6 +52,7 @@ export class IdentityClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   identityStub?: Promise<{[name: string]: Function}>;
@@ -192,6 +193,9 @@ export class IdentityClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -55,6 +55,7 @@ export class MessagingClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -228,6 +229,9 @@ export class MessagingClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -53,6 +53,7 @@ export class TestingClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   testingStub?: Promise<{[name: string]: Function}>;
@@ -195,6 +196,9 @@ export class TestingClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -220,6 +220,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -236,6 +237,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -263,6 +265,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -280,6 +283,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -296,6 +300,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -323,6 +328,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -340,6 +346,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -357,6 +364,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -387,6 +395,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -402,6 +411,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -418,6 +428,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -436,6 +447,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -452,6 +464,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -477,6 +490,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -503,6 +517,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -531,6 +546,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -559,6 +575,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -588,6 +605,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -617,6 +635,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -637,6 +656,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -668,6 +688,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -683,6 +704,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -715,6 +737,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -742,6 +765,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -765,6 +789,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -171,6 +171,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -187,6 +188,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -214,6 +216,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -231,6 +234,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -255,6 +259,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -290,6 +295,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -315,6 +321,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -340,6 +347,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -376,6 +384,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -402,6 +411,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -426,6 +436,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -461,6 +472,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -486,6 +498,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -506,6 +519,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -537,6 +551,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -552,6 +567,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedResponse = [
@@ -584,6 +600,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedError = new Error('expected');
@@ -611,6 +628,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -634,6 +652,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -220,6 +220,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -236,6 +237,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -263,6 +265,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -280,6 +283,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -304,6 +308,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -339,6 +344,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -364,6 +370,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -389,6 +396,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -425,6 +433,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -451,6 +460,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -475,6 +485,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -510,6 +521,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -535,6 +547,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -559,6 +572,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -594,6 +608,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -619,6 +634,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -643,6 +659,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -678,6 +695,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -703,6 +721,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -728,6 +747,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -764,6 +784,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -790,6 +811,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -814,6 +836,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -849,6 +872,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -874,6 +898,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -899,6 +924,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -937,6 +963,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -960,6 +987,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -984,6 +1012,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1002,6 +1031,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1018,6 +1048,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1051,6 +1082,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1085,6 +1117,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
@@ -1113,6 +1146,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
@@ -1141,6 +1175,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
@@ -1170,6 +1205,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedError = new Error('expected');
@@ -1199,6 +1235,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1219,6 +1256,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1250,6 +1288,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1265,6 +1304,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedResponse = [
@@ -1297,6 +1337,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedError = new Error('expected');
@@ -1324,6 +1365,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1347,6 +1389,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -1369,6 +1412,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1397,6 +1441,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1436,6 +1481,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1459,6 +1505,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1498,6 +1545,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1532,6 +1580,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1562,6 +1611,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -171,6 +171,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -187,6 +188,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -214,6 +216,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -231,6 +234,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -255,6 +259,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -290,6 +295,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -315,6 +321,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -339,6 +346,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -374,6 +382,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -399,6 +408,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -423,6 +433,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -458,6 +469,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -483,6 +495,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -507,6 +520,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -542,6 +556,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -567,6 +582,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -591,6 +607,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -626,6 +643,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -651,6 +669,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -671,6 +690,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -702,6 +722,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -717,6 +738,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedResponse = [
@@ -749,6 +771,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedError = new Error('expected');
@@ -776,6 +799,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -799,6 +823,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -821,6 +846,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -849,6 +875,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -888,6 +915,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -911,6 +939,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -950,6 +979,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -984,6 +1014,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1014,6 +1045,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -60,6 +60,7 @@ export class DlpServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   dlpServiceStub?: Promise<{[name: string]: Function}>;
@@ -211,6 +212,9 @@ export class DlpServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -171,6 +171,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -195,6 +196,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -230,6 +232,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -255,6 +258,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -279,6 +283,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -314,6 +319,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -339,6 +345,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -363,6 +370,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -398,6 +406,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -423,6 +432,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -447,6 +457,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -482,6 +493,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -507,6 +519,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -531,6 +544,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -566,6 +580,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -591,6 +606,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -615,6 +631,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -650,6 +667,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -675,6 +693,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -699,6 +718,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -734,6 +754,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -759,6 +780,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -783,6 +805,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -818,6 +841,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -843,6 +867,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -867,6 +892,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -902,6 +928,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -927,6 +954,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -951,6 +979,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -986,6 +1015,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -1011,6 +1041,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1035,6 +1066,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1070,6 +1102,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1095,6 +1128,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1119,6 +1153,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1154,6 +1189,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1179,6 +1215,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1203,6 +1240,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1238,6 +1276,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1263,6 +1302,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1287,6 +1327,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1322,6 +1363,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1347,6 +1389,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1371,6 +1414,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1406,6 +1450,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1431,6 +1476,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1455,6 +1501,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1490,6 +1537,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1515,6 +1563,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1539,6 +1588,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1574,6 +1624,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1599,6 +1650,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1623,6 +1675,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1658,6 +1711,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1683,6 +1737,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1707,6 +1762,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1742,6 +1798,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1767,6 +1824,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1791,6 +1849,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1826,6 +1885,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1851,6 +1911,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1875,6 +1936,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1910,6 +1972,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1935,6 +1998,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -1959,6 +2023,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -1994,6 +2059,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -2019,6 +2085,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2043,6 +2110,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2078,6 +2146,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2103,6 +2172,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2127,6 +2197,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2162,6 +2233,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2187,6 +2259,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2211,6 +2284,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2246,6 +2320,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2271,6 +2346,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2295,6 +2371,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2330,6 +2407,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2355,6 +2433,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2383,6 +2462,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2422,6 +2502,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2445,6 +2526,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2484,6 +2566,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2518,6 +2601,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2548,6 +2632,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2577,6 +2662,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2605,6 +2691,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2644,6 +2731,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2667,6 +2755,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2706,6 +2795,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2740,6 +2830,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2770,6 +2861,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2799,6 +2891,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2827,6 +2920,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2866,6 +2960,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2889,6 +2984,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2928,6 +3024,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2962,6 +3059,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2992,6 +3090,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -3021,6 +3120,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3049,6 +3149,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3088,6 +3189,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3111,6 +3213,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3150,6 +3253,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3184,6 +3288,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3214,6 +3319,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3243,6 +3349,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3271,6 +3378,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3310,6 +3418,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3333,6 +3442,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3372,6 +3482,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3406,6 +3517,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3436,6 +3548,7 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -62,6 +62,7 @@ export class KeyManagementServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   iamClient: IamClient;
   keyManagementServiceStub?: Promise<{[name: string]: Function}>;
@@ -177,6 +178,9 @@ export class KeyManagementServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -171,6 +171,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -363,6 +370,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -398,6 +406,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -423,6 +432,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -447,6 +457,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -482,6 +493,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -507,6 +519,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -531,6 +544,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -566,6 +580,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -591,6 +606,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -615,6 +631,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -650,6 +667,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -675,6 +693,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -699,6 +718,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -734,6 +754,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -759,6 +780,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -783,6 +805,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -818,6 +841,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -843,6 +867,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -867,6 +892,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -902,6 +928,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -927,6 +954,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -951,6 +979,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -986,6 +1015,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -1011,6 +1041,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1036,6 +1067,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1072,6 +1104,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1098,6 +1131,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1123,6 +1157,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1159,6 +1194,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1185,6 +1221,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1209,6 +1246,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1244,6 +1282,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1269,6 +1308,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1293,6 +1333,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1328,6 +1369,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1353,6 +1395,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1377,6 +1420,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1412,6 +1456,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1437,6 +1482,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1461,6 +1507,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1496,6 +1543,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1521,6 +1569,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1545,6 +1594,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1580,6 +1630,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1605,6 +1656,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1629,6 +1681,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1664,6 +1717,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1689,6 +1743,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1713,6 +1768,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1748,6 +1804,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1773,6 +1830,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1801,6 +1859,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1840,6 +1899,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1863,6 +1923,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1902,6 +1963,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1936,6 +1998,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1966,6 +2029,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1995,6 +2059,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2023,6 +2088,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2062,6 +2128,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2085,6 +2152,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2124,6 +2192,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2158,6 +2227,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2188,6 +2258,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2217,6 +2288,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2245,6 +2317,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2284,6 +2357,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2307,6 +2381,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2346,6 +2421,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2380,6 +2456,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2410,6 +2487,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2439,6 +2517,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2467,6 +2546,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2506,6 +2586,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2529,6 +2610,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2568,6 +2650,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2602,6 +2685,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2632,6 +2716,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2660,6 +2745,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2687,6 +2773,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2726,6 +2813,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2752,6 +2840,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2779,6 +2868,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2818,6 +2908,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2844,6 +2935,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()
@@ -2871,6 +2963,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()
@@ -2910,6 +3003,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -52,6 +52,7 @@ export class ConfigServiceV2Client {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   configServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -238,6 +239,9 @@ export class ConfigServiceV2Client {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -52,6 +52,7 @@ export class LoggingServiceV2Client {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   loggingServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -252,6 +253,9 @@ export class LoggingServiceV2Client {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -52,6 +52,7 @@ export class MetricsServiceV2Client {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   metricsServiceV2Stub?: Promise<{[name: string]: Function}>;
@@ -231,6 +232,9 @@ export class MetricsServiceV2Client {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -171,6 +171,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -363,6 +370,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -398,6 +406,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -423,6 +432,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -447,6 +457,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -482,6 +493,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -507,6 +519,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -531,6 +544,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -566,6 +580,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -591,6 +606,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -615,6 +631,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -650,6 +667,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -675,6 +693,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -699,6 +718,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -734,6 +754,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -759,6 +780,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -783,6 +805,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -818,6 +841,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -843,6 +867,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -867,6 +892,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -902,6 +928,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -927,6 +954,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -951,6 +979,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -986,6 +1015,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -1011,6 +1041,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1035,6 +1066,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1070,6 +1102,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1095,6 +1128,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1119,6 +1153,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1154,6 +1189,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1179,6 +1215,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1207,6 +1244,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1246,6 +1284,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1269,6 +1308,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1308,6 +1348,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1342,6 +1383,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1372,6 +1414,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1401,6 +1444,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1429,6 +1473,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1468,6 +1513,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1491,6 +1537,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1530,6 +1577,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1564,6 +1612,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1594,6 +1643,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1623,6 +1673,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1651,6 +1702,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1690,6 +1742,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1713,6 +1766,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1752,6 +1806,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1786,6 +1841,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1816,6 +1872,7 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -171,6 +171,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -195,6 +196,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -230,6 +232,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -255,6 +258,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -271,6 +275,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -298,6 +303,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -315,6 +321,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -335,6 +342,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -366,6 +374,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -381,6 +390,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedResponse = [
@@ -413,6 +423,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedError = new Error('expected');
@@ -440,6 +451,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -463,6 +475,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());const expectedError = new Error('expected');
             client.descriptors.page.listLogEntries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -485,6 +498,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -505,6 +519,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -536,6 +551,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -551,6 +567,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedResponse = [
@@ -583,6 +600,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedError = new Error('expected');
@@ -610,6 +628,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -633,6 +652,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -655,6 +675,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -679,6 +700,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -714,6 +736,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -737,6 +760,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -772,6 +796,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -806,6 +831,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -832,6 +858,7 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -171,6 +171,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -195,6 +196,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -230,6 +232,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -255,6 +258,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -279,6 +283,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -314,6 +319,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -339,6 +345,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -363,6 +370,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -398,6 +406,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -423,6 +432,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -447,6 +457,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -482,6 +493,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -507,6 +519,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -535,6 +548,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -574,6 +588,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -597,6 +612,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -636,6 +652,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -670,6 +687,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -700,6 +718,7 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -60,6 +60,7 @@ export class AlertPolicyServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   alertPolicyServiceStub?: Promise<{[name: string]: Function}>;
@@ -245,6 +246,9 @@ export class AlertPolicyServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -63,6 +63,7 @@ export class GroupServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   groupServiceStub?: Promise<{[name: string]: Function}>;
@@ -250,6 +251,9 @@ export class GroupServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -53,6 +53,7 @@ export class MetricServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   metricServiceStub?: Promise<{[name: string]: Function}>;
@@ -260,6 +261,9 @@ export class MetricServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -53,6 +53,7 @@ export class NotificationChannelServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   notificationChannelServiceStub?: Promise<{[name: string]: Function}>;
@@ -240,6 +241,9 @@ export class NotificationChannelServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -55,6 +55,7 @@ export class ServiceMonitoringServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   serviceMonitoringServiceStub?: Promise<{[name: string]: Function}>;
@@ -242,6 +243,9 @@ export class ServiceMonitoringServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -59,6 +59,7 @@ export class UptimeCheckServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   uptimeCheckServiceStub?: Promise<{[name: string]: Function}>;
@@ -246,6 +247,9 @@ export class UptimeCheckServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -363,6 +370,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -398,6 +406,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -423,6 +432,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -448,6 +458,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -484,6 +495,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -510,6 +522,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -538,6 +551,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -577,6 +591,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -600,6 +615,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -639,6 +655,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -673,6 +690,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -703,6 +721,7 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -364,6 +371,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -400,6 +408,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -426,6 +435,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -450,6 +460,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -485,6 +496,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -510,6 +522,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -538,6 +551,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -577,6 +591,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -600,6 +615,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -639,6 +655,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -673,6 +690,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -703,6 +721,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -732,6 +751,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -760,6 +780,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -799,6 +820,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -822,6 +844,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -861,6 +884,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -895,6 +919,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -925,6 +950,7 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -363,6 +370,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -398,6 +406,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -423,6 +432,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -447,6 +457,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -482,6 +493,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -507,6 +519,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -531,6 +544,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -566,6 +580,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -591,6 +606,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -619,6 +635,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -658,6 +675,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -681,6 +699,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -720,6 +739,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -754,6 +774,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -784,6 +805,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -813,6 +835,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -841,6 +864,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -880,6 +904,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -903,6 +928,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -942,6 +968,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -976,6 +1003,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -1006,6 +1034,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -1035,6 +1064,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1063,6 +1093,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1102,6 +1133,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1125,6 +1157,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1164,6 +1197,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1198,6 +1232,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1228,6 +1263,7 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -363,6 +370,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -398,6 +406,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -423,6 +432,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -448,6 +458,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -484,6 +495,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -510,6 +522,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -534,6 +547,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -569,6 +583,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -594,6 +609,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -618,6 +634,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -653,6 +670,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -678,6 +696,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -702,6 +721,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -737,6 +757,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -762,6 +783,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -786,6 +808,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -821,6 +844,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -846,6 +870,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -874,6 +899,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -913,6 +939,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -936,6 +963,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -975,6 +1003,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1009,6 +1038,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1039,6 +1069,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1068,6 +1099,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1096,6 +1128,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1135,6 +1168,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1158,6 +1192,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1197,6 +1232,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1231,6 +1267,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1261,6 +1298,7 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -195,6 +196,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -230,6 +232,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -255,6 +258,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -279,6 +283,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -314,6 +319,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -339,6 +345,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -364,6 +371,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -400,6 +408,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -426,6 +435,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -450,6 +460,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -485,6 +496,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -510,6 +522,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -534,6 +547,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -569,6 +583,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -594,6 +609,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -618,6 +634,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -653,6 +670,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -678,6 +696,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -703,6 +722,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -739,6 +759,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -765,6 +786,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -789,6 +811,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -824,6 +847,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -849,6 +873,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -877,6 +902,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -916,6 +942,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -939,6 +966,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -978,6 +1006,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1012,6 +1041,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1042,6 +1072,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1071,6 +1102,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1099,6 +1131,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1138,6 +1171,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1161,6 +1195,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1200,6 +1235,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1234,6 +1270,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1264,6 +1301,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -171,6 +171,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -279,6 +283,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -314,6 +319,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -339,6 +345,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -364,6 +371,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -400,6 +408,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -426,6 +435,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -450,6 +460,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -485,6 +496,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -510,6 +522,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -538,6 +551,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -577,6 +591,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -600,6 +615,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -639,6 +655,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -673,6 +690,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -703,6 +721,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -732,6 +751,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -752,6 +772,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -783,6 +804,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -798,6 +820,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedResponse = [
@@ -830,6 +853,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedError = new Error('expected');
@@ -857,6 +881,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -880,6 +905,7 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckIps.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -52,6 +52,7 @@ export class NamingClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
   namingStub?: Promise<{[name: string]: Function}>;
@@ -181,6 +182,9 @@ export class NamingClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -187,6 +187,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -203,6 +204,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -230,6 +232,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -247,6 +250,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -263,6 +267,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -290,6 +295,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -307,6 +313,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -323,6 +330,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -350,6 +358,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -367,6 +376,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -383,6 +393,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -410,6 +421,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -427,6 +439,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -443,6 +456,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -470,6 +484,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -487,6 +502,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -503,6 +519,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -530,6 +547,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -547,6 +565,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -563,6 +582,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -590,6 +610,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -607,6 +628,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -623,6 +645,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -650,6 +673,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -667,6 +691,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -683,6 +708,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -710,6 +736,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -727,6 +754,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -744,6 +772,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -774,6 +803,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -789,6 +819,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -805,6 +836,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -823,6 +855,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const expectedError = new Error('expected');
 
@@ -839,6 +872,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -859,6 +893,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -890,6 +925,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -905,6 +941,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedResponse = [
@@ -937,6 +974,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedError = new Error('expected');
@@ -964,6 +1002,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -987,6 +1026,7 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -66,6 +66,7 @@ export class CloudRedisClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -248,6 +249,9 @@ export class CloudRedisClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -187,6 +187,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -211,6 +212,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -246,6 +248,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -271,6 +274,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -296,6 +300,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -334,6 +339,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -357,6 +363,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -381,6 +388,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -399,6 +407,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -415,6 +424,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -441,6 +451,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -480,6 +491,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -504,6 +516,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -529,6 +542,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -547,6 +561,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -563,6 +578,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -588,6 +604,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -626,6 +643,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -649,6 +667,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -673,6 +692,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -691,6 +711,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -707,6 +728,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -732,6 +754,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -770,6 +793,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -793,6 +817,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -817,6 +842,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -835,6 +861,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -851,6 +878,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -876,6 +904,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -914,6 +943,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -937,6 +967,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -961,6 +992,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -979,6 +1011,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -995,6 +1028,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1020,6 +1054,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1058,6 +1093,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1081,6 +1117,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1105,6 +1142,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1123,6 +1161,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1139,6 +1178,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1167,6 +1207,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1206,6 +1247,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1229,6 +1271,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1268,6 +1311,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1302,6 +1346,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1332,6 +1377,7 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -55,6 +55,7 @@ export class EchoClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
   echoStub?: Promise<{[name: string]: Function}>;
@@ -190,6 +191,9 @@ export class EchoClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -213,6 +213,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -229,6 +230,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -256,6 +258,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -273,6 +276,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -289,6 +293,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -316,6 +321,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -333,6 +339,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -350,6 +357,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -380,6 +388,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -395,6 +404,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -411,6 +421,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -429,6 +440,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -445,6 +457,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -470,6 +483,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -496,6 +510,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -524,6 +539,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -552,6 +568,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -581,6 +598,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -610,6 +628,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -630,6 +649,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -661,6 +681,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -676,6 +697,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -708,6 +730,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -735,6 +758,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -758,6 +782,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -56,6 +56,7 @@ export class EchoClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -227,6 +228,9 @@ export class EchoClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -52,6 +52,7 @@ export class IdentityClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   identityStub?: Promise<{[name: string]: Function}>;
@@ -192,6 +193,9 @@ export class IdentityClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -55,6 +55,7 @@ export class MessagingClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -228,6 +229,9 @@ export class MessagingClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -53,6 +53,7 @@ export class TestingClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   testingStub?: Promise<{[name: string]: Function}>;
@@ -195,6 +196,9 @@ export class TestingClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -220,6 +220,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -236,6 +237,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -263,6 +265,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -280,6 +283,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -296,6 +300,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -323,6 +328,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -340,6 +346,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -357,6 +364,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -387,6 +395,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -402,6 +411,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -418,6 +428,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -436,6 +447,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -452,6 +464,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -477,6 +490,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -503,6 +517,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -531,6 +546,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -559,6 +575,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -588,6 +605,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -617,6 +635,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -637,6 +656,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -668,6 +688,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -683,6 +704,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -715,6 +737,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -742,6 +765,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -765,6 +789,7 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -171,6 +171,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -187,6 +188,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -214,6 +216,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -231,6 +234,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -255,6 +259,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -290,6 +295,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -315,6 +321,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -340,6 +347,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -376,6 +384,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -402,6 +411,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -426,6 +436,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -461,6 +472,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -486,6 +498,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -506,6 +519,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -537,6 +551,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -552,6 +567,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedResponse = [
@@ -584,6 +600,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedError = new Error('expected');
@@ -611,6 +628,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -634,6 +652,7 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -220,6 +220,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -236,6 +237,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -263,6 +265,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -280,6 +283,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -304,6 +308,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -339,6 +344,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -364,6 +370,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -389,6 +396,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -425,6 +433,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -451,6 +460,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -475,6 +485,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -510,6 +521,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -535,6 +547,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -559,6 +572,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -594,6 +608,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -619,6 +634,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -643,6 +659,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -678,6 +695,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -703,6 +721,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -728,6 +747,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -764,6 +784,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -790,6 +811,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -814,6 +836,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -849,6 +872,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -874,6 +898,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -899,6 +924,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -937,6 +963,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -960,6 +987,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -984,6 +1012,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1002,6 +1031,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1018,6 +1048,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1051,6 +1082,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1085,6 +1117,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
@@ -1113,6 +1146,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
@@ -1141,6 +1175,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
@@ -1170,6 +1205,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedError = new Error('expected');
@@ -1199,6 +1235,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1219,6 +1256,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1250,6 +1288,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1265,6 +1304,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedResponse = [
@@ -1297,6 +1337,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedError = new Error('expected');
@@ -1324,6 +1365,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1347,6 +1389,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -1369,6 +1412,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1397,6 +1441,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1436,6 +1481,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1459,6 +1505,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1498,6 +1545,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1532,6 +1580,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1562,6 +1611,7 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -171,6 +171,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -187,6 +188,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -214,6 +216,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -231,6 +234,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -255,6 +259,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -290,6 +295,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -315,6 +321,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -339,6 +346,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -374,6 +382,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -399,6 +408,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -423,6 +433,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -458,6 +469,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -483,6 +495,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -507,6 +520,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -542,6 +556,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -567,6 +582,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -591,6 +607,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -626,6 +643,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -651,6 +669,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -671,6 +690,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -702,6 +722,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -717,6 +738,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedResponse = [
@@ -749,6 +771,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedError = new Error('expected');
@@ -776,6 +799,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -799,6 +823,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -821,6 +846,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -849,6 +875,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -888,6 +915,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -911,6 +939,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -950,6 +979,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -984,6 +1014,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1014,6 +1045,7 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -53,6 +53,7 @@ export class CloudTasksClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   cloudTasksStub?: Promise<{[name: string]: Function}>;
@@ -174,6 +175,9 @@ export class CloudTasksClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -171,6 +171,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -195,6 +196,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -230,6 +232,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -255,6 +258,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -279,6 +283,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -314,6 +319,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -339,6 +345,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -364,6 +371,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -400,6 +408,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -426,6 +435,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -450,6 +460,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -485,6 +496,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -510,6 +522,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -534,6 +547,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -569,6 +583,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -594,6 +609,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -618,6 +634,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -653,6 +670,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -678,6 +696,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -702,6 +721,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -737,6 +757,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -762,6 +783,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -786,6 +808,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -821,6 +844,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -846,6 +870,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -870,6 +895,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -905,6 +931,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -930,6 +957,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -954,6 +982,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -989,6 +1018,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -1014,6 +1044,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1038,6 +1069,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1073,6 +1105,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1098,6 +1131,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1122,6 +1156,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1157,6 +1192,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1182,6 +1218,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1206,6 +1243,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1241,6 +1279,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1266,6 +1305,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1290,6 +1330,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1325,6 +1366,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1350,6 +1392,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1378,6 +1421,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1417,6 +1461,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1440,6 +1485,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1479,6 +1525,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1513,6 +1560,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1543,6 +1591,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1572,6 +1621,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1600,6 +1650,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1639,6 +1690,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1662,6 +1714,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1701,6 +1754,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1735,6 +1789,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1765,6 +1820,7 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -50,6 +50,7 @@ export class TextToSpeechClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   textToSpeechStub?: Promise<{[name: string]: Function}>;
 
@@ -148,6 +149,9 @@ export class TextToSpeechClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -124,6 +124,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -140,6 +141,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -167,6 +169,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -184,6 +187,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};
@@ -200,6 +204,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};
@@ -227,6 +232,7 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -52,6 +52,7 @@ export class TranslationServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
   operationsClient: gax.OperationsClient;
@@ -210,6 +211,9 @@ export class TranslationServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -187,6 +187,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -211,6 +212,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -246,6 +248,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -271,6 +274,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -295,6 +299,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -330,6 +335,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -355,6 +361,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -379,6 +386,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -414,6 +422,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -439,6 +448,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -463,6 +473,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -498,6 +509,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -523,6 +535,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -548,6 +561,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -586,6 +600,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -609,6 +624,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -633,6 +649,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -651,6 +668,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -667,6 +685,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -692,6 +711,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -730,6 +750,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -753,6 +774,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -777,6 +799,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -795,6 +818,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -811,6 +835,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -836,6 +861,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -874,6 +900,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -897,6 +924,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -921,6 +949,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -939,6 +968,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -955,6 +985,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -983,6 +1014,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1022,6 +1054,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1045,6 +1078,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1084,6 +1118,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1118,6 +1153,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1148,6 +1184,7 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -50,6 +50,7 @@ export class VideoIntelligenceServiceClient {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   operationsClient: gax.OperationsClient;
   videoIntelligenceServiceStub?: Promise<{[name: string]: Function}>;
@@ -171,6 +172,9 @@ export class VideoIntelligenceServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -136,6 +136,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -153,6 +154,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -183,6 +185,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -198,6 +201,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -214,6 +218,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -232,6 +237,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -73,6 +73,7 @@ export class {{ service.name }}Client {
     longrunning: {},
     batching: {},
   };
+  warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   {%- if service.iamService > 0 %}
   iamClient: IamClient;
@@ -326,6 +327,9 @@ export class {{ service.name }}Client {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this.innerApiCalls = {};
+
+    // Add a warn function to the client constructor so it can be easily tested.
+    this.warn = gax.warn;
   }
 
   /**
@@ -343,7 +347,7 @@ export class {{ service.name }}Client {
     // If the client stub promise is already initialized, return immediately.
     if (this.{{ service.name.toCamelCase() }}Stub) {
       {%- if service.options and service.options.deprecated %}
-      gax.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+      this.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
       {%- endif %}
       return this.{{ service.name.toCamelCase() }}Stub;
     }
@@ -405,7 +409,7 @@ export class {{ service.name }}Client {
       this.innerApiCalls[methodName] = apiCall;
     }
     {%- if service.options and service.options.deprecated %}
-    gax.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
 
     return this.{{ service.name.toCamelCase() }}Stub;
@@ -527,7 +531,7 @@ export class {{ service.name }}Client {
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
@@ -545,7 +549,7 @@ export class {{ service.name }}Client {
     gax.CancellableStream {
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(options);
   }
@@ -564,7 +568,7 @@ export class {{ service.name }}Client {
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options);
   }
@@ -605,7 +609,7 @@ export class {{ service.name }}Client {
     const options = optionsOrCallback as CallOptions;
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(null, options, callback);
   }
@@ -664,7 +668,7 @@ export class {{ service.name }}Client {
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
@@ -737,7 +741,7 @@ export class {{ service.name }}Client {
     {{ util.buildHeaderRequestParam(method) }}
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
   }
@@ -757,7 +761,7 @@ export class {{ service.name }}Client {
     const callSettings = new gax.CallSettings(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.descriptors.page.{{ method.name.toCamelCase() }}.createStream(
       this.innerApiCalls.{{ method.name.toCamelCase() }} as gax.GaxCall,
@@ -782,7 +786,7 @@ export class {{ service.name }}Client {
     const callSettings = new gax.CallSettings(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
-    gax.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
+    this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate(
       this.innerApiCalls['{{ method.name.toCamelCase() }}'] as GaxCall,

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -247,12 +247,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
@@ -263,6 +267,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -280,6 +285,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                     });
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
@@ -290,12 +298,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -309,6 +321,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -316,6 +329,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(expectedResponse);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
             const [response] = await operation.promise();
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
@@ -326,6 +342,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -346,6 +363,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             });
             const operation = await promise as LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>;
             const [response] = await operation.promise();
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
@@ -356,12 +376,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -371,6 +395,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -378,6 +403,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
             await assert.rejects(operation.promise(), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -387,6 +415,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -395,6 +424,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
 
             client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
             const decodedOperation = await client.{{ id.get("check" + method.name.toPascalCase() + "Progress") }}(expectedResponse.name);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
             assert(decodedOperation.metadata);
             assert((client.operationsClient.getOperation as SinonStub).getCall(0));
@@ -405,11 +437,15 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const expectedError = new Error('expected');
 
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ id.get("check" + method.name.toPascalCase() + "Progress") }}(''), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0));
         });
@@ -423,6 +459,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -438,6 +475,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 });
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions));
@@ -448,6 +488,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -463,6 +504,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions));
         });
@@ -476,6 +520,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
@@ -492,6 +537,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 stream.end();
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWithExactly(undefined));
@@ -504,6 +552,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
@@ -520,6 +569,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 stream.end();
             });
             await assert.rejects(promise, expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWithExactly(undefined));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
@@ -535,6 +587,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
@@ -553,6 +606,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 stream.end();
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(null, {} /*, callback defined above */));
@@ -564,6 +620,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
@@ -582,6 +639,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 stream.end();
             });
             await assert.rejects(promise, expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(null, {} /*, callback defined above */));
         });
@@ -595,12 +655,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
@@ -611,6 +675,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -628,6 +693,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                     });
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
@@ -638,12 +706,16 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -653,6 +725,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             {{ util.initPagingResponse(method) }}
@@ -671,6 +744,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 });
             });
             const responses = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase() }}, request));
@@ -688,6 +764,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
@@ -706,6 +783,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase() }}, request));
 {%- if method.headerRequestParams.length > 0 %}
@@ -722,6 +802,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initPagingResponse(method) }}
@@ -731,6 +812,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             for await (const resource of iterable) {
                 responses.push(resource!);
             }
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(responses, expectedResponse);
             assert.deepStrictEqual(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
@@ -749,6 +833,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
@@ -760,6 +845,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                     responses.push(resource!);
                 }
             });
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
@@ -782,6 +870,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
@@ -804,6 +893,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             );
             client.iamClient.{{ method }} = stubSimpleCall(expectedResponse);
             const response = await client.{{ method }}(request, expectedOptions);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.iamClient.{{ method }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
@@ -813,6 +905,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
@@ -851,6 +944,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                     });
             });
             const response = await promise;
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.iamClient.{{ method }} as SinonStub)
                 .getCall(0));
@@ -860,6 +956,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            const stub = sinon.stub(client, 'warn');
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
@@ -876,6 +973,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const expectedError = new Error('expected');
             client.iamClient.{{ method }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method }}(request, expectedOptions), expectedError);
+            {%- if method.options and method.options.deprecated %}
+            assert(stub.calledOnce);
+            {%- endif %}
             assert((client.iamClient.{{ method }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });


### PR DESCRIPTION
Fix for Issue googleapis/google-cloud-node-core#614

Update deprecation warning to use sinon stub instead of gax.warn in the test file.