### PR TITLE
fix: update Stream and Async methods to use default callOptions

### DIFF
--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -539,12 +539,11 @@ export class AddressesClient {
       'project': request.project || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.aggregatedList.asyncIterate(
       this.innerApiCalls['aggregatedList'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<[string, protos.google.cloud.compute.v1.IAddressesScopedList]>;
   }
   list(
@@ -695,12 +694,11 @@ export class AddressesClient {
     ] = gax.routingHeader.fromParams({
       'project': request.project || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.list.createStream(
       this.innerApiCalls.list as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -762,12 +760,11 @@ export class AddressesClient {
       'project': request.project || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.list.asyncIterate(
       this.innerApiCalls['list'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.compute.v1.IAddress>;
   }
 

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -797,12 +797,11 @@ export class EchoClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
       this.innerApiCalls.pagedExpand as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -841,12 +840,11 @@ export class EchoClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }
   // --------------------

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -701,12 +701,11 @@ export class IdentityClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUsers.createStream(
       this.innerApiCalls.listUsers as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -746,12 +745,11 @@ export class IdentityClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUsers.asyncIterate(
       this.innerApiCalls['listUsers'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IUser>;
   }
   // --------------------

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -1257,12 +1257,11 @@ export class MessagingClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listRooms.createStream(
       this.innerApiCalls.listRooms as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1302,12 +1301,11 @@ export class MessagingClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listRooms.asyncIterate(
       this.innerApiCalls['listRooms'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
   listBlurbs(
@@ -1435,12 +1433,11 @@ export class MessagingClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.createStream(
       this.innerApiCalls.listBlurbs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1490,12 +1487,11 @@ export class MessagingClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.asyncIterate(
       this.innerApiCalls['listBlurbs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IBlurb>;
   }
   // --------------------

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -853,12 +853,11 @@ export class TestingClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSessions.createStream(
       this.innerApiCalls.listSessions as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -895,12 +894,11 @@ export class TestingClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSessions.asyncIterate(
       this.innerApiCalls['listSessions'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
   listTests(
@@ -1019,12 +1017,11 @@ export class TestingClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTests.createStream(
       this.innerApiCalls.listTests as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1070,12 +1067,11 @@ export class TestingClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTests.asyncIterate(
       this.innerApiCalls['listTests'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.ITest>;
   }
   // --------------------

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -2598,12 +2598,11 @@ export class DlpServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listInspectTemplates.createStream(
       this.innerApiCalls.listInspectTemplates as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2669,12 +2668,11 @@ export class DlpServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listInspectTemplates.asyncIterate(
       this.innerApiCalls['listInspectTemplates'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IInspectTemplate>;
   }
   listDeidentifyTemplates(
@@ -2835,12 +2833,11 @@ export class DlpServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listDeidentifyTemplates.createStream(
       this.innerApiCalls.listDeidentifyTemplates as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2906,12 +2903,11 @@ export class DlpServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listDeidentifyTemplates.asyncIterate(
       this.innerApiCalls['listDeidentifyTemplates'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDeidentifyTemplate>;
   }
   listJobTriggers(
@@ -3123,12 +3119,11 @@ export class DlpServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listJobTriggers.createStream(
       this.innerApiCalls.listJobTriggers as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -3220,12 +3215,11 @@ export class DlpServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listJobTriggers.asyncIterate(
       this.innerApiCalls['listJobTriggers'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IJobTrigger>;
   }
   listDlpJobs(
@@ -3442,12 +3436,11 @@ export class DlpServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listDlpJobs.createStream(
       this.innerApiCalls.listDlpJobs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -3541,12 +3534,11 @@ export class DlpServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listDlpJobs.asyncIterate(
       this.innerApiCalls['listDlpJobs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDlpJob>;
   }
   listStoredInfoTypes(
@@ -3709,12 +3701,11 @@ export class DlpServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listStoredInfoTypes.createStream(
       this.innerApiCalls.listStoredInfoTypes as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -3781,12 +3772,11 @@ export class DlpServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listStoredInfoTypes.asyncIterate(
       this.innerApiCalls['listStoredInfoTypes'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IStoredInfoType>;
   }
   // --------------------

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -1940,12 +1940,11 @@ export class KeyManagementServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listKeyRings.createStream(
       this.innerApiCalls.listKeyRings as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2001,12 +2000,11 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listKeyRings.asyncIterate(
       this.innerApiCalls['listKeyRings'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>;
   }
   listCryptoKeys(
@@ -2149,12 +2147,11 @@ export class KeyManagementServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeys.createStream(
       this.innerApiCalls.listCryptoKeys as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2212,12 +2209,11 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeys.asyncIterate(
       this.innerApiCalls['listCryptoKeys'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>;
   }
   listCryptoKeyVersions(
@@ -2362,12 +2358,11 @@ export class KeyManagementServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeyVersions.createStream(
       this.innerApiCalls.listCryptoKeyVersions as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2426,12 +2421,11 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeyVersions.asyncIterate(
       this.innerApiCalls['listCryptoKeyVersions'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>;
   }
   listImportJobs(
@@ -2570,12 +2564,11 @@ export class KeyManagementServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listImportJobs.createStream(
       this.innerApiCalls.listImportJobs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2631,12 +2624,11 @@ export class KeyManagementServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listImportJobs.asyncIterate(
       this.innerApiCalls['listImportJobs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.kms.v1.IImportJob>;
   }
 /**

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -1585,12 +1585,11 @@ export class ConfigServiceV2Client {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBuckets.createStream(
       this.innerApiCalls.listBuckets as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1650,12 +1649,11 @@ export class ConfigServiceV2Client {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBuckets.asyncIterate(
       this.innerApiCalls['listBuckets'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
   }
   listSinks(
@@ -1794,12 +1792,11 @@ export class ConfigServiceV2Client {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSinks.createStream(
       this.innerApiCalls.listSinks as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1855,12 +1852,11 @@ export class ConfigServiceV2Client {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSinks.asyncIterate(
       this.innerApiCalls['listSinks'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
   listExclusions(
@@ -1999,12 +1995,11 @@ export class ConfigServiceV2Client {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listExclusions.createStream(
       this.innerApiCalls.listExclusions as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2060,12 +2055,11 @@ export class ConfigServiceV2Client {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listExclusions.asyncIterate(
       this.innerApiCalls['listExclusions'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.logging.v2.ILogExclusion>;
   }
   // --------------------

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -765,12 +765,11 @@ export class LoggingServiceV2Client {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogEntries.createStream(
       this.innerApiCalls.listLogEntries as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -838,12 +837,11 @@ export class LoggingServiceV2Client {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogEntries.asyncIterate(
       this.innerApiCalls['listLogEntries'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.logging.v2.ILogEntry>;
   }
   listMonitoredResourceDescriptors(
@@ -954,12 +952,11 @@ export class LoggingServiceV2Client {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.createStream(
       this.innerApiCalls.listMonitoredResourceDescriptors as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1001,12 +998,11 @@ export class LoggingServiceV2Client {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.asyncIterate(
       this.innerApiCalls['listMonitoredResourceDescriptors'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
   listLogs(
@@ -1146,12 +1142,11 @@ export class LoggingServiceV2Client {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogs.createStream(
       this.innerApiCalls.listLogs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1207,12 +1202,11 @@ export class LoggingServiceV2Client {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogs.asyncIterate(
       this.innerApiCalls['listLogs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<string>;
   }
   // --------------------

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -795,12 +795,11 @@ export class MetricsServiceV2Client {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogMetrics.createStream(
       this.innerApiCalls.listLogMetrics as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -853,12 +852,11 @@ export class MetricsServiceV2Client {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listLogMetrics.asyncIterate(
       this.innerApiCalls['listLogMetrics'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.logging.v2.ILogMetric>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -865,12 +865,11 @@ export class AlertPolicyServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listAlertPolicies.createStream(
       this.innerApiCalls.listAlertPolicies as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -939,12 +938,11 @@ export class AlertPolicyServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listAlertPolicies.asyncIterate(
       this.innerApiCalls['listAlertPolicies'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IAlertPolicy>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -831,12 +831,11 @@ export class GroupServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGroups.createStream(
       this.innerApiCalls.listGroups as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -900,12 +899,11 @@ export class GroupServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGroups.asyncIterate(
       this.innerApiCalls['listGroups'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IGroup>;
   }
   listGroupMembers(
@@ -1056,12 +1054,11 @@ export class GroupServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGroupMembers.createStream(
       this.innerApiCalls.listGroupMembers as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1123,12 +1120,11 @@ export class GroupServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGroupMembers.asyncIterate(
       this.innerApiCalls['listGroupMembers'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.api.IMonitoredResource>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -911,12 +911,11 @@ export class MetricServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.createStream(
       this.innerApiCalls.listMonitoredResourceDescriptors as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -973,12 +972,11 @@ export class MetricServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.asyncIterate(
       this.innerApiCalls['listMonitoredResourceDescriptors'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
   listMetricDescriptors(
@@ -1121,12 +1119,11 @@ export class MetricServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMetricDescriptors.createStream(
       this.innerApiCalls.listMetricDescriptors as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1184,12 +1181,11 @@ export class MetricServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listMetricDescriptors.asyncIterate(
       this.innerApiCalls['listMetricDescriptors'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.api.IMetricDescriptor>;
   }
   listTimeSeries(
@@ -1368,12 +1364,11 @@ export class MetricServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTimeSeries.createStream(
       this.innerApiCalls.listTimeSeries as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1449,12 +1444,11 @@ export class MetricServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTimeSeries.asyncIterate(
       this.innerApiCalls['listTimeSeries'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.ITimeSeries>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -1150,12 +1150,11 @@ export class NotificationChannelServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannelDescriptors.createStream(
       this.innerApiCalls.listNotificationChannelDescriptors as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1213,12 +1212,11 @@ export class NotificationChannelServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannelDescriptors.asyncIterate(
       this.innerApiCalls['listNotificationChannelDescriptors'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannelDescriptor>;
   }
   listNotificationChannels(
@@ -1383,12 +1381,11 @@ export class NotificationChannelServiceClient {
     ] = gax.routingHeader.fromParams({
       'name': request.name || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannels.createStream(
       this.innerApiCalls.listNotificationChannels as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1457,12 +1454,11 @@ export class NotificationChannelServiceClient {
       'name': request.name || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannels.asyncIterate(
       this.innerApiCalls['listNotificationChannels'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannel>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -1127,12 +1127,11 @@ export class ServiceMonitoringServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listServices.createStream(
       this.innerApiCalls.listServices as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1198,12 +1197,11 @@ export class ServiceMonitoringServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listServices.asyncIterate(
       this.innerApiCalls['listServices'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IService>;
   }
   listServiceLevelObjectives(
@@ -1344,12 +1342,11 @@ export class ServiceMonitoringServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listServiceLevelObjectives.createStream(
       this.innerApiCalls.listServiceLevelObjectives as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1406,12 +1403,11 @@ export class ServiceMonitoringServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listServiceLevelObjectives.asyncIterate(
       this.innerApiCalls['listServiceLevelObjectives'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IServiceLevelObjective>;
   }
   // --------------------

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -813,12 +813,11 @@ export class UptimeCheckServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckConfigs.createStream(
       this.innerApiCalls.listUptimeCheckConfigs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -870,12 +869,11 @@ export class UptimeCheckServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckConfigs.asyncIterate(
       this.innerApiCalls['listUptimeCheckConfigs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckConfig>;
   }
   listUptimeCheckIps(
@@ -990,12 +988,11 @@ export class UptimeCheckServiceClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckIps.createStream(
       this.innerApiCalls.listUptimeCheckIps as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1039,12 +1036,11 @@ export class UptimeCheckServiceClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckIps.asyncIterate(
       this.innerApiCalls['listUptimeCheckIps'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckIp>;
   }
   // --------------------

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -1040,12 +1040,11 @@ export class NamingClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize1();
     return this.descriptors.page.paginatedMethod.createStream(
       this.innerApiCalls.paginatedMethod as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1081,12 +1080,11 @@ export class NamingClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize1();
     return this.descriptors.page.paginatedMethod.asyncIterate(
       this.innerApiCalls['paginatedMethod'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.protobuf.IEmpty>;
   }
 

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1227,12 +1227,11 @@ export class CloudRedisClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listInstances.createStream(
       this.innerApiCalls.listInstances as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1287,12 +1286,11 @@ export class CloudRedisClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listInstances.asyncIterate(
       this.innerApiCalls['listInstances'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.redis.v1beta1.IInstance>;
   }
   // --------------------

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -756,12 +756,11 @@ export class EchoClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
       this.innerApiCalls.pagedExpand as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -800,12 +799,11 @@ export class EchoClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }
 

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -803,12 +803,11 @@ export class EchoClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
       this.innerApiCalls.pagedExpand as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -847,12 +846,11 @@ export class EchoClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }
 /**

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -719,12 +719,11 @@ export class IdentityClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUsers.createStream(
       this.innerApiCalls.listUsers as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -764,12 +763,11 @@ export class IdentityClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listUsers.asyncIterate(
       this.innerApiCalls['listUsers'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IUser>;
   }
 /**

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -1263,12 +1263,11 @@ export class MessagingClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listRooms.createStream(
       this.innerApiCalls.listRooms as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1308,12 +1307,11 @@ export class MessagingClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listRooms.asyncIterate(
       this.innerApiCalls['listRooms'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
   listBlurbs(
@@ -1441,12 +1439,11 @@ export class MessagingClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.createStream(
       this.innerApiCalls.listBlurbs as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1496,12 +1493,11 @@ export class MessagingClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.asyncIterate(
       this.innerApiCalls['listBlurbs'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.IBlurb>;
   }
 /**

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -871,12 +871,11 @@ export class TestingClient {
     Transform{
     request = request || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSessions.createStream(
       this.innerApiCalls.listSessions as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -913,12 +912,11 @@ export class TestingClient {
     request = request || {};
     options = options || {};
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listSessions.asyncIterate(
       this.innerApiCalls['listSessions'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
   listTests(
@@ -1037,12 +1035,11 @@ export class TestingClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTests.createStream(
       this.innerApiCalls.listTests as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1088,12 +1085,11 @@ export class TestingClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTests.asyncIterate(
       this.innerApiCalls['listTests'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.showcase.v1beta1.ITest>;
   }
 /**

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -1699,12 +1699,11 @@ export class CloudTasksClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listQueues.createStream(
       this.innerApiCalls.listQueues as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1776,12 +1775,11 @@ export class CloudTasksClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listQueues.asyncIterate(
       this.innerApiCalls['listQueues'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.tasks.v2.IQueue>;
   }
   listTasks(
@@ -1966,12 +1964,11 @@ export class CloudTasksClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTasks.createStream(
       this.innerApiCalls.listTasks as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -2046,12 +2043,11 @@ export class CloudTasksClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listTasks.asyncIterate(
       this.innerApiCalls['listTasks'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.tasks.v2.ITask>;
   }
   // --------------------

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1228,12 +1228,11 @@ export class TranslationServiceClient {
     ] = gax.routingHeader.fromParams({
       'parent': request.parent || '',
     });
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGlossaries.createStream(
       this.innerApiCalls.listGlossaries as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 
@@ -1287,12 +1286,11 @@ export class TranslationServiceClient {
       'parent': request.parent || '',
     });
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.initialize();
     return this.descriptors.page.listGlossaries.asyncIterate(
       this.innerApiCalls['listGlossaries'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     ) as AsyncIterable<protos.google.cloud.translation.v3beta1.IGlossary>;
   }
   // --------------------

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -800,7 +800,6 @@ export class {{ service.name }}Client {
     Transform{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
-    const callSettings = new gax.CallSettings(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
@@ -808,7 +807,7 @@ export class {{ service.name }}Client {
     return this.descriptors.page.{{ method.name.toCamelCase() }}.createStream(
       this.innerApiCalls.{{ method.name.toCamelCase() }} as gax.GaxCall,
       request,
-      callSettings
+      options
     );
   }
 {%- endif %}
@@ -830,7 +829,6 @@ export class {{ service.name }}Client {
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
     options = options || {};
-    const callSettings = new gax.CallSettings(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
@@ -838,7 +836,7 @@ export class {{ service.name }}Client {
     return this.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate(
       this.innerApiCalls['{{ method.name.toCamelCase() }}'] as GaxCall,
       request as unknown as RequestType,
-      callSettings
+      options
     {%- if method.pagingMapResponseType %}
     ) as AsyncIterable<[string, {{ util.toInterface(method.pagingMapResponseType) }}]>;
     {%- else %}


### PR DESCRIPTION
This updates generated Stream and Async methods to use the default retry configuration of the base method if set by the service. 
For instance, with this fix, BaseMethodStream and BaseMethodAsync will use the retry configuration of the BaseMethod method. Originally, they were using a default timeout of 30s with no retry configuration. 

Please ping me for internal docs if desired.