### PR TITLE
chore: disable release failure checker for this repository

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 releaseType: node
 handleGHRelease: true
+disableFailureChecker: true


### PR DESCRIPTION
This feature is introduced in https://github.com/googleapis/repo-automation-bots/pull/2272.