### PR TITLE
feat(diregapic)(LRO): Add minimum wrapper for mitigate future full-implementation diregapic LRO change

### DIFF
--- a/baselines/compute/protos/google/cloud/compute/v1/compute_small.proto.baseline
+++ b/baselines/compute/protos/google/cloud/compute/v1/compute_small.proto.baseline
@@ -623,6 +623,19 @@ message GetRegionOperationRequest {
 
 }
 
+// A request message for RegionOperations.Wait. See the method description for details.
+message WaitRegionOperationRequest {
+  // Name of the Operations resource to return.
+  string operation = 52090215 [(google.api.field_behavior) = REQUIRED];
+
+  // Project ID for this request.
+  string project = 227560217 [(google.api.field_behavior) = REQUIRED];
+
+  // Name of the region for this request.
+  string region = 138946292 [(google.api.field_behavior) = REQUIRED];
+
+}
+
 //
 // Services
 //
@@ -688,5 +701,16 @@ service RegionOperations {
     option (google.api.method_signature) = "project,region,operation";
   }
 
-}
+  // Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
+  //
+  // This method is called on a best-effort basis. Specifically:
+  // - In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
+  // - If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not `DONE`.
+  rpc Wait(WaitRegionOperationRequest) returns (Operation) {
+    option (google.api.http) = {
+      post: "/compute/v1/projects/projects/{project}/regions/{region}/operations/{operation}/wait"
+    };
+    option (google.api.method_signature) = "project,region,operation";
+  }
 
+}

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -18,7 +18,7 @@
 
 /* global window */
 import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
+import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
@@ -297,8 +297,8 @@ export class AddressesClient {
       request?: protos.google.cloud.compute.v1.IDeleteAddressRequest,
       options?: CallOptions):
       Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IDeleteAddressRequest|undefined, {}|undefined
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
       ]>;
   delete(
       request: protos.google.cloud.compute.v1.IDeleteAddressRequest,
@@ -351,8 +351,8 @@ export class AddressesClient {
           protos.google.cloud.compute.v1.IDeleteAddressRequest|null|undefined,
           {}|null|undefined>):
       Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IDeleteAddressRequest|undefined, {}|undefined
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: CallOptions;
@@ -372,14 +372,33 @@ export class AddressesClient {
       'project': request.project || '',
     });
     this.initialize();
-    return this.innerApiCalls.delete(request, options, callback);
+    return new Promise<[
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
+      ]>((resolve, reject) => {
+      this.innerApiCalls.delete(request, options, callback)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(([response, next, rawResponse]: [any, any, any]) => {
+        resolve([
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          { latestResponse: response, done: false, name: response.id},
+          next,
+          rawResponse
+        ]);
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .catch((err: any) => {
+        reject(err);
+      })
+    });
   }
   insert(
       request?: protos.google.cloud.compute.v1.IInsertAddressRequest,
       options?: CallOptions):
       Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IInsertAddressRequest|undefined, {}|undefined
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
       ]>;
   insert(
       request: protos.google.cloud.compute.v1.IInsertAddressRequest,
@@ -432,8 +451,8 @@ export class AddressesClient {
           protos.google.cloud.compute.v1.IInsertAddressRequest|null|undefined,
           {}|null|undefined>):
       Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IInsertAddressRequest|undefined, {}|undefined
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
       ]>|void {
     request = request || {};
     let options: CallOptions;
@@ -453,7 +472,26 @@ export class AddressesClient {
       'project': request.project || '',
     });
     this.initialize();
-    return this.innerApiCalls.insert(request, options, callback);
+    return new Promise<[
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
+      ]>((resolve, reject) => {
+      this.innerApiCalls.insert(request, options, callback)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(([response, next, rawResponse]: [any, any, any]) => {
+        resolve([
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          { latestResponse: response, done: false, name: response.id},
+          next,
+          rawResponse
+        ]);
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .catch((err: any) => {
+        reject(err);
+      })
+    });
   }
 
 

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -333,12 +333,13 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Operation]{@link google.cloud.compute.v1.Operation}.
+ *   The first element of the array is an object representing
+ *   a long running operation.
  *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
  *   for more details and examples.
  * @example
- * const [response] = await client.delete(request);
+ * const [operation] = await client.delete(request);
  */
   delete(
       request?: protos.google.cloud.compute.v1.IDeleteAddressRequest,
@@ -382,7 +383,7 @@ export class AddressesClient {
         resolve([
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
         ]);
@@ -433,12 +434,13 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Operation]{@link google.cloud.compute.v1.Operation}.
+ *   The first element of the array is an object representing
+ *   a long running operation.
  *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
  *   for more details and examples.
  * @example
- * const [response] = await client.insert(request);
+ * const [operation] = await client.insert(request);
  */
   insert(
       request?: protos.google.cloud.compute.v1.IInsertAddressRequest,
@@ -482,7 +484,7 @@ export class AddressesClient {
         resolve([
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
         ]);

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -381,9 +381,7 @@ export class AddressesClient {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(([response, next, rawResponse]: [any, any, any]) => {
         resolve([
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
           next,
           rawResponse
         ]);
@@ -482,9 +480,7 @@ export class AddressesClient {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(([response, next, rawResponse]: [any, any, any]) => {
         resolve([
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
           next,
           rawResponse
         ]);

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -378,7 +378,6 @@ export class AddressesClient {
     });
     this.initialize();
     return this.innerApiCalls.delete(request, options, callback)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
@@ -472,7 +471,6 @@ export class AddressesClient {
     });
     this.initialize();
     return this.innerApiCalls.insert(request, options, callback)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -379,10 +379,10 @@ export class AddressesClient {
     this.initialize();
     return this.innerApiCalls.delete(request, options, callback)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .then(([response, next, rawResponse]: [any, any, any]) => {
+    .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
-          next,
+          operation,
           rawResponse
         ];
     });
@@ -473,10 +473,10 @@ export class AddressesClient {
     this.initialize();
     return this.innerApiCalls.insert(request, options, callback)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .then(([response, next, rawResponse]: [any, any, any]) => {
+    .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
-          next,
+          operation,
           rawResponse
         ];
     });

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -338,6 +338,10 @@ export class AddressesClient {
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
  *   for more details and examples.
+ *   This method is considered to be in beta. This means while
+ *   stable it is still a work-in-progress and under active development,
+ *   and might get backwards-incompatible changes at any time.
+ *   `.promise()` is not supported yet.
  * @example
  * const [operation] = await client.delete(request);
  */
@@ -373,23 +377,14 @@ export class AddressesClient {
       'project': request.project || '',
     });
     this.initialize();
-    return new Promise<[
-        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
-        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
-      ]>((resolve, reject) => {
-      this.innerApiCalls.delete(request, options, callback)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then(([response, next, rawResponse]: [any, any, any]) => {
-        resolve([
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+    return this.innerApiCalls.delete(request, options, callback)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .then(([response, next, rawResponse]: [any, any, any]) => {
+      return [
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
-        ]);
-      })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .catch((err: any) => {
-        reject(err);
-      })
+        ];
     });
   }
   insert(
@@ -437,6 +432,10 @@ export class AddressesClient {
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
  *   for more details and examples.
+ *   This method is considered to be in beta. This means while
+ *   stable it is still a work-in-progress and under active development,
+ *   and might get backwards-incompatible changes at any time.
+ *   `.promise()` is not supported yet.
  * @example
  * const [operation] = await client.insert(request);
  */
@@ -472,23 +471,14 @@ export class AddressesClient {
       'project': request.project || '',
     });
     this.initialize();
-    return new Promise<[
-        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
-        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
-      ]>((resolve, reject) => {
-      this.innerApiCalls.insert(request, options, callback)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then(([response, next, rawResponse]: [any, any, any]) => {
-        resolve([
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+    return this.innerApiCalls.insert(request, options, callback)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .then(([response, next, rawResponse]: [any, any, any]) => {
+      return [
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
-        ]);
-      })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .catch((err: any) => {
-        reject(err);
-      })
+        ];
     });
   }
 

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -194,7 +194,7 @@ export class RegionOperationsClient {
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
     const regionOperationsStubMethods =
-        ['get'];
+        ['get', 'wait'];
     for (const methodName of regionOperationsStubMethods) {
       const callPromise = this.regionOperationsStub.then(
         stub => (...args: Array<{}>) => {
@@ -352,6 +352,85 @@ export class RegionOperationsClient {
     });
     this.initialize();
     return this.innerApiCalls.get(request, options, callback);
+  }
+  wait(
+      request?: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.compute.v1.IOperation,
+        protos.google.cloud.compute.v1.IWaitRegionOperationRequest|undefined, {}|undefined
+      ]>;
+  wait(
+      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
+  wait(
+      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
+/**
+ * Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
+ *
+ * This method is called on a best-effort basis. Specifically:
+ * - In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
+ * - If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not `DONE`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.operation
+ *   Name of the Operations resource to return.
+ * @param {string} request.project
+ *   Project ID for this request.
+ * @param {string} request.region
+ *   Name of the region for this request.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Operation]{@link google.cloud.compute.v1.Operation}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.wait(request);
+ */
+  wait(
+      request?: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.cloud.compute.v1.IOperation,
+        protos.google.cloud.compute.v1.IWaitRegionOperationRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      'project': request.project || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.wait(request, options, callback);
   }
 
 

--- a/baselines/compute/src/v1/region_operations_client_config.json.baseline
+++ b/baselines/compute/src/v1/region_operations_client_config.json.baseline
@@ -23,6 +23,10 @@
         "Get": {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "Wait": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -196,7 +196,7 @@ describe('v1.AddressesClient', () => {
             const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
             client.innerApiCalls.delete = stubSimpleCall(expectedResponse);
             const [response] = await client.delete(request);
-            assert.deepStrictEqual(response, expectedResponse);
+            assert.deepStrictEqual(response.latestResponse, expectedResponse);
             assert((client.innerApiCalls.delete as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -280,7 +280,7 @@ describe('v1.AddressesClient', () => {
             const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
             client.innerApiCalls.insert = stubSimpleCall(expectedResponse);
             const [response] = await client.insert(request);
-            assert.deepStrictEqual(response, expectedResponse);
+            assert.deepStrictEqual(response.latestResponse, expectedResponse);
             assert((client.innerApiCalls.insert as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -212,4 +212,88 @@ describe('v1.RegionOperationsClient', () => {
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
     });
+
+    describe('wait', () => {
+        it('invokes wait without error', async () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({
+              auth: googleAuth,
+              projectId: 'bogus',
+        });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            request.project = '';
+            const expectedHeaderRequestParams = "project=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            client.innerApiCalls.wait = stubSimpleCall(expectedResponse);
+            const [response] = await client.wait(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.wait as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes wait without error using callback', async () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({
+              auth: googleAuth,
+              projectId: 'bogus',
+        });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            request.project = '';
+            const expectedHeaderRequestParams = "project=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            client.innerApiCalls.wait = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.wait(
+                    request,
+                    (err?: Error|null, result?: protos.google.cloud.compute.v1.IOperation|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.wait as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes wait with error', async () => {
+            const client = new regionoperationsModule.v1.RegionOperationsClient({
+              auth: googleAuth,
+              projectId: 'bogus',
+        });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            request.project = '';
+            const expectedHeaderRequestParams = "project=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.wait = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.wait(request), expectedError);
+            assert((client.innerApiCalls.wait as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+    });
 });

--- a/baselines/pubsub-api-dump/api.json.baseline
+++ b/baselines/pubsub-api-dump/api.json.baseline
@@ -16,6 +16,7 @@
     {
       "method": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Topic",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -102,6 +103,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -151,6 +153,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PublishRequest",
           "outputInterface": ".google.pubsub.v1.PublishResponse",
           "comments": [
@@ -199,6 +202,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -237,6 +241,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "topics",
           "pagingResponseType": ".google.pubsub.v1.Topic",
           "inputInterface": ".google.pubsub.v1.ListTopicsRequest",
@@ -293,6 +298,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSubscriptionsRequest",
@@ -349,6 +355,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSnapshotsRequest",
@@ -409,6 +416,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteTopicRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -451,6 +459,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DetachSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.DetachSubscriptionResponse",
           "comments": [
@@ -3788,6 +3797,7 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Topic",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -3874,6 +3884,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -3923,6 +3934,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PublishRequest",
           "outputInterface": ".google.pubsub.v1.PublishResponse",
           "comments": [
@@ -3971,6 +3983,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -4009,6 +4022,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteTopicRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -4051,6 +4065,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DetachSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.DetachSubscriptionResponse",
           "comments": [
@@ -4090,12 +4105,14 @@
         }
       ],
       "longRunning": [],
+      "diregapicLRO": [],
       "streaming": [],
       "clientStreaming": [],
       "serverStreaming": [],
       "bidiStreaming": [],
       "paging": [
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "topics",
           "pagingResponseType": ".google.pubsub.v1.Topic",
           "inputInterface": ".google.pubsub.v1.ListTopicsRequest",
@@ -4152,6 +4169,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSubscriptionsRequest",
@@ -4208,6 +4226,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSnapshotsRequest",
@@ -4334,6 +4353,7 @@
     {
       "method": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -4396,6 +4416,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -4443,6 +4464,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "schemas",
           "pagingResponseType": ".google.pubsub.v1.Schema",
           "inputInterface": ".google.pubsub.v1.ListSchemasRequest",
@@ -4508,6 +4530,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSchemaRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -4546,6 +4569,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.ValidateSchemaResponse",
           "comments": [
@@ -4593,6 +4617,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateMessageRequest",
           "outputInterface": ".google.pubsub.v1.ValidateMessageResponse",
           "comments": [
@@ -7957,6 +7982,7 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -8019,6 +8045,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -8066,6 +8093,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSchemaRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8104,6 +8132,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.ValidateSchemaResponse",
           "comments": [
@@ -8151,6 +8180,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateMessageRequest",
           "outputInterface": ".google.pubsub.v1.ValidateMessageResponse",
           "comments": [
@@ -8218,12 +8248,14 @@
         }
       ],
       "longRunning": [],
+      "diregapicLRO": [],
       "streaming": [],
       "clientStreaming": [],
       "serverStreaming": [],
       "bidiStreaming": [],
       "paging": [
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "schemas",
           "pagingResponseType": ".google.pubsub.v1.Schema",
           "inputInterface": ".google.pubsub.v1.ListSchemasRequest",
@@ -8355,6 +8387,7 @@
     {
       "method": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Subscription",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8555,6 +8588,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8593,6 +8627,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8639,6 +8674,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.pubsub.v1.Subscription",
           "inputInterface": ".google.pubsub.v1.ListSubscriptionsRequest",
@@ -8695,6 +8731,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSubscriptionRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8737,6 +8774,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyAckDeadlineRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8803,6 +8841,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.AcknowledgeRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8858,6 +8897,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PullRequest",
           "outputInterface": ".google.pubsub.v1.PullResponse",
           "comments": [
@@ -8923,6 +8963,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -9053,6 +9094,7 @@
           "headerRequestParams": []
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyPushConfigRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -9110,6 +9152,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9152,6 +9195,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.pubsub.v1.Snapshot",
           "inputInterface": ".google.pubsub.v1.ListSnapshotsRequest",
@@ -9212,6 +9256,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9294,6 +9339,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9344,6 +9390,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSnapshotRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -9390,6 +9437,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.SeekRequest",
           "outputInterface": ".google.pubsub.v1.SeekResponse",
           "comments": [
@@ -12757,6 +12805,7 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Subscription",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -12957,6 +13006,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -12995,6 +13045,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -13041,6 +13092,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSubscriptionRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13083,6 +13135,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyAckDeadlineRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13149,6 +13202,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.AcknowledgeRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13204,6 +13258,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PullRequest",
           "outputInterface": ".google.pubsub.v1.PullResponse",
           "comments": [
@@ -13269,6 +13324,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyPushConfigRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13326,6 +13382,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13368,6 +13425,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13450,6 +13508,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13500,6 +13559,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSnapshotRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13546,6 +13606,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.SeekRequest",
           "outputInterface": ".google.pubsub.v1.SeekResponse",
           "comments": [
@@ -13614,8 +13675,10 @@
         }
       ],
       "longRunning": [],
+      "diregapicLRO": [],
       "streaming": [
         {
+          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -13750,6 +13813,7 @@
       "serverStreaming": [],
       "bidiStreaming": [
         {
+          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -13882,6 +13946,7 @@
       ],
       "paging": [
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.pubsub.v1.Subscription",
           "inputInterface": ".google.pubsub.v1.ListSubscriptionsRequest",
@@ -13938,6 +14003,7 @@
           ]
         },
         {
+          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.pubsub.v1.Snapshot",
           "inputInterface": ".google.pubsub.v1.ListSnapshotsRequest",

--- a/baselines/pubsub-api-dump/api.json.baseline
+++ b/baselines/pubsub-api-dump/api.json.baseline
@@ -16,7 +16,6 @@
     {
       "method": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Topic",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -103,7 +102,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -153,7 +151,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PublishRequest",
           "outputInterface": ".google.pubsub.v1.PublishResponse",
           "comments": [
@@ -202,7 +199,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -241,7 +237,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "topics",
           "pagingResponseType": ".google.pubsub.v1.Topic",
           "inputInterface": ".google.pubsub.v1.ListTopicsRequest",
@@ -298,7 +293,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSubscriptionsRequest",
@@ -355,7 +349,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSnapshotsRequest",
@@ -416,7 +409,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteTopicRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -459,7 +451,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DetachSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.DetachSubscriptionResponse",
           "comments": [
@@ -3797,7 +3788,6 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Topic",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -3884,7 +3874,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -3934,7 +3923,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PublishRequest",
           "outputInterface": ".google.pubsub.v1.PublishResponse",
           "comments": [
@@ -3983,7 +3971,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetTopicRequest",
           "outputInterface": ".google.pubsub.v1.Topic",
           "comments": [
@@ -4022,7 +4009,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteTopicRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -4065,7 +4051,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DetachSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.DetachSubscriptionResponse",
           "comments": [
@@ -4112,7 +4097,6 @@
       "bidiStreaming": [],
       "paging": [
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "topics",
           "pagingResponseType": ".google.pubsub.v1.Topic",
           "inputInterface": ".google.pubsub.v1.ListTopicsRequest",
@@ -4169,7 +4153,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSubscriptionsRequest",
@@ -4226,7 +4209,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.protobuf.FieldDescriptorProto.Type.TYPE_STRING",
           "inputInterface": ".google.pubsub.v1.ListTopicSnapshotsRequest",
@@ -4353,7 +4335,6 @@
     {
       "method": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -4416,7 +4397,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -4464,7 +4444,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "schemas",
           "pagingResponseType": ".google.pubsub.v1.Schema",
           "inputInterface": ".google.pubsub.v1.ListSchemasRequest",
@@ -4530,7 +4509,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSchemaRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -4569,7 +4547,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.ValidateSchemaResponse",
           "comments": [
@@ -4617,7 +4594,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateMessageRequest",
           "outputInterface": ".google.pubsub.v1.ValidateMessageResponse",
           "comments": [
@@ -7982,7 +7958,6 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -8045,7 +8020,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSchemaRequest",
           "outputInterface": ".google.pubsub.v1.Schema",
           "comments": [
@@ -8093,7 +8067,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSchemaRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8132,7 +8105,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateSchemaRequest",
           "outputInterface": ".google.pubsub.v1.ValidateSchemaResponse",
           "comments": [
@@ -8180,7 +8152,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ValidateMessageRequest",
           "outputInterface": ".google.pubsub.v1.ValidateMessageResponse",
           "comments": [
@@ -8255,7 +8226,6 @@
       "bidiStreaming": [],
       "paging": [
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "schemas",
           "pagingResponseType": ".google.pubsub.v1.Schema",
           "inputInterface": ".google.pubsub.v1.ListSchemasRequest",
@@ -8387,7 +8357,6 @@
     {
       "method": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Subscription",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8588,7 +8557,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8627,7 +8595,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -8674,7 +8641,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.pubsub.v1.Subscription",
           "inputInterface": ".google.pubsub.v1.ListSubscriptionsRequest",
@@ -8731,7 +8697,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSubscriptionRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8774,7 +8739,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyAckDeadlineRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8841,7 +8805,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.AcknowledgeRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -8897,7 +8860,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PullRequest",
           "outputInterface": ".google.pubsub.v1.PullResponse",
           "comments": [
@@ -8963,7 +8925,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -9094,7 +9055,6 @@
           "headerRequestParams": []
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyPushConfigRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -9152,7 +9112,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9195,7 +9154,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.pubsub.v1.Snapshot",
           "inputInterface": ".google.pubsub.v1.ListSnapshotsRequest",
@@ -9256,7 +9214,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9339,7 +9296,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -9390,7 +9346,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSnapshotRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -9437,7 +9392,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.SeekRequest",
           "outputInterface": ".google.pubsub.v1.SeekResponse",
           "comments": [
@@ -12805,7 +12759,6 @@
       "bundleConfigsMethods": [],
       "simpleMethods": [
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.Subscription",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -13006,7 +12959,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -13045,7 +12997,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSubscriptionRequest",
           "outputInterface": ".google.pubsub.v1.Subscription",
           "comments": [
@@ -13092,7 +13043,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSubscriptionRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13135,7 +13085,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyAckDeadlineRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13202,7 +13151,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.AcknowledgeRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13258,7 +13206,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.PullRequest",
           "outputInterface": ".google.pubsub.v1.PullResponse",
           "comments": [
@@ -13324,7 +13271,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.ModifyPushConfigRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13382,7 +13328,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.GetSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13425,7 +13370,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.CreateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13508,7 +13452,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.UpdateSnapshotRequest",
           "outputInterface": ".google.pubsub.v1.Snapshot",
           "comments": [
@@ -13559,7 +13502,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.DeleteSnapshotRequest",
           "outputInterface": ".google.protobuf.Empty",
           "comments": [
@@ -13606,7 +13548,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "inputInterface": ".google.pubsub.v1.SeekRequest",
           "outputInterface": ".google.pubsub.v1.SeekResponse",
           "comments": [
@@ -13678,7 +13619,6 @@
       "diregapicLRO": [],
       "streaming": [
         {
-          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -13813,7 +13753,6 @@
       "serverStreaming": [],
       "bidiStreaming": [
         {
-          "isDiregapicLRO": false,
           "streaming": "BIDI_STREAMING",
           "inputInterface": ".google.pubsub.v1.StreamingPullRequest",
           "outputInterface": ".google.pubsub.v1.StreamingPullResponse",
@@ -13946,7 +13885,6 @@
       ],
       "paging": [
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "subscriptions",
           "pagingResponseType": ".google.pubsub.v1.Subscription",
           "inputInterface": ".google.pubsub.v1.ListSubscriptionsRequest",
@@ -14003,7 +13941,6 @@
           ]
         },
         {
-          "isDiregapicLRO": false,
           "pagingFieldName": "snapshots",
           "pagingResponseType": ".google.pubsub.v1.Snapshot",
           "inputInterface": ".google.pubsub.v1.ListSnapshotsRequest",

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -1239,7 +1239,7 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes getOperation without error using callback', async () => {
             const client = new echoModule.v1beta1.EchoClient({
@@ -1306,7 +1306,7 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.cancelOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes cancelOperation without error using callback', async () => {
             const client = new echoModule.v1beta1.EchoClient({
@@ -1373,7 +1373,7 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.deleteOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes deleteOperation without error using callback', async () => {
             const client = new echoModule.v1beta1.EchoClient({

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -1108,7 +1108,7 @@ describe('v1beta1.IdentityClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes getOperation without error using callback', async () => {
             const client = new identityModule.v1beta1.IdentityClient({
@@ -1175,7 +1175,7 @@ describe('v1beta1.IdentityClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.cancelOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes cancelOperation without error using callback', async () => {
             const client = new identityModule.v1beta1.IdentityClient({
@@ -1242,7 +1242,7 @@ describe('v1beta1.IdentityClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.deleteOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes deleteOperation without error using callback', async () => {
             const client = new identityModule.v1beta1.IdentityClient({

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -2044,7 +2044,7 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes getOperation without error using callback', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
@@ -2111,7 +2111,7 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.cancelOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes cancelOperation without error using callback', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({
@@ -2178,7 +2178,7 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.deleteOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes deleteOperation without error using callback', async () => {
             const client = new messagingModule.v1beta1.MessagingClient({

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -1496,7 +1496,7 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.getOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes getOperation without error using callback', async () => {
             const client = new testingModule.v1beta1.TestingClient({
@@ -1563,7 +1563,7 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.cancelOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes cancelOperation without error using callback', async () => {
             const client = new testingModule.v1beta1.TestingClient({
@@ -1630,7 +1630,7 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.deleteOperation as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes deleteOperation without error using callback', async () => {
             const client = new testingModule.v1beta1.TestingClient({

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -160,6 +160,10 @@ limitations under the License.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
  *   for more details and examples.
+ *   This method is considered to be in beta. This means while
+ *   stable it is still a work-in-progress and under active development,
+ *   and might get backwards-incompatible changes at any time.
+ *   `.promise()` is not supported yet.
  * @example
  * const [operation] = await client.{{ method.name.toCamelCase() }}(request);
 {%- else %}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -153,6 +153,16 @@ limitations under the License.
 {%- endmacro -%}
 
 {%- macro printReturnSimpleMethod(method) %}
+{%- if method.isDiregapicLRO %}
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing
+ *   a long running operation.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   for more details and examples.
+ * @example
+ * const [operation] = await client.{{ method.name.toCamelCase() }}(request);
+{%- else %}
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {{ typeLink(method.outputType) }}.
  *   Please see the
@@ -160,6 +170,7 @@ limitations under the License.
  *   for more details and examples.
  * @example
  * const [response] = await client.{{ method.name.toCamelCase() }}(request);
+{%- endif %}
 {%- endmacro -%}
 
 {%- macro printReturnPagingServerMethod(method, generatedAsyncName) %}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -563,10 +563,10 @@ export class {{ service.name }}Client {
     {%- if method.isDiregapicLRO %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .then(([response, next, rawResponse]: [any, any, any]) => {
+    .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
-          next,
+          operation,
           rawResponse
         ];
     });

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -562,7 +562,6 @@ export class {{ service.name }}Client {
     {%- endif %}
     {%- if method.isDiregapicLRO %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
           { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -571,7 +571,7 @@ export class {{ service.name }}Client {
         resolve([
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
         ]);

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -28,7 +28,7 @@ limitations under the License.
 {{- namer.initialize(id, service) -}}
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions
-{%- if service.longRunning.length > 0 %}, LROperation{%- endif -%}
+{%- if service.longRunning.length > 0 or service.diregapicLRO.length > 0 %}, LROperation{%- endif -%}
 {%- if service.paging.length > 0 %}, PaginationCallback, GaxCall{%- endif -%}
 {%- if service.IAMPolicyMixin > 0 %}, IamClient, IamProtos{%- endif -%}
 {%- if service.LocationMixin > 0 %}, LocationsClient, LocationProtos{%- endif -%}
@@ -167,7 +167,7 @@ export class {{ service.name }}Client {
 
     // Save the auth object to the client, for use by other methods.
     this.auth = (this._gaxGrpc.auth as gax.GoogleAuth);
-  
+
 {%- if not api.diregapic %}
 
     // Set useJWTAccessWithScope on the auth object.
@@ -496,10 +496,17 @@ export class {{ service.name }}Client {
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
+{%- if method.isDiregapicLRO %}
+      Promise<[
+        LROperation<{{ util.toInterface(method.outputInterface) }}, null>,
+        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
+      ]>;
+{%- else %}
       Promise<[
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
       ]>;
+{%- endif %}
   {{ method.name.toCamelCase() }}(
       request: {{ util.toInterface(method.inputInterface) }},
       options: CallOptions,
@@ -529,9 +536,15 @@ export class {{ service.name }}Client {
           {{ util.toInterface(method.outputInterface) }},
           {{ util.toInterface(method.inputInterface) }}|null|undefined,
           {}|null|undefined>):
+{%- if method.isDiregapicLRO %}
+      Promise<[
+        LROperation<{{ util.toInterface(method.outputInterface) }}, null>,
+        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
+{%- else %}
       Promise<[
         {{ util.toInterface(method.outputInterface) }},
         {{ util.toInterface(method.inputInterface) }}|undefined, {}|undefined
+{%- endif %}
       ]>|void {
     request = request || {};
     let options: CallOptions;
@@ -547,7 +560,30 @@ export class {{ service.name }}Client {
     {%- if method.options and method.options.deprecated %}
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
+    {%- if method.isDiregapicLRO %}
+    return new Promise<[
+        LROperation<{{ util.toInterface(method.outputInterface) }}, null>,
+        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
+      ]>((resolve, reject) => {
+      this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(([response, next, rawResponse]: [any, any, any]) => {
+        resolve([
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          { latestResponse: response, done: false, name: response.id},
+          next,
+          rawResponse
+        ]);
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .catch((err: any) => {
+        reject(err);
+      })
+    });
+    {%- else %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);
+    {%- endif %}
   }
 {%- endfor %}
 {% for method in service.streaming %}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -561,23 +561,14 @@ export class {{ service.name }}Client {
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     {%- if method.isDiregapicLRO %}
-    return new Promise<[
-        LROperation<{{ util.toInterface(method.outputInterface) }}, null>,
-        {{ util.toInterface(method.outputInterface) }}|undefined, {}|undefined
-      ]>((resolve, reject) => {
-      this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then(([response, next, rawResponse]: [any, any, any]) => {
-        resolve([
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+    return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .then(([response, next, rawResponse]: [any, any, any]) => {
+      return [
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
           next,
           rawResponse
-        ]);
-      })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .catch((err: any) => {
-        reject(err);
-      })
+        ];
     });
     {%- else %}
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback);

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -569,9 +569,7 @@ export class {{ service.name }}Client {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(([response, next, rawResponse]: [any, any, any]) => {
         resolve([
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}} as LROperation<protos.google.cloud.compute.v1.IOperation, null>,
           next,
           rawResponse
         ]);

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -266,7 +266,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
+            {%- if method.isDiregapicLRO %}
+            assert.deepStrictEqual(response.latestResponse, expectedResponse);
+            {%- else %}
             assert.deepStrictEqual(response, expectedResponse);
+            {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
@@ -1223,7 +1227,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.deepStrictEqual(response, [expectedResponse]);
             assert((client.operationsClient.{{ method }} as SinonStub)
                 .getCall(0).calledWith(request)
-            );        
+            );
         });
         it('invokes {{ method }} without error using callback', async () => {
             const client = new {{ service.name.toLowerCase() }}Module.{{ api.naming.version }}.{{ service.name }}Client({{- util.initClientOptions(api.rest) -}});
@@ -1350,7 +1354,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 (client.operationsClient.descriptor.{{method}}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
         });
-    });    
+    });
 {%- endif %}
 {%- if (service.pathTemplates.length > 0) %}
 

--- a/test-fixtures/protos/google/cloud/compute/v1/compute_small.proto
+++ b/test-fixtures/protos/google/cloud/compute/v1/compute_small.proto
@@ -623,6 +623,19 @@ message GetRegionOperationRequest {
 
 }
 
+// A request message for RegionOperations.Wait. See the method description for details.
+message WaitRegionOperationRequest {
+  // Name of the Operations resource to return.
+  string operation = 52090215 [(google.api.field_behavior) = REQUIRED];
+
+  // Project ID for this request.
+  string project = 227560217 [(google.api.field_behavior) = REQUIRED];
+
+  // Name of the region for this request.
+  string region = 138946292 [(google.api.field_behavior) = REQUIRED];
+
+}
+
 //
 // Services
 //
@@ -688,5 +701,16 @@ service RegionOperations {
     option (google.api.method_signature) = "project,region,operation";
   }
 
-}
+  // Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
+  //
+  // This method is called on a best-effort basis. Specifically:
+  // - In uncommon cases, when the server is overloaded, the request might return before the default deadline is reached, or might return after zero seconds.
+  // - If the default deadline is reached, there is no guarantee that the operation is actually done when the method returns. Be prepared to retry if the operation is not `DONE`.
+  rpc Wait(WaitRegionOperationRequest) returns (Operation) {
+    option (google.api.http) = {
+      post: "/compute/v1/projects/projects/{project}/regions/{region}/operations/{operation}/wait"
+    };
+    option (google.api.method_signature) = "project,region,operation";
+  }
 
+}

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -167,9 +167,10 @@ function isDiregapicLRO(
   packageName: string,
   method: MethodDescriptorProto,
   isDiregapic?: boolean
-): boolean {
+): boolean | '' | null | undefined {
   const operationOutputType = toFullyQualifiedName(packageName, 'Operation');
-  return isDiregapic &&
+  return (
+    isDiregapic &&
     method.outputType &&
     method.outputType === operationOutputType &&
     method.options?.['.google.api.http'] &&
@@ -177,8 +178,7 @@ function isDiregapicLRO(
       method.options?.['.google.api.http'].get ||
       (method.name === 'Wait' && method.options?.['.google.api.http'].post)
     )
-    ? true
-    : false;
+  );
 }
 
 // convert from input interface to message name

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -175,7 +175,7 @@ function isDiregapicLRO(
     method.options?.['.google.api.http'] &&
     !(
       method.options?.['.google.api.http'].get ||
-      (method.name === 'Wait' && method.options?.['.google.api.http']?.post)
+      (method.name === 'Wait' && method.options?.['.google.api.http'].post)
     )
     ? true
     : false;


### PR DESCRIPTION
Wrap an unary operations, that made it return a response compatible with the [eventual LRO operation](https://github.com/googleapis/gax-nodejs/blob/master/src/clientInterface.ts#L62). In another word, utilize duck typing to return the similar structure, but no ".promise" field.

Sample code test on generated client library:
```
async function main() {
  const projectId = await regionOperationClient.getProjectId();
  const region = 'us-central1';
  const rand = Math.floor(Math.random() * 1000);
  const addressResource = {
    name: `operation-insert-address-test-${rand}`,
  };
  const [operation] = await addressClient.insert({
    addressResource: addressResource,
    project: projectId,
    region: region
  })
  console.log('insert address operation.id:: ', operation);
  }
```
The output:
insert address operation.id::  {
  latestResponse: {
    warnings: [],
    id: '3894509470566436984',
    _id: 'id',
    startTime: '2021-08-29T22:37:27.644-07:00',
    _startTime: 'startTime',
    targetLink: 'https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-central1/addresses/operation-insert-address-test-188',
    _targetLink: 'targetLink',
    progress: 0,
    _progress: 'progress',
    region: 'https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-central1',
    _region: 'region',
    operationType: 'insert',
    _operationType: 'operationType',
    status: 'RUNNING',
    _status: 'status',
    ...
  },
  done: false,
  name: '3894509470566436984',
  metadata: null,
  result: {}
}