### PR TITLE
fix: google.cloud.location is a common proto package

### DIFF
--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -47,6 +47,7 @@ export class API {
     return (
       fd.package === 'google.longrunning' ||
       fd.package === 'google.cloud' ||
+      fd.package === 'google.cloud.location' ||
       fd.package === 'google.protobuf' ||
       fd.package === 'google.type' ||
       fd.package === 'google.rpc' ||


### PR DESCRIPTION
Fixing this failure for notebooks v1 API:

```
--typescript-gapic_out: Cannot parse package name google.cloud: version does not match /^((v[0-9]+(p[0-9]+)?((alpha|beta)[0-9]+)?[^.]*))?$/.
```