### PR TITLE
feat(diregapic): Add diregapic option in command line

### DIFF
--- a/baselines/pubsub-api-dump/api.json.baseline
+++ b/baselines/pubsub-api-dump/api.json.baseline
@@ -14062,5 +14062,6 @@
       ]
     }
   ],
+  "diregapic": false,
   "legacyProtoLoad": false
 }

--- a/rules_typescript_gapic/typescript_gapic.bzl
+++ b/rules_typescript_gapic/typescript_gapic.bzl
@@ -25,6 +25,7 @@ def typescript_gapic_library(
   service_yaml = None,
   metadata = None,
   transport = None,
+  diregapic = None,
   legacy_proto_load = None,
   extra_protoc_parameters = [],
   extra_protoc_file_parameters = {},
@@ -39,6 +40,8 @@ def typescript_gapic_library(
     plugin_args_dict["metadata"] = "true"
   if transport:
     plugin_args_dict["transport"] = transport
+  if diregapic:
+    plugin_args_dict["diregapic"] = "true"
   if legacy_proto_load:
     plugin_args_dict["legacy-proto-load"] = "true"
 

--- a/typescript/src/gapic-generator-typescript.ts
+++ b/typescript/src/gapic-generator-typescript.ts
@@ -81,7 +81,11 @@ yargs.describe(
 yargs.boolean('metadata');
 yargs.describe(
   'transport',
-  'Default transport is gRPC. Set transport=rest for an API requires HTTP transport, or Google Discovery API.'
+  'Default transport is gRPC. Set transport=rest for gRPC or non-gRPC API requires REST transport with http annotation in proto3 files.'
+);
+yargs.describe(
+  'diregapic',
+  'DIREGAPIC represents Discovery Rest GAPICs. Set to true for GCE API or non-gRPC APIs with a Discovery doc description.'
 );
 yargs.describe(
   'legacy_proto_load',
@@ -111,6 +115,7 @@ export interface IArguments {
   commonProtoPath?: string;
   descriptor?: string;
   transport?: string;
+  diregapic?: boolean;
   legacyProtoLoad?: boolean;
   _: string[];
   $0: string;
@@ -128,6 +133,7 @@ const gapicValidatorOut = argv.gapicValidatorOut as string | undefined;
 const validation = (argv.validation as string | undefined) ?? 'true';
 const metadata = argv.metadata as boolean | undefined;
 const transport = argv.transport as string | undefined;
+const diregapic = argv.diregapic as boolean | undefined;
 const legacyProtoLoad = argv.legacyProtoLoad as boolean | undefined;
 const protoc = (argv.protoc as string | undefined) ?? 'protoc';
 const protoDirs: string[] = [];
@@ -177,6 +183,9 @@ if (template) {
 }
 if (metadata) {
   protocCommand.push('--typescript_gapic_opt="metadata"');
+}
+if (diregapic) {
+  protocCommand.push('--typescript_gapic_opt="diregapic"');
 }
 if (transport && transport === 'rest') {
   protocCommand.push('--typescript_gapic_opt="transport=rest"');

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -71,6 +71,7 @@ export class Generator {
   templates: string[];
   metadata?: boolean;
   rest?: boolean;
+  diregapic?: boolean;
   legacyProtoLoad?: boolean;
 
   constructor() {
@@ -189,6 +190,13 @@ export class Generator {
     }
   }
 
+  private readDiregapic() {
+    if (this.paramMap['diregapic'] === 'true') {
+      this.diregapic = true;
+      this.rest = true;
+    }
+  }
+
   private readLegacyProtoLoad() {
     if (this.paramMap['legacy-proto-load'] === 'true') {
       this.legacyProtoLoad = true;
@@ -209,6 +217,7 @@ export class Generator {
       this.readMainServiceName();
       this.readTemplates();
       this.readRest();
+      this.readDiregapic();
       this.readLegacyProtoLoad();
     }
   }
@@ -248,6 +257,7 @@ export class Generator {
       mainServiceName: this.mainServiceName,
       serviceYaml: this.serviceYaml,
       rest: this.rest,
+      diregapic: this.diregapic,
       legacyProtoLoad: this.legacyProtoLoad,
     });
     return api;

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -36,6 +36,7 @@ export class API {
   uniqKeywords: string[];
   packageName: string;
   rest?: boolean;
+  diregapic?: boolean;
   legacyProtoLoad: boolean;
 
   static isIgnoredService(
@@ -87,6 +88,7 @@ export class API {
     this.publishName =
       options.publishName || this.naming.productName.toKebabCase();
     this.rest = options.rest;
+    this.diregapic = options.diregapic ?? false;
     this.legacyProtoLoad = options.legacyProtoLoad ?? false;
 
     const [allResourceDatabase, resourceDatabase] = getResourceDatabase(
@@ -209,6 +211,7 @@ export class API {
       port: this.port,
       services: this.services,
       rest: this.rest,
+      diregapic: this.diregapic,
       legacyProtoLoad: this.legacyProtoLoad,
     });
   }

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -25,6 +25,7 @@ export interface Options {
   mainServiceName?: string;
   serviceYaml?: ServiceYaml;
   rest?: boolean;
+  diregapic?: boolean;
   legacyProtoLoad?: boolean;
 }
 

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -183,7 +183,7 @@ function pagingField(
   messages: MessagesMap,
   method: MethodDescriptorProto,
   service?: ServiceDescriptorProto,
-  rest?: boolean
+  diregapic?: boolean
 ) {
   // TODO: remove this once the next version of the Talent API is published.
   //
@@ -213,7 +213,8 @@ function pagingField(
     inputType &&
     inputType.field!.some(
       field =>
-        field.name === 'page_size' || (rest && field.name === 'max_results')
+        field.name === 'page_size' ||
+        (diregapic && field.name === 'max_results')
     );
   const hasNextPageToken =
     outputType &&
@@ -263,18 +264,18 @@ function pagingFieldName(
   messages: MessagesMap,
   method: MethodDescriptorProto,
   service?: ServiceDescriptorProto,
-  rest?: boolean
+  diregapic?: boolean
 ) {
-  const field = pagingField(messages, method, service, rest);
+  const field = pagingField(messages, method, service, diregapic);
   return field?.name;
 }
 
 function pagingResponseType(
   messages: MessagesMap,
   method: MethodDescriptorProto,
-  rest?: boolean
+  diregapic?: boolean
 ) {
-  const field = pagingField(messages, method, undefined, rest);
+  const field = pagingField(messages, method, undefined, diregapic);
   if (!field || !field.type) {
     return undefined;
   }
@@ -292,11 +293,11 @@ function pagingResponseType(
 function pagingMapResponseType(
   messages: MessagesMap,
   method: MethodDescriptorProto,
-  rest?: boolean
+  diregapic?: boolean
 ) {
-  const pagingfield = pagingField(messages, method, undefined, rest);
+  const pagingfield = pagingField(messages, method, undefined, diregapic);
   const outputType = messages[method.outputType!];
-  if (!pagingfield?.type || !rest || !outputType.nestedType) {
+  if (!pagingfield?.type || !diregapic || !outputType.nestedType) {
     return undefined;
   }
   const mapResponses = outputType.nestedType.filter(desProto => {
@@ -375,7 +376,7 @@ interface AugmentMethodParameters {
   allMessages: MessagesMap;
   localMessages: MessagesMap;
   service: ServiceDescriptorProto;
-  rest?: boolean;
+  diregapic?: boolean;
 }
 
 function augmentMethod(
@@ -398,17 +399,17 @@ function augmentMethod(
         parameters.allMessages,
         method,
         parameters.service,
-        parameters.rest
+        parameters.diregapic
       ),
       pagingResponseType: pagingResponseType(
         parameters.allMessages,
         method,
-        parameters.rest
+        parameters.diregapic
       ),
       pagingMapResponseType: pagingMapResponseType(
         parameters.allMessages,
         method,
-        parameters.rest
+        parameters.diregapic
       ),
       inputInterface: method.inputType!,
       outputInterface: method.outputType!,
@@ -603,7 +604,7 @@ function augmentService(parameters: AugmentServiceParameters) {
         allMessages: parameters.allMessages,
         localMessages: parameters.localMessages,
         service: augmentedService,
-        rest: parameters.options.rest,
+        diregapic: parameters.options.diregapic,
       },
       method
     )
@@ -735,7 +736,7 @@ export class Proto {
   allMessages: MessagesMap = {};
   localMessages: MessagesMap = {};
   fileToGenerate = true;
-  rest?: boolean;
+  diregapic?: boolean;
   // TODO: need to store metadata? address?
 
   // allResourceDatabase: resources that defined by `google.api.resource`
@@ -752,7 +753,7 @@ export class Proto {
         map[`.${parameters.fd.package!}.${message.name!}`] = message;
         return map;
       }, {} as MessagesMap);
-    this.rest = parameters.options.rest;
+    this.diregapic = parameters.options.diregapic;
     const protopackage = parameters.fd.package;
     // Allow to generate if a proto has no service and its package name is differ from its service's.
     if (

--- a/typescript/test/unit/baselines.ts
+++ b/typescript/test/unit/baselines.ts
@@ -165,6 +165,6 @@ describe('Baseline tests', () => {
     protoPath: 'google/cloud/compute/v1/*.proto',
     useCommonProto: false,
     packageName: '@google-cloud/compute',
-    transport: 'rest',
+    diregapic: true,
   });
 });

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -347,8 +347,8 @@ describe('src/schema/proto.ts', () => {
     });
   });
 
-  describe('should add rest for Proto class', () => {
-    it('should be false when rest is not set', () => {
+  describe('should add diregapic option for Proto class', () => {
+    it('should be false when diregapic is not set', () => {
       const fd = new protos.google.protobuf.FileDescriptorProto();
       const proto = new Proto({
         fd,
@@ -361,9 +361,9 @@ describe('src/schema/proto.ts', () => {
         },
         commentsMap: new CommentsMap([fd]),
       });
-      assert.strictEqual(proto.rest, undefined);
+      assert.strictEqual(proto.diregapic, undefined);
     });
-    it('should be true when rest is set', () => {
+    it('should be true when diregapic is set', () => {
       const fd = new protos.google.protobuf.FileDescriptorProto();
       const proto = new Proto({
         fd,
@@ -373,16 +373,16 @@ describe('src/schema/proto.ts', () => {
         resourceDatabase: new ResourceDatabase(),
         options: {
           grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
-          rest: true,
+          diregapic: true,
         },
         commentsMap: new CommentsMap([fd]),
       });
-      assert.strictEqual(proto.rest, true);
+      assert.strictEqual(proto.diregapic, true);
     });
   });
 
-  describe('should support pagination for Discovery-based APIs', () => {
-    it('should be page field if api require rest transport and use "max_results" as field name', () => {
+  describe('should support pagination for non-gRPC APIs, diregapic mode', () => {
+    it('should be page field if diregapic mode and use "max_results" as field name', () => {
       const fd = new protos.google.protobuf.FileDescriptorProto();
       fd.name = 'google/cloud/showcase/v1beta1/test.proto';
       fd.package = 'google.cloud.showcase.v1beta1';
@@ -425,7 +425,7 @@ describe('src/schema/proto.ts', () => {
       fd.messageType[1].field[1].name = 'page_token';
       const options: Options = {
         grpcServiceConfig: new protos.grpc.service_config.ServiceConfig(),
-        rest: true,
+        diregapic: true,
       };
       const allMessages: MessagesMap = {};
       fd.messageType

--- a/typescript/test/util.ts
+++ b/typescript/test/util.ts
@@ -38,6 +38,7 @@ export interface BaselineOptions {
   metadata?: boolean;
   legacyProtoLoad?: boolean;
   transport?: string;
+  diregapic?: boolean;
 }
 
 const cwd = process.cwd();
@@ -124,6 +125,9 @@ export function runBaselineTest(options: BaselineOptions) {
     }
     if (options.transport && options.transport === 'rest') {
       commandLine += ' --transport=rest';
+    }
+    if (options.diregapic) {
+      commandLine += ' --diregapic';
     }
     execSync(commandLine);
     assert(equalToBaseline(outputDir, baselineDir));


### PR DESCRIPTION
Add `diregapic` option for allows Yoshi Node libraries team to implement self-signed JWT for Node libraries, because Self-signed JWTs apply to all GAPIC libraries, but not DIREGAPIC.

REST mode cover DIREGAPIC mode:
1. All DIREGPAIC(non-gRPC API) mode use REST mode,
2. gRPC API with http annotation use REST mode.

Replace proto `rest` mode by `diregapic`

bazel run test:
```
$ bazel run //:gapic_generator_typescript -- -I $GOOGLEAPIS_DISCOVERY --output-dir /tmp/output /Users/summerji/Work/googleapis-discovery/google/cloud/compute/v1/compute_small.proto --package-name @google-cloud/compute --diregapic
```
bazel build test under $GOOGLEAPIS_DISCOVERY
```
 $ bazel build //google/cloud/compute/v1:compute-small-v1-nodejs

 nodejs_gapic_library(
    name = "compute_nodejs_gapic",
    package_name = "@google-cloud/compute",
    src = ":compute_proto_with_info",
    extra_protoc_parameters = ["metadata"],
    diregapic = True,
    deps = [],
)
 ```