### PR TITLE
chore: enable npm test to output errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "gts check",
     "prepack": "npm run compile && cd templates/typescript_gapic && rm -f package.json.njk && mv package.json package.json.njk && cd ../.. && mkdir -p build && cp -rf bazel-bin/typescript templates protos build/",
     "postpack": "cd templates/typescript_gapic && mv package.json.njk package.json && ln -s package.json package.json.njk",
-    "test": "bazel test //:unit_tests",
+    "test": "bazel test --test_output=errors //:unit_tests",
     "ts-test-application": "mocha bazel-bin/typescript/test/test-application/test-ts --timeout 600000"
   },
   "dependencies": {


### PR DESCRIPTION
Edit the `test` script to output errors directly for better usability when testing changes in the generator. 
