### PR TITLE
fix: Remove duplicate service_yaml parameter

### DIFF
--- a/rules_typescript_gapic/typescript_gapic.bzl
+++ b/rules_typescript_gapic/typescript_gapic.bzl
@@ -25,7 +25,6 @@ def typescript_gapic_library(
   service_yaml = None,
   metadata = None,
   legacy_proto_load = None,
-  service_yaml = None,
   extra_protoc_parameters = [],
   extra_protoc_file_parameters = {},
   **kwargs):


### PR DESCRIPTION
Remove the duplicate service_yaml parameter in 'gapic_generator_typescript/rules_typescript_gapic/typescript_gapic.bzl'.