### PR TITLE
feat: close mixin clients

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -1035,6 +1035,7 @@ export class AssetServiceClient {
       return this.assetServiceStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -1183,6 +1183,7 @@ export class EchoClient {
       return this.echoStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -1832,6 +1832,7 @@ export class MessagingClient {
       return this.messagingStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -2786,6 +2786,7 @@ export class KeyManagementServiceClient {
       return this.keyManagementServiceStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.iamClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -1096,6 +1096,7 @@ export class NamingClient {
       return this.namingStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1390,6 +1390,7 @@ export class CloudRedisClient {
       return this.cloudRedisStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -815,6 +815,7 @@ export class EchoClient {
       return this.echoStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -1578,6 +1578,9 @@ export class EchoClient {
       return this.echoStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.iamClient.close();
+        this.locationsClient.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -1495,6 +1495,9 @@ export class IdentityClient {
       return this.identityStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.iamClient.close();
+        this.locationsClient.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -2227,6 +2227,9 @@ export class MessagingClient {
       return this.messagingStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.iamClient.close();
+        this.locationsClient.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -1819,6 +1819,9 @@ export class TestingClient {
       return this.testingStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.iamClient.close();
+        this.locationsClient.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1390,6 +1390,7 @@ export class TranslationServiceClient {
       return this.translationServiceStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -424,6 +424,7 @@ export class VideoIntelligenceServiceClient {
       return this.videoIntelligenceServiceStub!.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -876,6 +876,15 @@ export class {{ service.name }}Client {
       return this.{{ service.name.toCamelCase() }}Stub!.then(stub => {
         this._terminated = true;
         stub.close();
+        {%- if service.IAMPolicyMixin > 0 %}
+        this.iamClient.close();
+        {%- endif %}
+        {%- if service.LocationMixin > 0 %}
+        this.locationsClient.close();
+        {%- endif %}
+        {%- if service.longRunning.length > 0 or service.LongRunningOperationsMixin > 0 %}
+        this.operationsClient.close();
+        {%- endif %}
       });
     }
     return Promise.resolve();


### PR DESCRIPTION
For services that use a mixin client (IAMPolicy, Locations, LongRunningOperations), when they call `close()` on the client, it does not currently close the mixin client. If one is generating many clients in a row, this can cause memory leaks (see: https://github.com/googleapis/google-cloud-node-core/issues/625).

This feature closes the mixin clients in addition to the service client when the end user calls `close()`. 

This significantly improves memory leakage for clients using LongRunningOperations such as `InstanceAdminClient`. 