### PR TITLE
chore(renovate): disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    "docker:disable"
+    "docker:disable",
+    ":disableDependencyDashboard"
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,


### PR DESCRIPTION
I see some errors in Renovate log related to it being unable to find a dependency dashboard issue, disabling it might help.