### PR TITLE
fix: only invoke stub for methods that are deprecated

### DIFF
--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -140,7 +140,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -165,7 +164,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -201,7 +199,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
             request.parent = '';
@@ -227,7 +224,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -252,7 +248,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -288,7 +283,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
             request.parent = '';
@@ -314,7 +308,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -339,7 +332,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -375,7 +367,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
             request.name = '';
@@ -401,7 +392,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -426,7 +416,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -462,7 +451,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
             request.parent = '';
@@ -488,7 +476,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -514,7 +501,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -551,7 +537,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
             request.feed = {};
@@ -578,7 +563,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -603,7 +587,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -639,7 +622,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
             request.name = '';
@@ -665,7 +647,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -691,7 +672,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -730,7 +710,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -754,7 +733,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
             request.parent = '';
@@ -779,7 +757,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -798,7 +775,6 @@ describe('v1.AssetServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -138,7 +138,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -166,7 +165,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -205,7 +203,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
             request.tableReference = {};
@@ -234,7 +231,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -260,7 +256,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -297,7 +292,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
             request.session = {};
@@ -324,7 +318,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -350,7 +343,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -387,7 +379,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
             request.stream = {};
@@ -414,7 +405,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -440,7 +430,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -477,7 +466,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
             request.originalStream = {};
@@ -504,7 +492,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
             request.readPosition = {};
@@ -540,7 +527,6 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
             request.readPosition = {};

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -124,7 +124,6 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -141,7 +140,6 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};
@@ -169,7 +167,6 @@ describe('v1.DeprecatedServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
             const expectedOptions = {};

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -220,7 +220,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -237,7 +236,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -265,7 +263,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -283,7 +280,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -300,7 +296,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -328,7 +323,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -346,7 +340,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -364,7 +357,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -395,7 +387,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -411,7 +402,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -428,7 +418,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -447,7 +436,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -464,7 +452,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -490,7 +477,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -517,7 +503,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -546,7 +531,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -575,7 +559,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -605,7 +588,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -635,7 +617,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -656,7 +637,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -688,7 +668,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -704,7 +683,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -737,7 +715,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -765,7 +742,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -789,7 +765,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -171,7 +171,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -188,7 +187,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -216,7 +214,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -234,7 +231,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -259,7 +255,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -295,7 +290,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -321,7 +315,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -347,7 +340,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -384,7 +376,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -411,7 +402,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -436,7 +426,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -472,7 +461,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -498,7 +486,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -519,7 +506,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -551,7 +537,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -567,7 +552,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedResponse = [
@@ -600,7 +584,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedError = new Error('expected');
@@ -628,7 +611,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -652,7 +634,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -220,7 +220,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -237,7 +236,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -265,7 +263,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -283,7 +280,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -308,7 +304,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -344,7 +339,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -370,7 +364,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -396,7 +389,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -433,7 +425,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -460,7 +451,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -485,7 +475,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -521,7 +510,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -547,7 +535,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -572,7 +559,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -608,7 +594,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -634,7 +619,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -659,7 +643,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -695,7 +678,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -721,7 +703,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -747,7 +728,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -784,7 +764,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -811,7 +790,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -836,7 +814,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -872,7 +849,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -898,7 +874,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -924,7 +899,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -963,7 +937,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -987,7 +960,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -1012,7 +984,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1031,7 +1002,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1048,7 +1018,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1082,7 +1051,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1117,7 +1085,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
@@ -1146,7 +1113,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
@@ -1175,7 +1141,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
@@ -1205,7 +1170,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedError = new Error('expected');
@@ -1235,7 +1199,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1256,7 +1219,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1288,7 +1250,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1304,7 +1265,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedResponse = [
@@ -1337,7 +1297,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedError = new Error('expected');
@@ -1365,7 +1324,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1389,7 +1347,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -1412,7 +1369,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1441,7 +1397,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1481,7 +1436,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1505,7 +1459,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1545,7 +1498,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1580,7 +1532,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1611,7 +1562,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -171,7 +171,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -188,7 +187,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -216,7 +214,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -234,7 +231,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -259,7 +255,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -295,7 +290,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -321,7 +315,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -346,7 +339,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -382,7 +374,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -408,7 +399,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -433,7 +423,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -469,7 +458,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -495,7 +483,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -520,7 +507,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -556,7 +542,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -582,7 +567,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -607,7 +591,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -643,7 +626,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -669,7 +651,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -690,7 +671,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -722,7 +702,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -738,7 +717,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedResponse = [
@@ -771,7 +749,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedError = new Error('expected');
@@ -799,7 +776,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -823,7 +799,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -846,7 +821,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -875,7 +849,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -915,7 +888,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -939,7 +911,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -979,7 +950,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1014,7 +984,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1045,7 +1014,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -171,7 +171,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -196,7 +195,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -232,7 +230,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
             request.parent = '';
@@ -258,7 +255,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -283,7 +279,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -319,7 +314,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
             request.parent = '';
@@ -345,7 +339,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -370,7 +363,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -406,7 +398,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
             request.parent = '';
@@ -432,7 +423,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -457,7 +447,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -493,7 +482,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
             request.parent = '';
@@ -519,7 +507,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -544,7 +531,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -580,7 +566,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
             request.locationId = '';
@@ -606,7 +591,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -631,7 +615,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -667,7 +650,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
             request.parent = '';
@@ -693,7 +675,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -718,7 +699,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -754,7 +734,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
             request.name = '';
@@ -780,7 +759,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -805,7 +783,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -841,7 +818,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
             request.name = '';
@@ -867,7 +843,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -892,7 +867,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -928,7 +902,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
             request.name = '';
@@ -954,7 +927,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -979,7 +951,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -1015,7 +986,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
             request.parent = '';
@@ -1041,7 +1011,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1066,7 +1035,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1102,7 +1070,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
             request.name = '';
@@ -1128,7 +1095,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1153,7 +1119,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1189,7 +1154,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
             request.name = '';
@@ -1215,7 +1179,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1240,7 +1203,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1276,7 +1238,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
             request.name = '';
@@ -1302,7 +1263,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1327,7 +1287,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1363,7 +1322,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
             request.parent = '';
@@ -1389,7 +1347,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1414,7 +1371,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1450,7 +1406,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
             request.name = '';
@@ -1476,7 +1431,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1501,7 +1455,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1537,7 +1490,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
             request.name = '';
@@ -1563,7 +1515,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1588,7 +1539,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1624,7 +1574,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
             request.name = '';
@@ -1650,7 +1599,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1675,7 +1623,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1711,7 +1658,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
             request.name = '';
@@ -1737,7 +1683,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1762,7 +1707,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1798,7 +1742,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
             request.parent = '';
@@ -1824,7 +1767,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1849,7 +1791,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1885,7 +1826,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
             request.name = '';
@@ -1911,7 +1851,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1936,7 +1875,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1972,7 +1910,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
             request.name = '';
@@ -1998,7 +1935,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -2023,7 +1959,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -2059,7 +1994,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
             request.name = '';
@@ -2085,7 +2019,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2110,7 +2043,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2146,7 +2078,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
             request.parent = '';
@@ -2172,7 +2103,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2197,7 +2127,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2233,7 +2162,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
             request.name = '';
@@ -2259,7 +2187,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2284,7 +2211,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2320,7 +2246,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
             request.name = '';
@@ -2346,7 +2271,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2371,7 +2295,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2407,7 +2330,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
             request.name = '';
@@ -2433,7 +2355,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2462,7 +2383,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2502,7 +2422,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2526,7 +2445,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2566,7 +2484,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2601,7 +2518,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2632,7 +2548,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
             request.parent = '';
@@ -2662,7 +2577,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2691,7 +2605,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2731,7 +2644,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2755,7 +2667,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2795,7 +2706,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2830,7 +2740,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2861,7 +2770,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
             request.parent = '';
@@ -2891,7 +2799,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2920,7 +2827,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2960,7 +2866,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -2984,7 +2889,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -3024,7 +2928,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -3059,7 +2962,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -3090,7 +2992,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
             request.parent = '';
@@ -3120,7 +3021,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3149,7 +3049,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3189,7 +3088,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3213,7 +3111,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3253,7 +3150,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3288,7 +3184,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3319,7 +3214,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
             request.parent = '';
@@ -3349,7 +3243,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3378,7 +3271,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3418,7 +3310,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3442,7 +3333,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3482,7 +3372,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3517,7 +3406,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';
@@ -3548,7 +3436,6 @@ describe('v2.DlpServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
             request.parent = '';

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -171,7 +171,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -370,7 +363,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -406,7 +398,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
             request.name = '';
@@ -432,7 +423,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -457,7 +447,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -493,7 +482,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
             request.name = '';
@@ -519,7 +507,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -544,7 +531,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -580,7 +566,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
             request.name = '';
@@ -606,7 +591,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -631,7 +615,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -667,7 +650,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
             request.parent = '';
@@ -693,7 +675,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -718,7 +699,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -754,7 +734,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
             request.parent = '';
@@ -780,7 +759,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -805,7 +783,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -841,7 +818,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
             request.parent = '';
@@ -867,7 +843,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -892,7 +867,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -928,7 +902,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
             request.parent = '';
@@ -954,7 +927,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -979,7 +951,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -1015,7 +986,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
             request.parent = '';
@@ -1041,7 +1011,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1067,7 +1036,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1104,7 +1072,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
             request.cryptoKey = {};
@@ -1131,7 +1098,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1157,7 +1123,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1194,7 +1159,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
             request.cryptoKeyVersion = {};
@@ -1221,7 +1185,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1246,7 +1209,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1282,7 +1244,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
             request.name = '';
@@ -1308,7 +1269,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1333,7 +1293,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1369,7 +1328,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
             request.name = '';
@@ -1395,7 +1353,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1420,7 +1377,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1456,7 +1412,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
             request.name = '';
@@ -1482,7 +1437,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1507,7 +1461,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1543,7 +1496,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
             request.name = '';
@@ -1569,7 +1521,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1594,7 +1545,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1630,7 +1580,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
             request.name = '';
@@ -1656,7 +1605,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1681,7 +1629,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1717,7 +1664,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
             request.name = '';
@@ -1743,7 +1689,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1768,7 +1713,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1804,7 +1748,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
             request.name = '';
@@ -1830,7 +1773,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1859,7 +1801,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1899,7 +1840,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1923,7 +1863,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1963,7 +1902,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -1998,7 +1936,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -2029,7 +1966,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
             request.parent = '';
@@ -2059,7 +1995,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2088,7 +2023,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2128,7 +2062,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2152,7 +2085,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2192,7 +2124,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2227,7 +2158,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2258,7 +2188,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
             request.parent = '';
@@ -2288,7 +2217,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2317,7 +2245,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2357,7 +2284,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2381,7 +2307,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2421,7 +2346,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2456,7 +2380,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2487,7 +2410,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
             request.parent = '';
@@ -2517,7 +2439,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2546,7 +2467,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2586,7 +2506,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2610,7 +2529,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2650,7 +2568,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2685,7 +2602,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2716,7 +2632,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
             request.parent = '';
@@ -2745,7 +2660,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2773,7 +2687,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2813,7 +2726,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.GetIamPolicyRequest()
@@ -2840,7 +2752,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2868,7 +2779,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2908,7 +2818,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.SetIamPolicyRequest()
@@ -2935,7 +2844,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()
@@ -2963,7 +2871,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()
@@ -3003,7 +2910,6 @@ describe('v1.KeyManagementServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.TestIamPermissionsRequest()

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -171,7 +171,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -370,7 +363,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -406,7 +398,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
             request.sinkName = '';
@@ -432,7 +423,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -457,7 +447,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -493,7 +482,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
             request.parent = '';
@@ -519,7 +507,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -544,7 +531,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -580,7 +566,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
             request.sinkName = '';
@@ -606,7 +591,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -631,7 +615,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -667,7 +650,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
             request.sinkName = '';
@@ -693,7 +675,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -718,7 +699,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -754,7 +734,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
             request.name = '';
@@ -780,7 +759,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -805,7 +783,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -841,7 +818,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
             request.parent = '';
@@ -867,7 +843,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -892,7 +867,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -928,7 +902,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
             request.name = '';
@@ -954,7 +927,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -979,7 +951,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -1015,7 +986,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
             request.name = '';
@@ -1041,7 +1011,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1066,7 +1035,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1102,7 +1070,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
             request.name = '';
@@ -1128,7 +1095,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1153,7 +1119,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1189,7 +1154,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
             request.name = '';
@@ -1215,7 +1179,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1244,7 +1207,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1284,7 +1246,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1308,7 +1269,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1348,7 +1308,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1383,7 +1342,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1414,7 +1372,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
             request.parent = '';
@@ -1444,7 +1401,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1473,7 +1429,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1513,7 +1468,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1537,7 +1491,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1577,7 +1530,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1612,7 +1564,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1643,7 +1594,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
             request.parent = '';
@@ -1673,7 +1623,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1702,7 +1651,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1742,7 +1690,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1766,7 +1713,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1806,7 +1752,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1841,7 +1786,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';
@@ -1872,7 +1816,6 @@ describe('v2.ConfigServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
             request.parent = '';

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -171,7 +171,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -196,7 +195,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -232,7 +230,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
             request.logName = '';
@@ -258,7 +255,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -275,7 +271,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -303,7 +298,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
             const expectedOptions = {};
@@ -321,7 +315,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -342,7 +335,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -374,7 +366,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedOptions = {};
@@ -390,7 +381,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedResponse = [
@@ -423,7 +413,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
             const expectedError = new Error('expected');
@@ -451,7 +440,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -475,7 +463,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());const expectedError = new Error('expected');
             client.descriptors.page.listLogEntries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -498,7 +485,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -519,7 +505,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -551,7 +536,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedOptions = {};
@@ -567,7 +551,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedResponse = [
@@ -600,7 +583,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
             const expectedError = new Error('expected');
@@ -628,7 +610,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -652,7 +633,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -675,7 +655,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -700,7 +679,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -736,7 +714,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -760,7 +737,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -796,7 +772,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -831,7 +806,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';
@@ -858,7 +832,6 @@ describe('v2.LoggingServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
             request.parent = '';

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -171,7 +171,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -196,7 +195,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -232,7 +230,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
             request.metricName = '';
@@ -258,7 +255,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -283,7 +279,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -319,7 +314,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
             request.parent = '';
@@ -345,7 +339,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -370,7 +363,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -406,7 +398,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
             request.metricName = '';
@@ -432,7 +423,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -457,7 +447,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -493,7 +482,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
             request.metricName = '';
@@ -519,7 +507,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -548,7 +535,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -588,7 +574,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -612,7 +597,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -652,7 +636,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -687,7 +670,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';
@@ -718,7 +700,6 @@ describe('v2.MetricsServiceV2Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
             request.parent = '';

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -370,7 +363,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -406,7 +398,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
             request.name = '';
@@ -432,7 +423,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -458,7 +448,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -495,7 +484,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
             request.alertPolicy = {};
@@ -522,7 +510,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -551,7 +538,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -591,7 +577,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -615,7 +600,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -655,7 +639,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -690,7 +673,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';
@@ -721,7 +703,6 @@ describe('v3.AlertPolicyServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -371,7 +364,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -408,7 +400,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
             request.group = {};
@@ -435,7 +426,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -460,7 +450,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -496,7 +485,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
             request.name = '';
@@ -522,7 +510,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -551,7 +538,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -591,7 +577,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -615,7 +600,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -655,7 +639,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -690,7 +673,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -721,7 +703,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
             request.name = '';
@@ -751,7 +732,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -780,7 +760,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -820,7 +799,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -844,7 +822,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -884,7 +861,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -919,7 +895,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';
@@ -950,7 +925,6 @@ describe('v3.GroupServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -370,7 +363,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -406,7 +398,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
             request.name = '';
@@ -432,7 +423,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -457,7 +447,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -493,7 +482,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
             request.name = '';
@@ -519,7 +507,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -544,7 +531,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -580,7 +566,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
             request.name = '';
@@ -606,7 +591,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -635,7 +619,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -675,7 +658,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -699,7 +681,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -739,7 +720,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -774,7 +754,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -805,7 +784,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
             request.name = '';
@@ -835,7 +813,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -864,7 +841,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -904,7 +880,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -928,7 +903,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -968,7 +942,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -1003,7 +976,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -1034,7 +1006,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
             request.name = '';
@@ -1064,7 +1035,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1093,7 +1063,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1133,7 +1102,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1157,7 +1125,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1197,7 +1164,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1232,7 +1198,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';
@@ -1263,7 +1228,6 @@ describe('v3.MetricServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -370,7 +363,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -406,7 +398,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
             request.name = '';
@@ -432,7 +423,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -458,7 +448,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -495,7 +484,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
             request.notificationChannel = {};
@@ -522,7 +510,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -547,7 +534,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -583,7 +569,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
             request.name = '';
@@ -609,7 +594,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -634,7 +618,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -670,7 +653,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -696,7 +678,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -721,7 +702,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -757,7 +737,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
             request.name = '';
@@ -783,7 +762,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -808,7 +786,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -844,7 +821,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
             request.name = '';
@@ -870,7 +846,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -899,7 +874,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -939,7 +913,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -963,7 +936,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1003,7 +975,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1038,7 +1009,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1069,7 +1039,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
             request.name = '';
@@ -1099,7 +1068,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1128,7 +1096,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1168,7 +1135,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1192,7 +1158,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1232,7 +1197,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1267,7 +1231,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';
@@ -1298,7 +1261,6 @@ describe('v3.NotificationChannelServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
             request.name = '';

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -196,7 +195,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -232,7 +230,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
             request.parent = '';
@@ -258,7 +255,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -283,7 +279,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -319,7 +314,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
             request.name = '';
@@ -345,7 +339,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -371,7 +364,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -408,7 +400,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
             request.service = {};
@@ -435,7 +426,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -460,7 +450,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -496,7 +485,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
             request.name = '';
@@ -522,7 +510,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -547,7 +534,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -583,7 +569,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
             request.parent = '';
@@ -609,7 +594,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -634,7 +618,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -670,7 +653,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
             request.name = '';
@@ -696,7 +678,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -722,7 +703,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -759,7 +739,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
             request.serviceLevelObjective = {};
@@ -786,7 +765,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -811,7 +789,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -847,7 +824,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
             request.name = '';
@@ -873,7 +849,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -902,7 +877,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -942,7 +916,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -966,7 +939,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1006,7 +978,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1041,7 +1012,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1072,7 +1042,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
             request.parent = '';
@@ -1102,7 +1071,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1131,7 +1099,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1171,7 +1138,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1195,7 +1161,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1235,7 +1200,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1270,7 +1234,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';
@@ -1301,7 +1264,6 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
             request.parent = '';

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -171,7 +171,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -283,7 +279,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -319,7 +314,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
             request.parent = '';
@@ -345,7 +339,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -371,7 +364,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -408,7 +400,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
             request.uptimeCheckConfig = {};
@@ -435,7 +426,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -460,7 +450,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -496,7 +485,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
             request.name = '';
@@ -522,7 +510,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -551,7 +538,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -591,7 +577,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -615,7 +600,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -655,7 +639,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -690,7 +673,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -721,7 +703,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
             request.parent = '';
@@ -751,7 +732,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -772,7 +752,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -804,7 +783,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedOptions = {};
@@ -820,7 +798,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedResponse = [
@@ -853,7 +830,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
             const expectedError = new Error('expected');
@@ -881,7 +857,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -905,7 +880,6 @@ describe('v3.UptimeCheckServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckIps.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -187,7 +187,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -204,7 +203,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -232,7 +230,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -250,7 +247,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -267,7 +263,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -295,7 +290,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -313,7 +307,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -330,7 +323,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -358,7 +350,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -376,7 +367,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -393,7 +383,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -421,7 +410,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -439,7 +427,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -456,7 +443,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -484,7 +470,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -502,7 +487,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -519,7 +503,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -547,7 +530,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -565,7 +547,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -582,7 +563,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -610,7 +590,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -628,7 +607,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -645,7 +623,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -673,7 +650,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -691,7 +667,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -708,7 +683,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -736,7 +710,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -754,7 +727,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -772,7 +744,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -803,7 +774,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -819,7 +789,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {};
@@ -836,7 +805,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -855,7 +823,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const expectedError = new Error('expected');
 
@@ -872,7 +839,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -893,7 +859,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -925,7 +890,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedOptions = {};
@@ -941,7 +905,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedResponse = [
@@ -974,7 +937,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
             const expectedError = new Error('expected');
@@ -1002,7 +964,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1026,7 +987,6 @@ describe('v1beta1.NamingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize1();
             const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -187,7 +187,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -212,7 +211,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -248,7 +246,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
             request.name = '';
@@ -274,7 +271,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -300,7 +296,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -339,7 +334,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -363,7 +357,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
             request.parent = '';
@@ -388,7 +381,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -407,7 +399,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -424,7 +415,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -451,7 +441,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -491,7 +480,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -516,7 +504,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
             request.instance = {};
@@ -542,7 +529,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -561,7 +547,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -578,7 +563,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -604,7 +588,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -643,7 +626,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -667,7 +649,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
             request.name = '';
@@ -692,7 +673,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -711,7 +691,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -728,7 +707,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -754,7 +732,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -793,7 +770,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -817,7 +793,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
             request.name = '';
@@ -842,7 +817,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -861,7 +835,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -878,7 +851,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -904,7 +876,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -943,7 +914,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -967,7 +937,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
             request.name = '';
@@ -992,7 +961,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1011,7 +979,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1028,7 +995,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1054,7 +1020,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1093,7 +1058,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1117,7 +1081,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
             request.name = '';
@@ -1142,7 +1105,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1161,7 +1123,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1178,7 +1139,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1207,7 +1167,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1247,7 +1206,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1271,7 +1229,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1311,7 +1268,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1346,7 +1302,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';
@@ -1377,7 +1332,6 @@ describe('v1beta1.CloudRedisClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
             request.parent = '';

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -213,7 +213,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -230,7 +229,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -258,7 +256,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -276,7 +273,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -293,7 +289,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -321,7 +316,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -339,7 +333,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -357,7 +350,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -388,7 +380,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -404,7 +395,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -421,7 +411,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -440,7 +429,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -457,7 +445,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -483,7 +470,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -510,7 +496,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -539,7 +524,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -568,7 +552,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -598,7 +581,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -628,7 +610,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -649,7 +630,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -681,7 +661,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -697,7 +676,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -730,7 +708,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -758,7 +735,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -782,7 +758,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -220,7 +220,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -237,7 +236,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -265,7 +263,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedOptions = {};
@@ -283,7 +280,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -300,7 +296,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -328,7 +323,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
             const expectedOptions = {};
@@ -346,7 +340,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -364,7 +357,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -395,7 +387,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -411,7 +402,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
             const expectedOptions = {};
@@ -428,7 +418,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -447,7 +436,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -464,7 +452,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -490,7 +477,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
             const expectedOptions = {};
@@ -517,7 +503,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -546,7 +531,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
@@ -575,7 +559,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
@@ -605,7 +588,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
             const expectedError = new Error('expected');
@@ -635,7 +617,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -656,7 +637,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -688,7 +668,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedOptions = {};
@@ -704,7 +683,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedResponse = [
@@ -737,7 +715,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
             const expectedError = new Error('expected');
@@ -765,7 +742,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -789,7 +765,6 @@ describe('v1beta1.EchoClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -171,7 +171,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -188,7 +187,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -216,7 +214,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
             const expectedOptions = {};
@@ -234,7 +231,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -259,7 +255,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -295,7 +290,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
             request.name = '';
@@ -321,7 +315,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -347,7 +340,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -384,7 +376,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
             request.user = {};
@@ -411,7 +402,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -436,7 +426,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -472,7 +461,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
             request.name = '';
@@ -498,7 +486,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -519,7 +506,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -551,7 +537,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedOptions = {};
@@ -567,7 +552,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedResponse = [
@@ -600,7 +584,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
             const expectedError = new Error('expected');
@@ -628,7 +611,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -652,7 +634,6 @@ describe('v1beta1.IdentityClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -220,7 +220,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -237,7 +236,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -265,7 +263,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
             const expectedOptions = {};
@@ -283,7 +280,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -308,7 +304,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -344,7 +339,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
             request.name = '';
@@ -370,7 +364,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -396,7 +389,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -433,7 +425,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
             request.room = {};
@@ -460,7 +451,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -485,7 +475,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -521,7 +510,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
             request.name = '';
@@ -547,7 +535,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -572,7 +559,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -608,7 +594,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             request.parent = '';
@@ -634,7 +619,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -659,7 +643,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -695,7 +678,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
             request.name = '';
@@ -721,7 +703,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -747,7 +728,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -784,7 +764,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
             request.blurb = {};
@@ -811,7 +790,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -836,7 +814,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -872,7 +849,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
             request.name = '';
@@ -898,7 +874,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -924,7 +899,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -963,7 +937,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -987,7 +960,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
             request.parent = '';
@@ -1012,7 +984,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -1031,7 +1002,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -1048,7 +1018,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1082,7 +1051,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
             request.name = '';
@@ -1117,7 +1085,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
@@ -1146,7 +1113,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
@@ -1175,7 +1141,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
@@ -1205,7 +1170,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
             const expectedError = new Error('expected');
@@ -1235,7 +1199,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1256,7 +1219,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1288,7 +1250,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedOptions = {};
@@ -1304,7 +1265,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedResponse = [
@@ -1337,7 +1297,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
             const expectedError = new Error('expected');
@@ -1365,7 +1324,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1389,7 +1347,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -1412,7 +1369,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1441,7 +1397,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1481,7 +1436,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1505,7 +1459,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1545,7 +1498,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1580,7 +1532,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';
@@ -1611,7 +1562,6 @@ describe('v1beta1.MessagingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
             request.parent = '';

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -171,7 +171,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -188,7 +187,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -216,7 +214,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
             const expectedOptions = {};
@@ -234,7 +231,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -259,7 +255,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -295,7 +290,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
             request.name = '';
@@ -321,7 +315,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -346,7 +339,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -382,7 +374,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
             request.name = '';
@@ -408,7 +399,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -433,7 +423,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -469,7 +458,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
             request.name = '';
@@ -495,7 +483,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -520,7 +507,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -556,7 +542,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
             request.name = '';
@@ -582,7 +567,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -607,7 +591,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -643,7 +626,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
             request.name = '';
@@ -669,7 +651,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -690,7 +671,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -722,7 +702,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedOptions = {};
@@ -738,7 +717,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedResponse = [
@@ -771,7 +749,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
             const expectedError = new Error('expected');
@@ -799,7 +776,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -823,7 +799,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
@@ -846,7 +821,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -875,7 +849,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -915,7 +888,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -939,7 +911,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -979,7 +950,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1014,7 +984,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';
@@ -1045,7 +1014,6 @@ describe('v1beta1.TestingClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
             request.parent = '';

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -171,7 +171,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -196,7 +195,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -232,7 +230,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
             request.name = '';
@@ -258,7 +255,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -283,7 +279,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -319,7 +314,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
             request.parent = '';
@@ -345,7 +339,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -371,7 +364,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -408,7 +400,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
             request.queue = {};
@@ -435,7 +426,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -460,7 +450,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -496,7 +485,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
             request.name = '';
@@ -522,7 +510,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -547,7 +534,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -583,7 +569,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
             request.name = '';
@@ -609,7 +594,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -634,7 +618,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -670,7 +653,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
             request.name = '';
@@ -696,7 +678,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -721,7 +702,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -757,7 +737,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
             request.name = '';
@@ -783,7 +762,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -808,7 +786,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -844,7 +821,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
             request.resource = '';
@@ -870,7 +846,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -895,7 +870,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -931,7 +905,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
             request.resource = '';
@@ -957,7 +930,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -982,7 +954,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -1018,7 +989,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
             request.resource = '';
@@ -1044,7 +1014,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1069,7 +1038,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1105,7 +1073,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
             request.name = '';
@@ -1131,7 +1098,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1156,7 +1122,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1192,7 +1157,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
             request.parent = '';
@@ -1218,7 +1182,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1243,7 +1206,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1279,7 +1241,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
             request.name = '';
@@ -1305,7 +1266,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1330,7 +1290,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1366,7 +1325,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
             request.name = '';
@@ -1392,7 +1350,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1421,7 +1378,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1461,7 +1417,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1485,7 +1440,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1525,7 +1479,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1560,7 +1513,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1591,7 +1543,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
             request.parent = '';
@@ -1621,7 +1572,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1650,7 +1600,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1690,7 +1639,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1714,7 +1662,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1754,7 +1701,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1789,7 +1735,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';
@@ -1820,7 +1765,6 @@ describe('v2.CloudTasksClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
             request.parent = '';

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -124,7 +124,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -141,7 +140,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -169,7 +167,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
             const expectedOptions = {};
@@ -187,7 +184,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};
@@ -204,7 +200,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};
@@ -232,7 +227,6 @@ describe('v1.TextToSpeechClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
             const expectedOptions = {};

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -187,7 +187,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -212,7 +211,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -248,7 +246,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
             request.parent = '';
@@ -274,7 +271,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -299,7 +295,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -335,7 +330,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
             request.parent = '';
@@ -361,7 +355,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -386,7 +379,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -422,7 +414,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
             request.parent = '';
@@ -448,7 +439,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -473,7 +463,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -509,7 +498,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
             request.name = '';
@@ -535,7 +523,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -561,7 +548,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -600,7 +586,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -624,7 +609,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
             request.parent = '';
@@ -649,7 +633,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -668,7 +651,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -685,7 +667,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -711,7 +692,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -750,7 +730,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -774,7 +753,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
             request.parent = '';
@@ -799,7 +777,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -818,7 +795,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -835,7 +811,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -861,7 +836,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -900,7 +874,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -924,7 +897,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
             request.name = '';
@@ -949,7 +921,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -968,7 +939,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 
@@ -985,7 +955,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1014,7 +983,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1054,7 +1022,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1078,7 +1045,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1118,7 +1084,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1153,7 +1118,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';
@@ -1184,7 +1148,6 @@ describe('v3beta1.TranslationServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
             request.parent = '';

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -136,7 +136,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -154,7 +153,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -185,7 +183,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -201,7 +198,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
             const expectedOptions = {};
@@ -218,7 +214,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -237,7 +232,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
-            const stub = sinon.stub(client, 'warn');
             client.initialize();
             const expectedError = new Error('expected');
 

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -247,7 +247,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -267,7 +269,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -298,7 +302,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -321,7 +327,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -342,7 +350,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -376,7 +386,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -395,7 +407,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -415,7 +429,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
             expectedResponse.name = 'test';
@@ -437,7 +453,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const expectedError = new Error('expected');
 
@@ -459,7 +477,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -488,7 +508,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -520,7 +542,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
@@ -552,7 +576,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
@@ -587,7 +613,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
@@ -620,7 +648,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
@@ -655,7 +685,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -675,7 +707,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -706,7 +740,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
@@ -725,7 +761,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             {{ util.initPagingResponse(method) }}
@@ -764,7 +802,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
@@ -802,7 +842,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initPagingResponse(method) }}
@@ -833,7 +875,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
             const expectedError = new Error('expected');
@@ -870,7 +914,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
@@ -905,7 +951,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
@@ -956,7 +1004,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 credentials: {client_email: 'bogus', private_key: 'bogus'},
                 projectId: 'bogus',
             });
+            {%- if method.options and method.options.deprecated %}
             const stub = sinon.stub(client, 'warn');
+            {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
                 new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()


### PR DESCRIPTION
Follow up to https://github.com/googleapis/gapic-generator-typescript/pull/921 - the stub replacement for the `gax.warn` function should only be invoked when the method is deprecated; otherwise this generates linter warnings for an unused stub. 