### PR TITLE
build: decrease concurrency of link checking

### DIFF
--- a/baselines/asset/linkinator.config.json.baseline
+++ b/baselines/asset/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/bigquery-storage/linkinator.config.json.baseline
+++ b/baselines/bigquery-storage/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/compute/linkinator.config.json.baseline
+++ b/baselines/compute/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/deprecatedtest/linkinator.config.json.baseline
+++ b/baselines/deprecatedtest/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/disable-packing-test/linkinator.config.json.baseline
+++ b/baselines/disable-packing-test/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/dlp/linkinator.config.json.baseline
+++ b/baselines/dlp/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/kms/linkinator.config.json.baseline
+++ b/baselines/kms/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/logging/linkinator.config.json.baseline
+++ b/baselines/logging/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/monitoring/linkinator.config.json.baseline
+++ b/baselines/monitoring/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/naming/linkinator.config.json.baseline
+++ b/baselines/naming/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/redis/linkinator.config.json.baseline
+++ b/baselines/redis/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/showcase-legacy/linkinator.config.json.baseline
+++ b/baselines/showcase-legacy/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/showcase/linkinator.config.json.baseline
+++ b/baselines/showcase/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/tasks/linkinator.config.json.baseline
+++ b/baselines/tasks/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/texttospeech/linkinator.config.json.baseline
+++ b/baselines/texttospeech/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/translate/linkinator.config.json.baseline
+++ b/baselines/translate/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/baselines/videointelligence/linkinator.config.json.baseline
+++ b/baselines/videointelligence/linkinator.config.json.baseline
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }

--- a/templates/typescript_gapic/linkinator.config.json.njk
+++ b/templates/typescript_gapic/linkinator.config.json.njk
@@ -6,5 +6,5 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 10
+  "concurrency": 5
 }


### PR DESCRIPTION
Large libraries like nodejs-ai-platform bump into issues with concurrency of 10, reduce to 5.