### PR TITLE
fix: multiple proto listing for legacy loading

### DIFF
--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -140,8 +140,7 @@ export class EchoClient {
         {},
         this._gaxGrpc.loadProto(
             path.join(__dirname, '..', '..', 'protos'),
-            'google/showcase/v1beta1/echo.proto')
-    );
+            'google/showcase/v1beta1/echo.proto'));
 
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -202,8 +202,9 @@ export class {{ service.name }}Client {
         this._gaxGrpc.loadProto(
             path.join(__dirname, '..', '..', 'protos'),
             '{{ filename }}')
+{%- endfor -%}
     );
-{%- endfor -%}{%- else %}
+{%- else %}
     this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
 {%- endif %}
 


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#607. Cc: @aohren 

If there are multiple protos to be listed, make sure we use the correct joiner (a comma).