### PR TITLE
chore(renovate): add summer-ji-eng, rename package group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,14 +11,14 @@
   "packageRules": [
     {
       "packagePatterns": ["^.*$"],
-      "groupName": "all packages"
+      "groupName": "all dependencies"
     }
   ],
   "reviewers": [
     "alexander-fenster",
-    "bcoe"
+    "bcoe",
+    "summer-ji-eng"
   ],
-  "rebaseWhen": "never",
   "supportPolicy": "all",
   "ignoreDeps": ["node"]
 }


### PR DESCRIPTION
I _think_ the problem with renovate might be caused by some of its old PRs and the fact that we changed the main branch name. Let's try a few things:

(1) remove [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen) option;
(2) rename the package group name to make sure renovate will start using new branch.

Also, adding @summer-ji-eng as a reviewer for future Renovate PRs.

Hope it will work :)