### PR TITLE
fix: handle the fields with nums

### DIFF
--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -71,6 +71,10 @@ export function milliseconds(
   );
 }
 
+export function isNumber(value: string): boolean {
+  return value !== '' && !isNaN(Number(value));
+}
+
 String.prototype.capitalize = function (this: string): string {
   if (this.length === 0) {
     return this;
@@ -91,7 +95,14 @@ String.prototype.toCamelCase = function (this: string): string {
     return this;
   }
   const result = [words[0]];
-  result.push(...words.slice(1).map(w => w.capitalize()));
+  result.push(
+    ...words.slice(1).map(w => {
+      if (isNumber(w)) {
+        return '_' + w;
+      }
+      return w.capitalize();
+    })
+  );
   return result.join('');
 };
 

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -71,8 +71,8 @@ export function milliseconds(
   );
 }
 
-export function isNumber(value: string): boolean {
-  return value !== '' && !isNaN(Number(value));
+export function isDigit(value: string): boolean {
+  return /^\d+$/.test(value);
 }
 
 String.prototype.capitalize = function (this: string): string {
@@ -97,7 +97,7 @@ String.prototype.toCamelCase = function (this: string): string {
   const result = [words[0]];
   result.push(
     ...words.slice(1).map(w => {
-      if (isNumber(w)) {
+      if (isDigit(w)) {
         return '_' + w;
       }
       return w.capitalize();

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -14,7 +14,13 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {commonPrefix, duration, seconds, milliseconds} from '../../src/util';
+import {
+  commonPrefix,
+  duration,
+  seconds,
+  milliseconds,
+  isNumber,
+} from '../../src/util';
 import * as protos from '../../../protos';
 
 describe('src/util.ts', () => {
@@ -194,6 +200,10 @@ describe('src/util.ts', () => {
       assert.deepStrictEqual(
         'productName.v1p1beta1'.toCamelCase(),
         'productNameV1p1beta1'
+      );
+      assert.deepStrictEqual(
+        'display_video_360_advertiser_link'.toCamelCase(),
+        'displayVideo_360AdvertiserLink'
       );
     });
 
@@ -391,6 +401,21 @@ describe('src/util.ts', () => {
         ['tableReference', 'project_id'].toSnakeCaseString('!.'),
         'table_reference!.project_id'
       );
+    });
+  });
+
+  describe('Detect number', () => {
+    it('should return true if the string is number', () => {
+      assert.deepStrictEqual(isNumber('123'), true);
+      assert.deepStrictEqual(isNumber('0b110100'), true);
+      assert.deepStrictEqual(isNumber('Infinity'), true);
+      assert.deepStrictEqual(isNumber('-Infinity'), true);
+    });
+    it('should return false if the string is not number', () => {
+      assert.deepStrictEqual(isNumber('abc345'), false);
+      assert.deepStrictEqual(isNumber(''), false);
+      assert.deepStrictEqual(isNumber('hello'), false);
+      assert.deepStrictEqual(isNumber('NaN'), false);
     });
   });
 });

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -19,7 +19,7 @@ import {
   duration,
   seconds,
   milliseconds,
-  isNumber,
+  isDigit,
 } from '../../src/util';
 import * as protos from '../../../protos';
 
@@ -406,16 +406,16 @@ describe('src/util.ts', () => {
 
   describe('Detect number', () => {
     it('should return true if the string is number', () => {
-      assert.deepStrictEqual(isNumber('123'), true);
-      assert.deepStrictEqual(isNumber('0b110100'), true);
-      assert.deepStrictEqual(isNumber('Infinity'), true);
-      assert.deepStrictEqual(isNumber('-Infinity'), true);
+      assert.deepStrictEqual(isDigit('123'), true);
     });
     it('should return false if the string is not number', () => {
-      assert.deepStrictEqual(isNumber('abc345'), false);
-      assert.deepStrictEqual(isNumber(''), false);
-      assert.deepStrictEqual(isNumber('hello'), false);
-      assert.deepStrictEqual(isNumber('NaN'), false);
+      assert.deepStrictEqual(isDigit('abc345'), false);
+      assert.deepStrictEqual(isDigit(''), false);
+      assert.deepStrictEqual(isDigit('hello'), false);
+      assert.deepStrictEqual(isDigit('NaN'), false);
+      assert.deepStrictEqual(isDigit('0b110100'), false);
+      assert.deepStrictEqual(isDigit('Infinity'), false);
+      assert.deepStrictEqual(isDigit('-Infinity'), false);
     });
   });
 });


### PR DESCRIPTION
fix issue https://github.com/googleapis/nodejs-analytics-admin/pull/150
Similar to the fix in gapic-generator-go https://github.com/googleapis/gapic-generator-go/pull/746

When a proto field has a number in a snake_case field name like `foo_123_bar`, protobufjs generates the field name and resulting accessor as `Foo_123Bar`and `GetFoo_123Bar` respectively. We recently had an API add such a field, seemingly a first for us.

This change updates the snakeToCamel helper to account for that, and updates several places where it was being used directly to generate accessors to instead use the fieldGetter helper that uses snakeToCamel under the hood.

