### PR TITLE
fix: find protoc based on its bazel location

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -100,7 +100,10 @@ nodejs_binary(
         "@com_google_protobuf//:protoc",
         ":protos",
     ] + npm_runtime_dependencies,
-    templated_args = ["--bazel_patch_module_resolver"],
+    templated_args = [
+        "--bazel_patch_module_resolver",
+        "--protoc=\"$(rootpath @com_google_protobuf//:protoc)\"",
+    ],
 )
 
 nodejs_test(

--- a/typescript/src/gapic-generator-typescript.ts
+++ b/typescript/src/gapic-generator-typescript.ts
@@ -135,7 +135,14 @@ const metadata = argv.metadata as boolean | undefined;
 const transport = argv.transport as string | undefined;
 const diregapic = argv.diregapic as boolean | undefined;
 const legacyProtoLoad = argv.legacyProtoLoad as boolean | undefined;
-const protoc = (argv.protoc as string | undefined) ?? 'protoc';
+
+// --protoc can be passed from BUILD.bazel and overridden from the command line
+let protocParameter = argv.protoc as string | string[] | undefined;
+if (Array.isArray(protocParameter)) {
+  protocParameter = protocParameter[protocParameter.length - 1];
+}
+const protoc = protocParameter ?? 'protoc';
+
 const protoDirs: string[] = [];
 if (argv.I) {
   protoDirs.push(...(argv.I as string[]));

--- a/typescript/test/util.ts
+++ b/typescript/test/util.ts
@@ -93,7 +93,7 @@ export function runBaselineTest(options: BaselineOptions) {
     fs.mkdirSync(outputDir);
 
     let commandLine =
-      `${entryPointPath} --protoc=./external/com_google_protobuf/protoc ` +
+      `${entryPointPath} ` +
       `--output_dir=${outputDir} ` +
       `-I${protosDirRoot} ${protoPaths.join(' ')}`;
     if (options.useCommonProto) {


### PR DESCRIPTION
Supply the proper value for `--protoc` because Bazel always knows where it can be found.