### PR TITLE
test: fixing typescript compilation error

### DIFF
--- a/test-fixtures/test-application-ts/src/browser-test.ts
+++ b/test-fixtures/test-application-ts/src/browser-test.ts
@@ -28,8 +28,8 @@ describe('BrowserTest for showcase library', () => {
         await exec('karma start');
       } catch (err) {
         console.log('execSync error:', err);
-        console.log('stdout:', err.stdout.toString());
-        console.log('stderr:', err.stderr.toString());
+        console.log('stdout:', (err as unknown as {stdout: Buffer}).stdout.toString());
+        console.log('stderr:', (err as unknown as {stderr: Buffer}).stderr.toString());
       }
       // Kill server process
       server.kill();


### PR DESCRIPTION
Apparently, either TypeScript update or `@types/node` update again broke this piece of test code.

![image](https://user-images.githubusercontent.com/4015807/131160352-6a07fb9a-18bd-4ffc-876f-1d940d6c40ce.png)
