### PR TITLE
fix: add targetLink in return LRO wrapper

### DIFF
--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -380,7 +380,7 @@ export class AddressesClient {
     return this.innerApiCalls.delete(request, options, callback)
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, targetLink: response.targetLink, metadata: null, result: {}},
           operation,
           rawResponse
         ];
@@ -473,7 +473,7 @@ export class AddressesClient {
     return this.innerApiCalls.insert(request, options, callback)
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, targetLink: response.targetLink, metadata: null, result: {}},
           operation,
           rawResponse
         ];

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -564,7 +564,7 @@ export class {{ service.name }}Client {
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options, callback)
     .then(([response, operation, rawResponse]: [protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation, protos.google.cloud.compute.v1.IOperation]) => {
       return [
-          { latestResponse: response, done: false, name: response.id, metadata: null, result: {}},
+          { latestResponse: response, done: false, name: response.id, targetLink: response.targetLink, metadata: null, result: {}},
           operation,
           rawResponse
         ];


### PR DESCRIPTION
system-test fails on generated nodejs-compute ([log](https://source.cloud.google.com/results/invocations/466896c9-70d0-407f-a865-38bef5f88089/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Fpresubmit%2Fgoogleapis%2Fnodejs-compute%2Fnode12%2Fsystem-test/log))

referred the operation.target ([code](https://github.com/googleapis/nodejs-compute/blob/main/system-test/compute.js#L321))
```
const instanceGroupManager = {
        baseInstanceName: 'tsgapic',
        instanceTemplate: insertOp.targetLink,
        name: instanceGroupName,
        targetSize: 0,
      };
```      