### PR TITLE
feat: add dynamic routing annotation parsing functionality

### DIFF
--- a/typescript/src/serviceyaml.ts
+++ b/typescript/src/serviceyaml.ts
@@ -15,4 +15,6 @@
 export interface ServiceYaml {
   title: string;
   apis: string[];
+  // TODO (alicejli): Dynamic routing headers will eventually be part of the ServiceYaml
+  // Refactor reading the annotation from the proto to the serviceYaml file once that is implemented.
 }

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -205,20 +205,16 @@ export function checkIfArrayContainsOnlyOneNamedSegment(
   pattern: string[]
 ): boolean {
   let countOfNamedSegments = 0;
-  let counter = 0;
   // Checks that resources are named
   const regexNamed = new RegExp(/^.+=.+/);
   const regexWildcard = new RegExp(/^{[a-zA-Z\d-]+}/);
-  pattern.forEach((element) => {
-    if (
-      regexNamed.test(element) ||
-      regexWildcard.test(element)
-    ) {
+  pattern.forEach(element => {
+    if (regexNamed.test(element) || regexWildcard.test(element)) {
       countOfNamedSegments++;
     }
-  })
-    return countOfNamedSegments === 1;
-  }
+  });
+  return countOfNamedSegments === 1;
+}
 
 // This takes in a path template segment and converts it into regex.
 export function convertSegmentToRegex(pattern: string): string {

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -307,35 +307,35 @@ export function convertTemplateToRegex(pattern: string): string {
 // This intakes a path template and returns an array where the first element is the full named
 // segment, the second element is the name of the segment, the third element is the segment itself,
 // and the fourth element is the named capture regex of the named segement.
-// If the path template does not contain exactly one named segment, this function will return an empty array. 
+// If the path template does not contain exactly one named segment, this function will return an empty array.
 export function getNamedSegment(pattern: string): string[] {
   //Named segment in path template will always be contained within curly braces, e.g. '{}'
   const curlyBraceRegex = new RegExp(/[^{}]+(?=})/g);
   const element = pattern.match(curlyBraceRegex);
   if (element && checkIfArrayContainsOnlyOneNamedSegment(element)) {
-      const namedSegment = [];
-      // This contains the full named segment.
-      namedSegment.push(element[0]);
-      // This extracts the name from the named segment.
-      const name = element[0].match(/^(.*?)=/);
-      namedSegment.push(name![1]);
-      // This extracts the segment from the named segement.
-      const extractNameRegex = new RegExp(name![1] + '=(.*)');
-      const segment = element[0].match(extractNameRegex)![1];
-      namedSegment.push(segment);
-      // This converts the full named segment into regex.
-      // Special case for double wildcard in a named segment as we
-      // do want to capture it for a named segment.
-      if (isDoubleStar(segment) || isDoubleStar(segment.replaceAll('}', ''))) {
-        const resourceRegex = '.*';
-        const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
-        namedSegment.push(fullRegex);
-      } else {
-        const resourceRegex = convertTemplateToRegex(segment);
-        const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
-        namedSegment.push(fullRegex);
-      }
-      return namedSegment;
+    const namedSegment = [];
+    // This contains the full named segment.
+    namedSegment.push(element[0]);
+    // This extracts the name from the named segment.
+    const name = element[0].match(/^(.*?)=/);
+    namedSegment.push(name![1]);
+    // This extracts the segment from the named segement.
+    const extractNameRegex = new RegExp(name![1] + '=(.*)');
+    const segment = element[0].match(extractNameRegex)![1];
+    namedSegment.push(segment);
+    // This converts the full named segment into regex.
+    // Special case for double wildcard in a named segment as we
+    // do want to capture it for a named segment.
+    if (isDoubleStar(segment) || isDoubleStar(segment.replaceAll('}', ''))) {
+      const resourceRegex = '.*';
+      const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
+      namedSegment.push(fullRegex);
+    } else {
+      const resourceRegex = convertTemplateToRegex(segment);
+      const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
+      namedSegment.push(fullRegex);
+    }
+    return namedSegment;
   } else {
     return [];
   }

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -209,20 +209,16 @@ export function checkIfArrayContainsOnlyOneNamedSegment(
   // Checks that resources are named
   const regexNamed = new RegExp(/^.+=.+/);
   const regexWildcard = new RegExp(/^{[a-zA-Z\d-]+}/);
-  while (counter < pattern.length) {
+  pattern.forEach((element) => {
     if (
-      regexNamed.test(pattern[counter]) ||
-      regexWildcard.test(pattern[counter])
+      regexNamed.test(element) ||
+      regexWildcard.test(element)
     ) {
       countOfNamedSegments++;
     }
-    counter++;
-    if (countOfNamedSegments > 1) {
-      return false;
-    }
+  })
+    return countOfNamedSegments === 1;
   }
-  return countOfNamedSegments === 1;
-}
 
 // This takes in a path template segment and converts it into regex.
 export function convertSegmentToRegex(pattern: string): string {

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -190,3 +190,153 @@ export function getResourceNameByPattern(pattern: string): string {
   }
   return name.join('_');
 }
+
+export function isStar(pattern: string): boolean {
+  if (pattern === '*') {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export function isDoubleStar(pattern: string): boolean {
+  if (pattern === '**') {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// This intakes an array of strings and checks if there is at least one and only one named segment.
+// Named segments can be resource names or wildcards.
+export function checkIfArrayContainsOnlyOneNamedSegment(
+  pattern: string[]
+): boolean {
+  let countOfNamedSegments = 0;
+  let counter = 0;
+  // Checks that resources are named
+  const regexNamed = new RegExp(/^.+=.+/);
+  const regexWildcard = new RegExp(/^{[a-zA-Z\d-]+}/);
+  while (counter < pattern.length) {
+    if (
+      regexNamed.test(pattern[counter]) ||
+      regexWildcard.test(pattern[counter])
+    ) {
+      countOfNamedSegments++;
+    }
+    counter++;
+    if (countOfNamedSegments > 1) {
+      return false;
+    }
+  }
+  if (countOfNamedSegments < 1) {
+    return false;
+  }
+  return true;
+}
+
+// This takes in a path template segment and converts it into regex.
+
+export function convertSegmentToRegex(pattern: string): string {
+  const curlyBraceRegex = new RegExp(/{(.[^}]+)/);
+  const namedResourceRegex = new RegExp(/=/);
+  const getBeforeAfterEqualsSign = new RegExp(/([^=]*)=(.*)/);
+  if (isStar(pattern) || isStar(pattern.replaceAll('}', ''))) {
+    return '[^/]+';
+  }
+  // If segment is a double-wildcard, then it will 'eat' the precending '/'.
+  else if (isDoubleStar(pattern) || isDoubleStar(pattern.replaceAll('}', ''))) {
+    return '(?:/.*)?';
+  }
+  // If segment has a starting curly brace, and is not named, then it is a wildcard.
+  else if (curlyBraceRegex.test(pattern) && !namedResourceRegex.test(pattern)) {
+    // Strip any curly braces
+    const newPattern = pattern.replaceAll('}', '').replaceAll('{', '');
+    return '(?<' + newPattern + '>[^/]+)';
+  }
+  // If segment contains named resource, then the resource could be a wildcard or
+  // a collectionId
+  else if (curlyBraceRegex.test(pattern) && namedResourceRegex.test(pattern)) {
+    // Strip any curly braces
+    const newPattern = pattern.replaceAll('}', '').replaceAll('{', '');
+    const elements = newPattern.match(getBeforeAfterEqualsSign);
+    const name = '(?<' + elements![1] + '>';
+    const resource = elements![2];
+    if (isStar(resource)) {
+      return name + '[^/]+)';
+    } else if (isDoubleStar(resource)) {
+      return name + '(?:/.*)?' + ')';
+    } else {
+      return name + resource + ')';
+    }
+  }
+  // If segment is just a CollectionId, then the regex equivalent is itself.
+  else if (pattern.match(/[a-zA-Z_-]+/)) {
+    return pattern;
+  } else {
+    return '';
+  }
+}
+
+// This takes in a full path template and converts it into regex.
+export function convertTemplateToRegex(pattern: string): string {
+  const splitStrings = pattern.split('/');
+  const regexStrings: string[] = [];
+  while (splitStrings.length > 0) {
+    const item = splitStrings.shift();
+    const itemToRegex = convertSegmentToRegex(item!);
+    // If item is a double-wildcard, then do not include a '/' separator as a double-wildcard may be empty.
+    const doubleWildcardRegex = new RegExp(/\*\*/);
+    if (doubleWildcardRegex.test(item!)) {
+      regexStrings.push(itemToRegex);
+    } else {
+      regexStrings.push('/');
+      regexStrings.push(itemToRegex);
+    }
+  }
+  const helperString = regexStrings.join('');
+  // Check if string begins with separator
+  const separatorRegex = new RegExp(/^\//);
+  if (separatorRegex.test(helperString)) {
+    const newString = helperString.substring(1);
+    return newString;
+  }
+  return helperString;
+}
+
+// This intakes a path template and returns an array where the first element is the full named
+// segment, the second element is the name of the segment, the third element is the segment itself,
+// and the fourth element is the named capture regex of the named segement.
+// If the path template does not contain exactly one named segment, this function will return an empty array. 
+export function getNamedSegment(pattern: string): string[] {
+  //Named segment in path template will always be contained within curly braces, e.g. '{}'
+  const curlyBraceRegex = new RegExp(/[^{}]+(?=})/g);
+  const element = pattern.match(curlyBraceRegex);
+  if (element && checkIfArrayContainsOnlyOneNamedSegment(element)) {
+      const namedSegment = [];
+      // This contains the full named segment.
+      namedSegment.push(element[0]);
+      // This extracts the name from the named segment.
+      const name = element[0].match(/^(.*?)=/);
+      namedSegment.push(name![1]);
+      // This extracts the segment from the named segement.
+      const extractNameRegex = new RegExp(name![1] + '=(.*)');
+      const segment = element[0].match(extractNameRegex)![1];
+      namedSegment.push(segment);
+      // This converts the full named segment into regex.
+      // Special case for double wildcard in a named segment as we
+      // do want to capture it for a named segment.
+      if (isDoubleStar(segment) || isDoubleStar(segment.replaceAll('}', ''))) {
+        const resourceRegex = '.*';
+        const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
+        namedSegment.push(fullRegex);
+      } else {
+        const resourceRegex = convertTemplateToRegex(segment);
+        const fullRegex = '(?<' + name![1] + '>' + resourceRegex + ')';
+        namedSegment.push(fullRegex);
+      }
+      return namedSegment;
+  } else {
+    return [];
+  }
+}

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -14,7 +14,17 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {commonPrefix, duration, seconds, milliseconds, isDigit, checkIfArrayContainsOnlyOneNamedSegment, convertSegmentToRegex, convertTemplateToRegex, getNamedSegment} from '../../src/util';
+import {
+  commonPrefix,
+  duration,
+  seconds,
+  milliseconds,
+  isDigit,
+  checkIfArrayContainsOnlyOneNamedSegment,
+  convertSegmentToRegex,
+  convertTemplateToRegex,
+  getNamedSegment,
+} from '../../src/util';
 import * as protos from '../../../protos';
 
 describe('src/util.ts', () => {
@@ -560,10 +570,15 @@ describe('src/util.ts', () => {
         '**',
         '(?<routing_id>.*)',
       ]);
-    it('should return an empty array if the path template does not contain exactly one named segment', () => {
-      assert.deepStrictEqual(getNamedSegment('test/database'), [])
-      assert.deepStrictEqual(getNamedSegment('test/{database=projects/*/databases/*}/documents/*/**/{hello=world}'), [])
-    });
+      it('should return an empty array if the path template does not contain exactly one named segment', () => {
+        assert.deepStrictEqual(getNamedSegment('test/database'), []);
+        assert.deepStrictEqual(
+          getNamedSegment(
+            'test/{database=projects/*/databases/*}/documents/*/**/{hello=world}'
+          ),
+          []
+        );
+      });
     });
   });
 });

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -422,7 +422,7 @@ describe('src/util.ts', () => {
       assert.deepStrictEqual(isDigit('-Infinity'), false);
     });
   });
-  
+
   describe('Array check', () => {
     it('should get return true if an array of strings contains exactly one named segment', () => {
       assert.deepStrictEqual(

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -570,6 +570,12 @@ describe('src/util.ts', () => {
         '**',
         '(?<routing_id>.*)',
       ]);
+      assert.deepStrictEqual(getNamedSegment('{database}'), [
+        'database',
+        'database',
+        '*',
+        '[^/]+',
+      ]);
       it('should return an empty array if the path template does not contain exactly one named segment', () => {
         assert.deepStrictEqual(getNamedSegment('test/database'), []);
         assert.deepStrictEqual(


### PR DESCRIPTION
Breaking up https://github.com/googleapis/gapic-generator-typescript/pull/1007 into 2 different PRs for ease of review. This part adds in the ability to parse a dynamic routing header annotation and convert it into regex. 

Background:

For issue: googleapis/google-cloud-node-core#584

For the purpose of routing at GFE level, there is a need for a part of RPC’s input message to be extracted and put into a header. This is called ‘dynamic routing’ and the header ‘the routing header’. There are 3 teams that currently have a need for this functionality: BigTable, Spanner and Firestore.

Currently there is a support for dynamic routing in client libraries – the code fills the x-goog-request-params header with the string constructed from the values of the fields bound to the URI in the google.api.http annotation. However, several teams want the ability to specify a more specific header. This header will be specified in a new google.api.routing annotation, detailed as such:

```
// Specification of information to add to facilitate correct routing of the API requests.
message RoutingRule {
  repeated HeaderParameter routing_parameters = 1;
}
```
where HeaderParameter is

```
// A projection from an input message to the routing header
message HeaderParameter {
  // A field to extract the header key-value pair from
  string field = 1;
  // A pattern matching the key-value field. Optional.
  // If not specified, the whole field specified in the field field will be taken as value, and its name used as key.  
  string path_template = 2;
}
```

TODO: The ability to override this annotation will exist in the ${service}.yaml file for each API. Once that is built, will need to add in that as a source for where the generator checks for the headers to generate.

Please ping me for additional internal docs or info if needed.