### PR TITLE
fix(linkinator): update linkinator to exclude CHANGELOG, node_modules

### DIFF
--- a/baselines/asset/linkinator.config.json.baseline
+++ b/baselines/asset/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/bigquery-storage/linkinator.config.json.baseline
+++ b/baselines/bigquery-storage/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/compute/linkinator.config.json.baseline
+++ b/baselines/compute/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/deprecatedtest/linkinator.config.json.baseline
+++ b/baselines/deprecatedtest/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/disable-packing-test/linkinator.config.json.baseline
+++ b/baselines/disable-packing-test/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/dlp/linkinator.config.json.baseline
+++ b/baselines/dlp/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/kms/linkinator.config.json.baseline
+++ b/baselines/kms/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/logging/linkinator.config.json.baseline
+++ b/baselines/logging/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/monitoring/linkinator.config.json.baseline
+++ b/baselines/monitoring/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/naming/linkinator.config.json.baseline
+++ b/baselines/naming/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/redis/linkinator.config.json.baseline
+++ b/baselines/redis/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/showcase-legacy/linkinator.config.json.baseline
+++ b/baselines/showcase-legacy/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/showcase/linkinator.config.json.baseline
+++ b/baselines/showcase/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/tasks/linkinator.config.json.baseline
+++ b/baselines/tasks/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/texttospeech/linkinator.config.json.baseline
+++ b/baselines/texttospeech/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/translate/linkinator.config.json.baseline
+++ b/baselines/translate/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/baselines/videointelligence/linkinator.config.json.baseline
+++ b/baselines/videointelligence/linkinator.config.json.baseline
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10

--- a/templates/typescript_gapic/linkinator.config.json.njk
+++ b/templates/typescript_gapic/linkinator.config.json.njk
@@ -3,7 +3,9 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "node_modules/",
+    "CHANGELOG.md"
   ],
   "silent": true,
   "concurrency": 10


### PR DESCRIPTION
Linkinator action attempts to crawl all prior releases in `CHANGELOG.md`, which can result in 100s of links being crawled blowing out quota.

`node_modules` should also be ignored form similar reasons.