### PR TITLE
feat: move comments in front of overloaded function

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -313,26 +313,6 @@ export class AssetServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  batchGetAssetsHistory(
-      request?: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
-        protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|undefined, {}|undefined
-      ]>;
-  batchGetAssetsHistory(
-      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
-          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
-          {}|null|undefined>): void;
-  batchGetAssetsHistory(
-      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
-          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Batch gets the update history of assets that overlap a time window.
  * For RESOURCE content, this API outputs history with asset in both
@@ -380,6 +360,26 @@ export class AssetServiceClient {
  */
   batchGetAssetsHistory(
       request?: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
+        protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|undefined, {}|undefined
+      ]>;
+  batchGetAssetsHistory(
+      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
+          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
+          {}|null|undefined>): void;
+  batchGetAssetsHistory(
+      request: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
+          protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
+          {}|null|undefined>): void;
+  batchGetAssetsHistory(
+      request?: protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryResponse,
           protos.google.cloud.asset.v1.IBatchGetAssetsHistoryRequest|null|undefined,
@@ -412,26 +412,6 @@ export class AssetServiceClient {
     this.initialize();
     return this.innerApiCalls.batchGetAssetsHistory(request, options, callback);
   }
-  createFeed(
-      request?: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.asset.v1.IFeed,
-        protos.google.cloud.asset.v1.ICreateFeedRequest|undefined, {}|undefined
-      ]>;
-  createFeed(
-      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
-          {}|null|undefined>): void;
-  createFeed(
-      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a feed in a parent project/folder/organization to listen to its
  * asset updates.
@@ -463,6 +443,26 @@ export class AssetServiceClient {
  * @example
  * const [response] = await client.createFeed(request);
  */
+  createFeed(
+      request?: protos.google.cloud.asset.v1.ICreateFeedRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.asset.v1.IFeed,
+        protos.google.cloud.asset.v1.ICreateFeedRequest|undefined, {}|undefined
+      ]>;
+  createFeed(
+      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
+          {}|null|undefined>): void;
+  createFeed(
+      request: protos.google.cloud.asset.v1.ICreateFeedRequest,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.ICreateFeedRequest|null|undefined,
+          {}|null|undefined>): void;
   createFeed(
       request?: protos.google.cloud.asset.v1.ICreateFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -497,26 +497,6 @@ export class AssetServiceClient {
     this.initialize();
     return this.innerApiCalls.createFeed(request, options, callback);
   }
-  getFeed(
-      request?: protos.google.cloud.asset.v1.IGetFeedRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.asset.v1.IFeed,
-        protos.google.cloud.asset.v1.IGetFeedRequest|undefined, {}|undefined
-      ]>;
-  getFeed(
-      request: protos.google.cloud.asset.v1.IGetFeedRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
-          {}|null|undefined>): void;
-  getFeed(
-      request: protos.google.cloud.asset.v1.IGetFeedRequest,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets details about an asset feed.
  *
@@ -537,6 +517,26 @@ export class AssetServiceClient {
  * @example
  * const [response] = await client.getFeed(request);
  */
+  getFeed(
+      request?: protos.google.cloud.asset.v1.IGetFeedRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.asset.v1.IFeed,
+        protos.google.cloud.asset.v1.IGetFeedRequest|undefined, {}|undefined
+      ]>;
+  getFeed(
+      request: protos.google.cloud.asset.v1.IGetFeedRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
+          {}|null|undefined>): void;
+  getFeed(
+      request: protos.google.cloud.asset.v1.IGetFeedRequest,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.IGetFeedRequest|null|undefined,
+          {}|null|undefined>): void;
   getFeed(
       request?: protos.google.cloud.asset.v1.IGetFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -571,6 +571,25 @@ export class AssetServiceClient {
     this.initialize();
     return this.innerApiCalls.getFeed(request, options, callback);
   }
+/**
+ * Lists all asset feeds in a parent project/folder/organization.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The parent project/folder/organization whose feeds are to be
+ *   listed. It can only be using project/folder/organization number (such as
+ *   "folders/12345")", or a project ID (such as "projects/my-project-id").
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ListFeedsResponse]{@link google.cloud.asset.v1.ListFeedsResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.listFeeds(request);
+ */
   listFeeds(
       request?: protos.google.cloud.asset.v1.IListFeedsRequest,
       options?: CallOptions):
@@ -591,25 +610,6 @@ export class AssetServiceClient {
           protos.google.cloud.asset.v1.IListFeedsResponse,
           protos.google.cloud.asset.v1.IListFeedsRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Lists all asset feeds in a parent project/folder/organization.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.parent
- *   Required. The parent project/folder/organization whose feeds are to be
- *   listed. It can only be using project/folder/organization number (such as
- *   "folders/12345")", or a project ID (such as "projects/my-project-id").
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [ListFeedsResponse]{@link google.cloud.asset.v1.ListFeedsResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.listFeeds(request);
- */
   listFeeds(
       request?: protos.google.cloud.asset.v1.IListFeedsRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -644,26 +644,6 @@ export class AssetServiceClient {
     this.initialize();
     return this.innerApiCalls.listFeeds(request, options, callback);
   }
-  updateFeed(
-      request?: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.asset.v1.IFeed,
-        protos.google.cloud.asset.v1.IUpdateFeedRequest|undefined, {}|undefined
-      ]>;
-  updateFeed(
-      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateFeed(
-      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
-      callback: Callback<
-          protos.google.cloud.asset.v1.IFeed,
-          protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates an asset feed configuration.
  *
@@ -689,6 +669,26 @@ export class AssetServiceClient {
  * @example
  * const [response] = await client.updateFeed(request);
  */
+  updateFeed(
+      request?: protos.google.cloud.asset.v1.IUpdateFeedRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.asset.v1.IFeed,
+        protos.google.cloud.asset.v1.IUpdateFeedRequest|undefined, {}|undefined
+      ]>;
+  updateFeed(
+      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateFeed(
+      request: protos.google.cloud.asset.v1.IUpdateFeedRequest,
+      callback: Callback<
+          protos.google.cloud.asset.v1.IFeed,
+          protos.google.cloud.asset.v1.IUpdateFeedRequest|null|undefined,
+          {}|null|undefined>): void;
   updateFeed(
       request?: protos.google.cloud.asset.v1.IUpdateFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -723,26 +723,6 @@ export class AssetServiceClient {
     this.initialize();
     return this.innerApiCalls.updateFeed(request, options, callback);
   }
-  deleteFeed(
-      request?: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.cloud.asset.v1.IDeleteFeedRequest|undefined, {}|undefined
-      ]>;
-  deleteFeed(
-      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteFeed(
-      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an asset feed.
  *
@@ -763,6 +743,26 @@ export class AssetServiceClient {
  * @example
  * const [response] = await client.deleteFeed(request);
  */
+  deleteFeed(
+      request?: protos.google.cloud.asset.v1.IDeleteFeedRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.cloud.asset.v1.IDeleteFeedRequest|undefined, {}|undefined
+      ]>;
+  deleteFeed(
+      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteFeed(
+      request: protos.google.cloud.asset.v1.IDeleteFeedRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.asset.v1.IDeleteFeedRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteFeed(
       request?: protos.google.cloud.asset.v1.IDeleteFeedRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -798,26 +798,6 @@ export class AssetServiceClient {
     return this.innerApiCalls.deleteFeed(request, options, callback);
   }
 
-  exportAssets(
-      request?: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  exportAssets(
-      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  exportAssets(
-      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Exports assets with time and resource types to a given Cloud Storage
  * location. The output format is newline-delimited JSON.
@@ -862,6 +842,26 @@ export class AssetServiceClient {
  * const [operation] = await client.exportAssets(request);
  * const [response] = await operation.promise();
  */
+  exportAssets(
+      request?: protos.google.cloud.asset.v1.IExportAssetsRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  exportAssets(
+      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  exportAssets(
+      request: protos.google.cloud.asset.v1.IExportAssetsRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   exportAssets(
       request?: protos.google.cloud.asset.v1.IExportAssetsRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -297,26 +297,6 @@ export class BigQueryStorageClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  createReadSession(
-      request?: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
-        protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|undefined, {}|undefined
-      ]>;
-  createReadSession(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
-          protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
-          {}|null|undefined>): void;
-  createReadSession(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
-          protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new read session. A read session divides the contents of a
  * BigQuery table into one or more streams, which can then be used to read
@@ -368,6 +348,26 @@ export class BigQueryStorageClient {
  */
   createReadSession(
       request?: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
+        protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|undefined, {}|undefined
+      ]>;
+  createReadSession(
+      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
+          protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
+          {}|null|undefined>): void;
+  createReadSession(
+      request: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
+          protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
+          {}|null|undefined>): void;
+  createReadSession(
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.bigquery.storage.v1beta1.IReadSession,
           protos.google.cloud.bigquery.storage.v1beta1.ICreateReadSessionRequest|null|undefined,
@@ -401,26 +401,6 @@ export class BigQueryStorageClient {
     this.initialize();
     return this.innerApiCalls.createReadSession(request, options, callback);
   }
-  batchCreateReadSessionStreams(
-      request?: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
-        protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|undefined, {}|undefined
-      ]>;
-  batchCreateReadSessionStreams(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
-          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
-          {}|null|undefined>): void;
-  batchCreateReadSessionStreams(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
-          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates additional streams for a ReadSession. This API can be used to
  * dynamically adjust the parallelism of a batch processing task upwards by
@@ -445,6 +425,26 @@ export class BigQueryStorageClient {
  * @example
  * const [response] = await client.batchCreateReadSessionStreams(request);
  */
+  batchCreateReadSessionStreams(
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
+        protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|undefined, {}|undefined
+      ]>;
+  batchCreateReadSessionStreams(
+      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
+          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
+          {}|null|undefined>): void;
+  batchCreateReadSessionStreams(
+      request: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsResponse,
+          protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest|null|undefined,
+          {}|null|undefined>): void;
   batchCreateReadSessionStreams(
       request?: protos.google.cloud.bigquery.storage.v1beta1.IBatchCreateReadSessionStreamsRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -479,26 +479,6 @@ export class BigQueryStorageClient {
     this.initialize();
     return this.innerApiCalls.batchCreateReadSessionStreams(request, options, callback);
   }
-  finalizeStream(
-      request?: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|undefined, {}|undefined
-      ]>;
-  finalizeStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
-          {}|null|undefined>): void;
-  finalizeStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Triggers the graceful termination of a single stream in a ReadSession. This
  * API can be used to dynamically adjust the parallelism of a batch processing
@@ -529,6 +509,26 @@ export class BigQueryStorageClient {
  * @example
  * const [response] = await client.finalizeStream(request);
  */
+  finalizeStream(
+      request?: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|undefined, {}|undefined
+      ]>;
+  finalizeStream(
+      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
+          {}|null|undefined>): void;
+  finalizeStream(
+      request: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest|null|undefined,
+          {}|null|undefined>): void;
   finalizeStream(
       request?: protos.google.cloud.bigquery.storage.v1beta1.IFinalizeStreamRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -563,26 +563,6 @@ export class BigQueryStorageClient {
     this.initialize();
     return this.innerApiCalls.finalizeStream(request, options, callback);
   }
-  splitReadStream(
-      request?: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
-        protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|undefined, {}|undefined
-      ]>;
-  splitReadStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
-          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
-          {}|null|undefined>): void;
-  splitReadStream(
-      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
-      callback: Callback<
-          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
-          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Splits a given read stream into two Streams. These streams are referred to
  * as the primary and the residual of the split. The original stream can still
@@ -620,6 +600,26 @@ export class BigQueryStorageClient {
  * @example
  * const [response] = await client.splitReadStream(request);
  */
+  splitReadStream(
+      request?: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
+        protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|undefined, {}|undefined
+      ]>;
+  splitReadStream(
+      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
+          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
+          {}|null|undefined>): void;
+  splitReadStream(
+      request: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
+      callback: Callback<
+          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamResponse,
+          protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest|null|undefined,
+          {}|null|undefined>): void;
   splitReadStream(
       request?: protos.google.cloud.bigquery.storage.v1beta1.ISplitReadStreamRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -293,26 +293,6 @@ export class AddressesClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  delete(
-      request?: protos.google.cloud.compute.v1.IDeleteAddressRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
-        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
-      ]>;
-  delete(
-      request: protos.google.cloud.compute.v1.IDeleteAddressRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IDeleteAddressRequest|null|undefined,
-          {}|null|undefined>): void;
-  delete(
-      request: protos.google.cloud.compute.v1.IDeleteAddressRequest,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IDeleteAddressRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes the specified address resource.
  *
@@ -345,6 +325,26 @@ export class AddressesClient {
  * @example
  * const [operation] = await client.delete(request);
  */
+  delete(
+      request?: protos.google.cloud.compute.v1.IDeleteAddressRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
+      ]>;
+  delete(
+      request: protos.google.cloud.compute.v1.IDeleteAddressRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IDeleteAddressRequest|null|undefined,
+          {}|null|undefined>): void;
+  delete(
+      request: protos.google.cloud.compute.v1.IDeleteAddressRequest,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IDeleteAddressRequest|null|undefined,
+          {}|null|undefined>): void;
   delete(
       request?: protos.google.cloud.compute.v1.IDeleteAddressRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -386,26 +386,6 @@ export class AddressesClient {
         ];
     });
   }
-  insert(
-      request?: protos.google.cloud.compute.v1.IInsertAddressRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
-        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
-      ]>;
-  insert(
-      request: protos.google.cloud.compute.v1.IInsertAddressRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IInsertAddressRequest|null|undefined,
-          {}|null|undefined>): void;
-  insert(
-      request: protos.google.cloud.compute.v1.IInsertAddressRequest,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IInsertAddressRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates an address resource in the specified project by using the data included in the request.
  *
@@ -438,6 +418,26 @@ export class AddressesClient {
  * @example
  * const [operation] = await client.insert(request);
  */
+  insert(
+      request?: protos.google.cloud.compute.v1.IInsertAddressRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.compute.v1.IOperation, null>,
+        protos.google.cloud.compute.v1.IOperation|undefined, {}|undefined
+      ]>;
+  insert(
+      request: protos.google.cloud.compute.v1.IInsertAddressRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IInsertAddressRequest|null|undefined,
+          {}|null|undefined>): void;
+  insert(
+      request: protos.google.cloud.compute.v1.IInsertAddressRequest,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IInsertAddressRequest|null|undefined,
+          {}|null|undefined>): void;
   insert(
       request?: protos.google.cloud.compute.v1.IInsertAddressRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -548,28 +548,7 @@ export class AddressesClient {
       callSettings
     ) as AsyncIterable<[string, protos.google.cloud.compute.v1.IAddressesScopedList]>;
   }
-  list(
-      request?: protos.google.cloud.compute.v1.IListAddressesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.compute.v1.IAddress[],
-        protos.google.cloud.compute.v1.IListAddressesRequest|null,
-        protos.google.cloud.compute.v1.IAddressList
-      ]>;
-  list(
-      request: protos.google.cloud.compute.v1.IListAddressesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.compute.v1.IListAddressesRequest,
-          protos.google.cloud.compute.v1.IAddressList|null|undefined,
-          protos.google.cloud.compute.v1.IAddress>): void;
-  list(
-      request: protos.google.cloud.compute.v1.IListAddressesRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.compute.v1.IListAddressesRequest,
-          protos.google.cloud.compute.v1.IAddressList|null|undefined,
-          protos.google.cloud.compute.v1.IAddress>): void;
-/**
+ /**
  * Retrieves a list of addresses contained within the specified region.
  *
  * @param {Object} request
@@ -609,6 +588,27 @@ export class AddressesClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  list(
+      request?: protos.google.cloud.compute.v1.IListAddressesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.compute.v1.IAddress[],
+        protos.google.cloud.compute.v1.IListAddressesRequest|null,
+        protos.google.cloud.compute.v1.IAddressList
+      ]>;
+  list(
+      request: protos.google.cloud.compute.v1.IListAddressesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.compute.v1.IListAddressesRequest,
+          protos.google.cloud.compute.v1.IAddressList|null|undefined,
+          protos.google.cloud.compute.v1.IAddress>): void;
+  list(
+      request: protos.google.cloud.compute.v1.IListAddressesRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.compute.v1.IListAddressesRequest,
+          protos.google.cloud.compute.v1.IAddressList|null|undefined,
+          protos.google.cloud.compute.v1.IAddress>): void;
   list(
       request?: protos.google.cloud.compute.v1.IListAddressesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -278,26 +278,6 @@ export class RegionOperationsClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  get(
-      request?: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IGetRegionOperationRequest|undefined, {}|undefined
-      ]>;
-  get(
-      request: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IGetRegionOperationRequest|null|undefined,
-          {}|null|undefined>): void;
-  get(
-      request: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IGetRegionOperationRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Retrieves the specified region-specific Operations resource.
  *
@@ -319,6 +299,26 @@ export class RegionOperationsClient {
  * @example
  * const [response] = await client.get(request);
  */
+  get(
+      request?: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.compute.v1.IOperation,
+        protos.google.cloud.compute.v1.IGetRegionOperationRequest|undefined, {}|undefined
+      ]>;
+  get(
+      request: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IGetRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
+  get(
+      request: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IGetRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
   get(
       request?: protos.google.cloud.compute.v1.IGetRegionOperationRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -353,26 +353,6 @@ export class RegionOperationsClient {
     this.initialize();
     return this.innerApiCalls.get(request, options, callback);
   }
-  wait(
-      request?: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.compute.v1.IOperation,
-        protos.google.cloud.compute.v1.IWaitRegionOperationRequest|undefined, {}|undefined
-      ]>;
-  wait(
-      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
-          {}|null|undefined>): void;
-  wait(
-      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
-      callback: Callback<
-          protos.google.cloud.compute.v1.IOperation,
-          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Waits for the specified Operation resource to return as `DONE` or for the request to approach the 2 minute deadline, and retrieves the specified Operation resource. This method differs from the `GET` method in that it waits for no more than the default deadline (2 minutes) and then returns the current state of the operation, which might be `DONE` or still in progress.
  *
@@ -398,6 +378,26 @@ export class RegionOperationsClient {
  * @example
  * const [response] = await client.wait(request);
  */
+  wait(
+      request?: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.compute.v1.IOperation,
+        protos.google.cloud.compute.v1.IWaitRegionOperationRequest|undefined, {}|undefined
+      ]>;
+  wait(
+      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
+  wait(
+      request: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
+      callback: Callback<
+          protos.google.cloud.compute.v1.IOperation,
+          protos.google.cloud.compute.v1.IWaitRegionOperationRequest|null|undefined,
+          {}|null|undefined>): void;
   wait(
       request?: protos.google.cloud.compute.v1.IWaitRegionOperationRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -277,6 +277,23 @@ export class DeprecatedServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Calculates Fibonacci on the provided value, quickly.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {number} request.value
+ *   The nth term to retrieve in the Fibonacci sequence.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.fastFibonacci(request);
+ */
   fastFibonacci(
       request?: protos.google.deprecatedtest.v1.IFibonacciRequest,
       options?: CallOptions):
@@ -297,23 +314,6 @@ export class DeprecatedServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.deprecatedtest.v1.IFibonacciRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Calculates Fibonacci on the provided value, quickly.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {number} request.value
- *   The nth term to retrieve in the Fibonacci sequence.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.fastFibonacci(request);
- */
   fastFibonacci(
       request?: protos.google.deprecatedtest.v1.IFibonacciRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -341,6 +341,24 @@ export class DeprecatedServiceClient {
     this.initialize();
     return this.innerApiCalls.fastFibonacci(request, options, callback);
   }
+/**
+ * Calculates Fibonacci on the provided value, slowly.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {number} request.value
+ *   The nth term to retrieve in the Fibonacci sequence.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.slowFibonacci(request);
+ * @deprecated SlowFibonacci is deprecated and may be removed in a future version.
+ */
   slowFibonacci(
       request?: protos.google.deprecatedtest.v1.IFibonacciRequest,
       options?: CallOptions):
@@ -361,24 +379,6 @@ export class DeprecatedServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.deprecatedtest.v1.IFibonacciRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Calculates Fibonacci on the provided value, slowly.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {number} request.value
- *   The nth term to retrieve in the Fibonacci sequence.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.slowFibonacci(request);
- * @deprecated SlowFibonacci is deprecated and may be removed in a future version.
- */
   slowFibonacci(
       request?: protos.google.deprecatedtest.v1.IFibonacciRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -353,6 +353,23 @@ export class EchoClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.content
+ *   The content to be echoed by the server.
+ * @param {google.rpc.Status} request.error
+ *   The error to be thrown by the server.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.echo(request);
+ */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       options?: CallOptions):
@@ -373,23 +390,6 @@ export class EchoClient {
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.content
- *   The content to be echoed by the server.
- * @param {google.rpc.Status} request.error
- *   The error to be thrown by the server.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.echo(request);
- */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -417,26 +417,6 @@ export class EchoClient {
     this.initialize();
     return this.innerApiCalls.echo(request, options, callback);
   }
-  block(
-      request?: protos.google.showcase.v1beta1.IBlockRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlockResponse,
-        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
-      ]>;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will block (wait) for the requested amount of time
  * and then return the response or error.
@@ -461,6 +441,26 @@ export class EchoClient {
  * @example
  * const [response] = await client.block(request);
  */
+  block(
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlockResponse,
+        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
+      ]>;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
   block(
       request?: protos.google.showcase.v1beta1.IBlockRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -521,19 +521,6 @@ export class EchoClient {
     return this.innerApiCalls.expand(request, options);
   }
 
-  collect(
-      options?: CallOptions,
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
-  collect(
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
 /**
  * This method will collect the words given to it. When the stream is closed
  * by the client, this method will return the a concatenation of the strings
@@ -551,6 +538,19 @@ export class EchoClient {
  * stream.write(request);
  * stream.end();
  */
+  collect(
+      options?: CallOptions,
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
+  collect(
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
   collect(
       optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
@@ -598,26 +598,6 @@ export class EchoClient {
     return this.innerApiCalls.chat(options);
   }
 
-  wait(
-      request?: protos.google.showcase.v1beta1.IWaitRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will wait the requested amount of and then return.
  * This method showcases how a client handles a request timing out.
@@ -646,6 +626,26 @@ export class EchoClient {
  * const [operation] = await client.wait(request);
  * const [response] = await operation.promise();
  */
+  wait(
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   wait(
       request?: protos.google.showcase.v1beta1.IWaitRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -694,28 +694,7 @@ export class EchoClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
-  pagedExpand(
-      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IEchoResponse[],
-        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
-        protos.google.showcase.v1beta1.IPagedExpandResponse
-      ]>;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-/**
+ /**
  * This is similar to the Expand method but instead of returning a stream of
  * expanded words, this method returns a paged list of expanded words.
  *
@@ -740,6 +719,27 @@ export class EchoClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  pagedExpand(
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IEchoResponse[],
+        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
+        protos.google.showcase.v1beta1.IPagedExpandResponse
+      ]>;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
   pagedExpand(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -316,6 +316,23 @@ export class IdentityClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a user.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.User} request.user
+ *   The user to create.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createUser(request);
+ */
   createUser(
       request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       options?: CallOptions):
@@ -336,23 +353,6 @@ export class IdentityClient {
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a user.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.User} request.user
- *   The user to create.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createUser(request);
- */
   createUser(
       request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -380,6 +380,23 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.createUser(request, options, callback);
   }
+/**
+ * Retrieves the User with the given uri.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested user.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getUser(request);
+ */
   getUser(
       request?: protos.google.showcase.v1beta1.IGetUserRequest,
       options?: CallOptions):
@@ -400,23 +417,6 @@ export class IdentityClient {
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the User with the given uri.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested user.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getUser(request);
- */
   getUser(
       request?: protos.google.showcase.v1beta1.IGetUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -451,26 +451,6 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.getUser(request, options, callback);
   }
-  updateUser(
-      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IUser,
-        protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
-      ]>;
-  updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IUser,
-          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IUser,
-          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a user.
  *
@@ -491,6 +471,26 @@ export class IdentityClient {
  * @example
  * const [response] = await client.updateUser(request);
  */
+  updateUser(
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IUser,
+        protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
+      ]>;
+  updateUser(
+      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IUser,
+          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateUser(
+      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IUser,
+          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
+          {}|null|undefined>): void;
   updateUser(
       request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -525,6 +525,23 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.updateUser(request, options, callback);
   }
+/**
+ * Deletes a user, their profile, and all of their authored messages.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the user to delete.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteUser(request);
+ */
   deleteUser(
       request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       options?: CallOptions):
@@ -545,23 +562,6 @@ export class IdentityClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a user, their profile, and all of their authored messages.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the user to delete.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteUser(request);
- */
   deleteUser(
       request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -597,28 +597,7 @@ export class IdentityClient {
     return this.innerApiCalls.deleteUser(request, options, callback);
   }
 
-  listUsers(
-      request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IUser[],
-        protos.google.showcase.v1beta1.IListUsersRequest|null,
-        protos.google.showcase.v1beta1.IListUsersResponse
-      ]>;
-  listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListUsersRequest,
-          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
-          protos.google.showcase.v1beta1.IUser>): void;
-  listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListUsersRequest,
-          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
-          protos.google.showcase.v1beta1.IUser>): void;
-/**
+ /**
  * Lists all users.
  *
  * @param {Object} request
@@ -643,6 +622,27 @@ export class IdentityClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listUsers(
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IUser[],
+        protos.google.showcase.v1beta1.IListUsersRequest|null,
+        protos.google.showcase.v1beta1.IListUsersResponse
+      ]>;
+  listUsers(
+      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListUsersRequest,
+          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
+          protos.google.showcase.v1beta1.IUser>): void;
+  listUsers(
+      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListUsersRequest,
+          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
+          protos.google.showcase.v1beta1.IUser>): void;
   listUsers(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -354,6 +354,23 @@ export class MessagingClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a room.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.Room} request.room
+ *   The room to create.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createRoom(request);
+ */
   createRoom(
       request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       options?: CallOptions):
@@ -374,23 +391,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a room.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.Room} request.room
- *   The room to create.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createRoom(request);
- */
   createRoom(
       request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -418,6 +418,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.createRoom(request, options, callback);
   }
+/**
+ * Retrieves the Room with the given resource name.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested room.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getRoom(request);
+ */
   getRoom(
       request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       options?: CallOptions):
@@ -438,23 +455,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the Room with the given resource name.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested room.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getRoom(request);
- */
   getRoom(
       request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -489,26 +489,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.getRoom(request, options, callback);
   }
-  updateRoom(
-      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IRoom,
-        protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
-      ]>;
-  updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IRoom,
-          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IRoom,
-          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a room.
  *
@@ -529,6 +509,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.updateRoom(request);
  */
+  updateRoom(
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IRoom,
+        protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
+      ]>;
+  updateRoom(
+      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IRoom,
+          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateRoom(
+      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IRoom,
+          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
+          {}|null|undefined>): void;
   updateRoom(
       request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -563,6 +563,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.updateRoom(request, options, callback);
   }
+/**
+ * Deletes a room and all of its blurbs.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested room.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteRoom(request);
+ */
   deleteRoom(
       request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       options?: CallOptions):
@@ -583,23 +600,6 @@ export class MessagingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a room and all of its blurbs.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested room.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteRoom(request);
- */
   deleteRoom(
       request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -634,26 +634,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.deleteRoom(request, options, callback);
   }
-  createBlurb(
-      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
-      ]>;
-  createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
-  createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a blurb. If the parent is a room, the blurb is understood to be a
  * message in that room. If the parent is a profile, the blurb is understood
@@ -676,6 +656,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.createBlurb(request);
  */
+  createBlurb(
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
+      ]>;
+  createBlurb(
+      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
+  createBlurb(
+      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
   createBlurb(
       request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -710,6 +710,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.createBlurb(request, options, callback);
   }
+/**
+ * Retrieves the Blurb with the given resource name.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested blurb.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Blurb]{@link google.showcase.v1beta1.Blurb}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getBlurb(request);
+ */
   getBlurb(
       request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       options?: CallOptions):
@@ -730,23 +747,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the Blurb with the given resource name.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested blurb.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Blurb]{@link google.showcase.v1beta1.Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getBlurb(request);
- */
   getBlurb(
       request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -781,26 +781,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.getBlurb(request, options, callback);
   }
-  updateBlurb(
-      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb,
-        protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
-      ]>;
-  updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a blurb.
  *
@@ -821,6 +801,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.updateBlurb(request);
  */
+  updateBlurb(
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb,
+        protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
+      ]>;
+  updateBlurb(
+      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateBlurb(
+      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
   updateBlurb(
       request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -855,6 +855,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.updateBlurb(request, options, callback);
   }
+/**
+ * Deletes a blurb.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested blurb.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteBlurb(request);
+ */
   deleteBlurb(
       request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       options?: CallOptions):
@@ -875,23 +892,6 @@ export class MessagingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a blurb.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested blurb.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteBlurb(request);
- */
   deleteBlurb(
       request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -966,19 +966,6 @@ export class MessagingClient {
     return this.innerApiCalls.streamBlurbs(request, options);
   }
 
-  sendBlurbs(
-      options?: CallOptions,
-      callback?: Callback<
-        protos.google.showcase.v1beta1.ISendBlurbsResponse,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
-  sendBlurbs(
-      callback?: Callback<
-        protos.google.showcase.v1beta1.ISendBlurbsResponse,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
 /**
  * This is a stream to create multiple blurbs. If an invalid blurb is
  * requested to be created, the stream will close with an error.
@@ -995,6 +982,19 @@ export class MessagingClient {
  * stream.write(request);
  * stream.end();
  */
+  sendBlurbs(
+      options?: CallOptions,
+      callback?: Callback<
+        protos.google.showcase.v1beta1.ISendBlurbsResponse,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
+  sendBlurbs(
+      callback?: Callback<
+        protos.google.showcase.v1beta1.ISendBlurbsResponse,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
   sendBlurbs(
       optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
@@ -1043,26 +1043,6 @@ export class MessagingClient {
     return this.innerApiCalls.connect(options);
   }
 
-  searchBlurbs(
-      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method searches through all blurbs across all rooms and profiles
  * for blurbs containing to words found in the query. Only posts that
@@ -1098,6 +1078,26 @@ export class MessagingClient {
  * const [operation] = await client.searchBlurbs(request);
  * const [response] = await operation.promise();
  */
+  searchBlurbs(
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  searchBlurbs(
+      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  searchBlurbs(
+      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   searchBlurbs(
       request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1153,28 +1153,7 @@ export class MessagingClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
-  listRooms(
-      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IRoom[],
-        protos.google.showcase.v1beta1.IListRoomsRequest|null,
-        protos.google.showcase.v1beta1.IListRoomsResponse
-      ]>;
-  listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListRoomsRequest,
-          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IRoom>): void;
-  listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListRoomsRequest,
-          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IRoom>): void;
-/**
+ /**
  * Lists all chat rooms.
  *
  * @param {Object} request
@@ -1199,6 +1178,27 @@ export class MessagingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listRooms(
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IRoom[],
+        protos.google.showcase.v1beta1.IListRoomsRequest|null,
+        protos.google.showcase.v1beta1.IListRoomsResponse
+      ]>;
+  listRooms(
+      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListRoomsRequest,
+          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IRoom>): void;
+  listRooms(
+      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListRoomsRequest,
+          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IRoom>): void;
   listRooms(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1312,28 +1312,7 @@ export class MessagingClient {
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
-  listBlurbs(
-      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb[],
-        protos.google.showcase.v1beta1.IListBlurbsRequest|null,
-        protos.google.showcase.v1beta1.IListBlurbsResponse
-      ]>;
-  listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListBlurbsRequest,
-          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IBlurb>): void;
-  listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListBlurbsRequest,
-          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IBlurb>): void;
-/**
+ /**
  * Lists blurbs for a specific chat room or user profile depending on the
  * parent resource name.
  *
@@ -1362,6 +1341,27 @@ export class MessagingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listBlurbs(
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb[],
+        protos.google.showcase.v1beta1.IListBlurbsRequest|null,
+        protos.google.showcase.v1beta1.IListBlurbsResponse
+      ]>;
+  listBlurbs(
+      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListBlurbsRequest,
+          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IBlurb>): void;
+  listBlurbs(
+      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListBlurbsRequest,
+          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IBlurb>): void;
   listBlurbs(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -319,6 +319,25 @@ export class TestingClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a new testing session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.Session} request.session
+ *   The session to be created.
+ *   Sessions are immutable once they are created (although they can
+ *   be deleted).
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createSession(request);
+ */
   createSession(
       request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       options?: CallOptions):
@@ -339,25 +358,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a new testing session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.Session} request.session
- *   The session to be created.
- *   Sessions are immutable once they are created (although they can
- *   be deleted).
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createSession(request);
- */
   createSession(
       request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -385,6 +385,23 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.createSession(request, options, callback);
   }
+/**
+ * Gets a testing session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be retrieved.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getSession(request);
+ */
   getSession(
       request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       options?: CallOptions):
@@ -405,23 +422,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a testing session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be retrieved.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getSession(request);
- */
   getSession(
       request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -456,6 +456,23 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.getSession(request, options, callback);
   }
+/**
+ * Delete a test session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be deleted.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteSession(request);
+ */
   deleteSession(
       request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       options?: CallOptions):
@@ -476,23 +493,6 @@ export class TestingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Delete a test session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be deleted.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteSession(request);
- */
   deleteSession(
       request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -527,6 +527,25 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.deleteSession(request, options, callback);
   }
+/**
+ * Report on the status of a session.
+ * This generates a report detailing which tests have been completed,
+ * and an overall rollup.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be reported on.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ReportSessionResponse]{@link google.showcase.v1beta1.ReportSessionResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.reportSession(request);
+ */
   reportSession(
       request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       options?: CallOptions):
@@ -547,25 +566,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Report on the status of a session.
- * This generates a report detailing which tests have been completed,
- * and an overall rollup.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be reported on.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [ReportSessionResponse]{@link google.showcase.v1beta1.ReportSessionResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.reportSession(request);
- */
   reportSession(
       request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -600,26 +600,6 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.reportSession(request, options, callback);
   }
-  deleteTest(
-      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
-      ]>;
-  deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Explicitly decline to implement a test.
  *
@@ -642,6 +622,26 @@ export class TestingClient {
  * @example
  * const [response] = await client.deleteTest(request);
  */
+  deleteTest(
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
+      ]>;
+  deleteTest(
+      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteTest(
+      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteTest(
       request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -676,26 +676,6 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.deleteTest(request, options, callback);
   }
-  verifyTest(
-      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IVerifyTestResponse,
-        protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
-      ]>;
-  verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IVerifyTestResponse,
-          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
-          {}|null|undefined>): void;
-  verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IVerifyTestResponse,
-          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Register a response to a test.
  *
@@ -720,6 +700,26 @@ export class TestingClient {
  * @example
  * const [response] = await client.verifyTest(request);
  */
+  verifyTest(
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IVerifyTestResponse,
+        protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
+      ]>;
+  verifyTest(
+      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IVerifyTestResponse,
+          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
+          {}|null|undefined>): void;
+  verifyTest(
+      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IVerifyTestResponse,
+          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
+          {}|null|undefined>): void;
   verifyTest(
       request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -755,28 +755,7 @@ export class TestingClient {
     return this.innerApiCalls.verifyTest(request, options, callback);
   }
 
-  listSessions(
-      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.ISession[],
-        protos.google.showcase.v1beta1.IListSessionsRequest|null,
-        protos.google.showcase.v1beta1.IListSessionsResponse
-      ]>;
-  listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListSessionsRequest,
-          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ISession>): void;
-  listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListSessionsRequest,
-          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ISession>): void;
-/**
+ /**
  * Lists the current test sessions.
  *
  * @param {Object} request
@@ -798,6 +777,27 @@ export class TestingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listSessions(
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.ISession[],
+        protos.google.showcase.v1beta1.IListSessionsRequest|null,
+        protos.google.showcase.v1beta1.IListSessionsResponse
+      ]>;
+  listSessions(
+      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListSessionsRequest,
+          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ISession>): void;
+  listSessions(
+      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListSessionsRequest,
+          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ISession>): void;
   listSessions(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -905,28 +905,7 @@ export class TestingClient {
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
-  listTests(
-      request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.ITest[],
-        protos.google.showcase.v1beta1.IListTestsRequest|null,
-        protos.google.showcase.v1beta1.IListTestsResponse
-      ]>;
-  listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListTestsRequest,
-          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ITest>): void;
-  listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListTestsRequest,
-          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ITest>): void;
-/**
+ /**
  * List the tests of a sessesion.
  *
  * @param {Object} request
@@ -950,6 +929,27 @@ export class TestingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listTests(
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.ITest[],
+        protos.google.showcase.v1beta1.IListTestsRequest|null,
+        protos.google.showcase.v1beta1.IListTestsResponse
+      ]>;
+  listTests(
+      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListTestsRequest,
+          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ITest>): void;
+  listTests(
+      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListTestsRequest,
+          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ITest>): void;
   listTests(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -337,26 +337,6 @@ export class DlpServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  inspectContent(
-      request?: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IInspectContentResponse,
-        protos.google.privacy.dlp.v2.IInspectContentRequest|undefined, {}|undefined
-      ]>;
-  inspectContent(
-      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectContentResponse,
-          protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
-          {}|null|undefined>): void;
-  inspectContent(
-      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectContentResponse,
-          protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Finds potentially sensitive info in content.
  * This method has limits on input size, processing time, and output size.
@@ -398,6 +378,26 @@ export class DlpServiceClient {
  */
   inspectContent(
       request?: protos.google.privacy.dlp.v2.IInspectContentRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IInspectContentResponse,
+        protos.google.privacy.dlp.v2.IInspectContentRequest|undefined, {}|undefined
+      ]>;
+  inspectContent(
+      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectContentResponse,
+          protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  inspectContent(
+      request: protos.google.privacy.dlp.v2.IInspectContentRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectContentResponse,
+          protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  inspectContent(
+      request?: protos.google.privacy.dlp.v2.IInspectContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IInspectContentResponse,
           protos.google.privacy.dlp.v2.IInspectContentRequest|null|undefined,
@@ -430,26 +430,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.inspectContent(request, options, callback);
   }
-  redactImage(
-      request?: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IRedactImageResponse,
-        protos.google.privacy.dlp.v2.IRedactImageRequest|undefined, {}|undefined
-      ]>;
-  redactImage(
-      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IRedactImageResponse,
-          protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
-          {}|null|undefined>): void;
-  redactImage(
-      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IRedactImageResponse,
-          protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Redacts potentially sensitive info from an image.
  * This method has limits on input size, processing time, and output size.
@@ -488,6 +468,26 @@ export class DlpServiceClient {
  */
   redactImage(
       request?: protos.google.privacy.dlp.v2.IRedactImageRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IRedactImageResponse,
+        protos.google.privacy.dlp.v2.IRedactImageRequest|undefined, {}|undefined
+      ]>;
+  redactImage(
+      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IRedactImageResponse,
+          protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
+          {}|null|undefined>): void;
+  redactImage(
+      request: protos.google.privacy.dlp.v2.IRedactImageRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IRedactImageResponse,
+          protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
+          {}|null|undefined>): void;
+  redactImage(
+      request?: protos.google.privacy.dlp.v2.IRedactImageRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IRedactImageResponse,
           protos.google.privacy.dlp.v2.IRedactImageRequest|null|undefined,
@@ -520,26 +520,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.redactImage(request, options, callback);
   }
-  deidentifyContent(
-      request?: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
-        protos.google.privacy.dlp.v2.IDeidentifyContentRequest|undefined, {}|undefined
-      ]>;
-  deidentifyContent(
-      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
-          protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
-          {}|null|undefined>): void;
-  deidentifyContent(
-      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
-          protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * De-identifies potentially sensitive info from a ContentItem.
  * This method has limits on input size and output size.
@@ -591,6 +571,26 @@ export class DlpServiceClient {
  */
   deidentifyContent(
       request?: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
+        protos.google.privacy.dlp.v2.IDeidentifyContentRequest|undefined, {}|undefined
+      ]>;
+  deidentifyContent(
+      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
+          protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  deidentifyContent(
+      request: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
+          protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  deidentifyContent(
+      request?: protos.google.privacy.dlp.v2.IDeidentifyContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDeidentifyContentResponse,
           protos.google.privacy.dlp.v2.IDeidentifyContentRequest|null|undefined,
@@ -623,26 +623,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.deidentifyContent(request, options, callback);
   }
-  reidentifyContent(
-      request?: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IReidentifyContentResponse,
-        protos.google.privacy.dlp.v2.IReidentifyContentRequest|undefined, {}|undefined
-      ]>;
-  reidentifyContent(
-      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IReidentifyContentResponse,
-          protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
-          {}|null|undefined>): void;
-  reidentifyContent(
-      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IReidentifyContentResponse,
-          protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Re-identifies content that has been de-identified.
  * See
@@ -696,6 +676,26 @@ export class DlpServiceClient {
  */
   reidentifyContent(
       request?: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IReidentifyContentResponse,
+        protos.google.privacy.dlp.v2.IReidentifyContentRequest|undefined, {}|undefined
+      ]>;
+  reidentifyContent(
+      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IReidentifyContentResponse,
+          protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  reidentifyContent(
+      request: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IReidentifyContentResponse,
+          protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
+          {}|null|undefined>): void;
+  reidentifyContent(
+      request?: protos.google.privacy.dlp.v2.IReidentifyContentRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IReidentifyContentResponse,
           protos.google.privacy.dlp.v2.IReidentifyContentRequest|null|undefined,
@@ -728,26 +728,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.reidentifyContent(request, options, callback);
   }
-  listInfoTypes(
-      request?: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IListInfoTypesResponse,
-        protos.google.privacy.dlp.v2.IListInfoTypesRequest|undefined, {}|undefined
-      ]>;
-  listInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IListInfoTypesResponse,
-          protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
-          {}|null|undefined>): void;
-  listInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IListInfoTypesResponse,
-          protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Returns a list of the sensitive information types that the DLP API
  * supports. See https://cloud.google.com/dlp/docs/infotypes-reference to
@@ -775,6 +755,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.listInfoTypes(request);
  */
+  listInfoTypes(
+      request?: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IListInfoTypesResponse,
+        protos.google.privacy.dlp.v2.IListInfoTypesRequest|undefined, {}|undefined
+      ]>;
+  listInfoTypes(
+      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IListInfoTypesResponse,
+          protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
+          {}|null|undefined>): void;
+  listInfoTypes(
+      request: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IListInfoTypesResponse,
+          protos.google.privacy.dlp.v2.IListInfoTypesRequest|null|undefined,
+          {}|null|undefined>): void;
   listInfoTypes(
       request?: protos.google.privacy.dlp.v2.IListInfoTypesRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -809,26 +809,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.listInfoTypes(request, options, callback);
   }
-  createInspectTemplate(
-      request?: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IInspectTemplate,
-        protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|undefined, {}|undefined
-      ]>;
-  createInspectTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  createInspectTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates an InspectTemplate for re-using frequently used configuration
  * for inspecting content, images, and storage.
@@ -859,6 +839,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.createInspectTemplate(request);
  */
+  createInspectTemplate(
+      request?: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IInspectTemplate,
+        protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|undefined, {}|undefined
+      ]>;
+  createInspectTemplate(
+      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  createInspectTemplate(
+      request: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   createInspectTemplate(
       request?: protos.google.privacy.dlp.v2.ICreateInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -893,26 +893,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.createInspectTemplate(request, options, callback);
   }
-  updateInspectTemplate(
-      request?: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IInspectTemplate,
-        protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|undefined, {}|undefined
-      ]>;
-  updateInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates the InspectTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates to learn more.
@@ -937,6 +917,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.updateInspectTemplate(request);
  */
+  updateInspectTemplate(
+      request?: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IInspectTemplate,
+        protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|undefined, {}|undefined
+      ]>;
+  updateInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   updateInspectTemplate(
       request?: protos.google.privacy.dlp.v2.IUpdateInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -971,26 +971,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.updateInspectTemplate(request, options, callback);
   }
-  getInspectTemplate(
-      request?: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IInspectTemplate,
-        protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|undefined, {}|undefined
-      ]>;
-  getInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  getInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IInspectTemplate,
-          protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets an InspectTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates to learn more.
@@ -1011,6 +991,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.getInspectTemplate(request);
  */
+  getInspectTemplate(
+      request?: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IInspectTemplate,
+        protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|undefined, {}|undefined
+      ]>;
+  getInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  getInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IInspectTemplate,
+          protos.google.privacy.dlp.v2.IGetInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   getInspectTemplate(
       request?: protos.google.privacy.dlp.v2.IGetInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1045,26 +1045,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.getInspectTemplate(request, options, callback);
   }
-  deleteInspectTemplate(
-      request?: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|undefined, {}|undefined
-      ]>;
-  deleteInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteInspectTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an InspectTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates to learn more.
@@ -1085,6 +1065,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.deleteInspectTemplate(request);
  */
+  deleteInspectTemplate(
+      request?: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|undefined, {}|undefined
+      ]>;
+  deleteInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteInspectTemplate(
+      request: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteInspectTemplate(
       request?: protos.google.privacy.dlp.v2.IDeleteInspectTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1119,26 +1119,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteInspectTemplate(request, options, callback);
   }
-  createDeidentifyTemplate(
-      request?: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-        protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|undefined, {}|undefined
-      ]>;
-  createDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  createDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a DeidentifyTemplate for re-using frequently used configuration
  * for de-identifying content, images, and storage.
@@ -1170,6 +1150,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.createDeidentifyTemplate(request);
  */
+  createDeidentifyTemplate(
+      request?: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+        protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|undefined, {}|undefined
+      ]>;
+  createDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  createDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   createDeidentifyTemplate(
       request?: protos.google.privacy.dlp.v2.ICreateDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1204,26 +1204,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.createDeidentifyTemplate(request, options, callback);
   }
-  updateDeidentifyTemplate(
-      request?: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-        protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|undefined, {}|undefined
-      ]>;
-  updateDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates the DeidentifyTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates-deid to learn
@@ -1249,6 +1229,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.updateDeidentifyTemplate(request);
  */
+  updateDeidentifyTemplate(
+      request?: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+        protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|undefined, {}|undefined
+      ]>;
+  updateDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   updateDeidentifyTemplate(
       request?: protos.google.privacy.dlp.v2.IUpdateDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1283,26 +1283,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.updateDeidentifyTemplate(request, options, callback);
   }
-  getDeidentifyTemplate(
-      request?: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-        protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|undefined, {}|undefined
-      ]>;
-  getDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  getDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
-          protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a DeidentifyTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates-deid to learn
@@ -1324,6 +1304,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.getDeidentifyTemplate(request);
  */
+  getDeidentifyTemplate(
+      request?: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+        protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|undefined, {}|undefined
+      ]>;
+  getDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  getDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate,
+          protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   getDeidentifyTemplate(
       request?: protos.google.privacy.dlp.v2.IGetDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1358,26 +1358,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.getDeidentifyTemplate(request, options, callback);
   }
-  deleteDeidentifyTemplate(
-      request?: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|undefined, {}|undefined
-      ]>;
-  deleteDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteDeidentifyTemplate(
-      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a DeidentifyTemplate.
  * See https://cloud.google.com/dlp/docs/creating-templates-deid to learn
@@ -1399,6 +1379,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.deleteDeidentifyTemplate(request);
  */
+  deleteDeidentifyTemplate(
+      request?: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|undefined, {}|undefined
+      ]>;
+  deleteDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteDeidentifyTemplate(
+      request: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteDeidentifyTemplate(
       request?: protos.google.privacy.dlp.v2.IDeleteDeidentifyTemplateRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1433,26 +1433,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteDeidentifyTemplate(request, options, callback);
   }
-  createJobTrigger(
-      request?: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IJobTrigger,
-        protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|undefined, {}|undefined
-      ]>;
-  createJobTrigger(
-      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IJobTrigger,
-          protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
-          {}|null|undefined>): void;
-  createJobTrigger(
-      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IJobTrigger,
-          protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a job trigger to run DLP actions such as scanning storage for
  * sensitive information on a set schedule.
@@ -1482,6 +1462,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.createJobTrigger(request);
  */
+  createJobTrigger(
+      request?: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IJobTrigger,
+        protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|undefined, {}|undefined
+      ]>;
+  createJobTrigger(
+      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IJobTrigger,
+          protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
+          {}|null|undefined>): void;
+  createJobTrigger(
+      request: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IJobTrigger,
+          protos.google.privacy.dlp.v2.ICreateJobTriggerRequest|null|undefined,
+          {}|null|undefined>): void;
   createJobTrigger(
       request?: protos.google.privacy.dlp.v2.ICreateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1516,26 +1516,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.createJobTrigger(request, options, callback);
   }
-  updateJobTrigger(
-      request?: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IJobTrigger,
-        protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|undefined, {}|undefined
-      ]>;
-  updateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IJobTrigger,
-          protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateJobTrigger(
-      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IJobTrigger,
-          protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a job trigger.
  * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
@@ -1559,6 +1539,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.updateJobTrigger(request);
  */
+  updateJobTrigger(
+      request?: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IJobTrigger,
+        protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|undefined, {}|undefined
+      ]>;
+  updateJobTrigger(
+      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IJobTrigger,
+          protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateJobTrigger(
+      request: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IJobTrigger,
+          protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest|null|undefined,
+          {}|null|undefined>): void;
   updateJobTrigger(
       request?: protos.google.privacy.dlp.v2.IUpdateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1593,6 +1593,25 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.updateJobTrigger(request, options, callback);
   }
+/**
+ * Gets a job trigger.
+ * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the project and the triggeredJob, for example
+ *   `projects/dlp-test-project/jobTriggers/53234423`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [JobTrigger]{@link google.privacy.dlp.v2.JobTrigger}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getJobTrigger(request);
+ */
   getJobTrigger(
       request?: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
       options?: CallOptions):
@@ -1613,25 +1632,6 @@ export class DlpServiceClient {
           protos.google.privacy.dlp.v2.IJobTrigger,
           protos.google.privacy.dlp.v2.IGetJobTriggerRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a job trigger.
- * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the project and the triggeredJob, for example
- *   `projects/dlp-test-project/jobTriggers/53234423`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [JobTrigger]{@link google.privacy.dlp.v2.JobTrigger}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getJobTrigger(request);
- */
   getJobTrigger(
       request?: protos.google.privacy.dlp.v2.IGetJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1666,6 +1666,25 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.getJobTrigger(request, options, callback);
   }
+/**
+ * Deletes a job trigger.
+ * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the project and the triggeredJob, for example
+ *   `projects/dlp-test-project/jobTriggers/53234423`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteJobTrigger(request);
+ */
   deleteJobTrigger(
       request?: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
       options?: CallOptions):
@@ -1686,25 +1705,6 @@ export class DlpServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a job trigger.
- * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the project and the triggeredJob, for example
- *   `projects/dlp-test-project/jobTriggers/53234423`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteJobTrigger(request);
- */
   deleteJobTrigger(
       request?: protos.google.privacy.dlp.v2.IDeleteJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1739,6 +1739,25 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteJobTrigger(request, options, callback);
   }
+/**
+ * Activate a job trigger. Causes the immediate execute of a trigger
+ * instead of waiting on the trigger event to occur.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the trigger to activate, for example
+ *   `projects/dlp-test-project/jobTriggers/53234423`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [DlpJob]{@link google.privacy.dlp.v2.DlpJob}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.activateJobTrigger(request);
+ */
   activateJobTrigger(
       request?: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
       options?: CallOptions):
@@ -1759,25 +1778,6 @@ export class DlpServiceClient {
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IActivateJobTriggerRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Activate a job trigger. Causes the immediate execute of a trigger
- * instead of waiting on the trigger event to occur.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the trigger to activate, for example
- *   `projects/dlp-test-project/jobTriggers/53234423`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [DlpJob]{@link google.privacy.dlp.v2.DlpJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.activateJobTrigger(request);
- */
   activateJobTrigger(
       request?: protos.google.privacy.dlp.v2.IActivateJobTriggerRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1812,26 +1812,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.activateJobTrigger(request, options, callback);
   }
-  createDlpJob(
-      request?: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDlpJob,
-        protos.google.privacy.dlp.v2.ICreateDlpJobRequest|undefined, {}|undefined
-      ]>;
-  createDlpJob(
-      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDlpJob,
-          protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
-  createDlpJob(
-      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IDlpJob,
-          protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new job to inspect storage or calculate risk metrics.
  * See https://cloud.google.com/dlp/docs/inspecting-storage and
@@ -1869,6 +1849,26 @@ export class DlpServiceClient {
  */
   createDlpJob(
       request?: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDlpJob,
+        protos.google.privacy.dlp.v2.ICreateDlpJobRequest|undefined, {}|undefined
+      ]>;
+  createDlpJob(
+      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDlpJob,
+          protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
+  createDlpJob(
+      request: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IDlpJob,
+          protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
+  createDlpJob(
+      request?: protos.google.privacy.dlp.v2.ICreateDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.ICreateDlpJobRequest|null|undefined,
@@ -1901,6 +1901,25 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.createDlpJob(request, options, callback);
   }
+/**
+ * Gets the latest state of a long-running DlpJob.
+ * See https://cloud.google.com/dlp/docs/inspecting-storage and
+ * https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the DlpJob resource.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [DlpJob]{@link google.privacy.dlp.v2.DlpJob}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getDlpJob(request);
+ */
   getDlpJob(
       request?: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
       options?: CallOptions):
@@ -1921,25 +1940,6 @@ export class DlpServiceClient {
           protos.google.privacy.dlp.v2.IDlpJob,
           protos.google.privacy.dlp.v2.IGetDlpJobRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets the latest state of a long-running DlpJob.
- * See https://cloud.google.com/dlp/docs/inspecting-storage and
- * https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The name of the DlpJob resource.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [DlpJob]{@link google.privacy.dlp.v2.DlpJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getDlpJob(request);
- */
   getDlpJob(
       request?: protos.google.privacy.dlp.v2.IGetDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1974,26 +1974,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.getDlpJob(request, options, callback);
   }
-  deleteDlpJob(
-      request?: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|undefined, {}|undefined
-      ]>;
-  deleteDlpJob(
-      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteDlpJob(
-      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a long-running DlpJob. This method indicates that the client is
  * no longer interested in the DlpJob result. The job will be cancelled if
@@ -2015,6 +1995,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.deleteDlpJob(request);
  */
+  deleteDlpJob(
+      request?: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|undefined, {}|undefined
+      ]>;
+  deleteDlpJob(
+      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteDlpJob(
+      request: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteDlpJob(
       request?: protos.google.privacy.dlp.v2.IDeleteDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2049,26 +2049,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteDlpJob(request, options, callback);
   }
-  cancelDlpJob(
-      request?: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.privacy.dlp.v2.ICancelDlpJobRequest|undefined, {}|undefined
-      ]>;
-  cancelDlpJob(
-      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
-  cancelDlpJob(
-      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Starts asynchronous cancellation on a long-running DlpJob. The server
  * makes a best effort to cancel the DlpJob, but success is not
@@ -2090,6 +2070,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.cancelDlpJob(request);
  */
+  cancelDlpJob(
+      request?: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.privacy.dlp.v2.ICancelDlpJobRequest|undefined, {}|undefined
+      ]>;
+  cancelDlpJob(
+      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
+  cancelDlpJob(
+      request: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.ICancelDlpJobRequest|null|undefined,
+          {}|null|undefined>): void;
   cancelDlpJob(
       request?: protos.google.privacy.dlp.v2.ICancelDlpJobRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2124,26 +2124,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.cancelDlpJob(request, options, callback);
   }
-  createStoredInfoType(
-      request?: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IStoredInfoType,
-        protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|undefined, {}|undefined
-      ]>;
-  createStoredInfoType(
-      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
-  createStoredInfoType(
-      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a pre-built stored infoType to be used for inspection.
  * See https://cloud.google.com/dlp/docs/creating-stored-infotypes to
@@ -2174,6 +2154,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.createStoredInfoType(request);
  */
+  createStoredInfoType(
+      request?: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IStoredInfoType,
+        protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|undefined, {}|undefined
+      ]>;
+  createStoredInfoType(
+      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
+  createStoredInfoType(
+      request: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
   createStoredInfoType(
       request?: protos.google.privacy.dlp.v2.ICreateStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2208,26 +2208,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.createStoredInfoType(request, options, callback);
   }
-  updateStoredInfoType(
-      request?: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IStoredInfoType,
-        protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|undefined, {}|undefined
-      ]>;
-  updateStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates the stored infoType by creating a new version. The existing version
  * will continue to be used until the new version is ready.
@@ -2256,6 +2236,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.updateStoredInfoType(request);
  */
+  updateStoredInfoType(
+      request?: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IStoredInfoType,
+        protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|undefined, {}|undefined
+      ]>;
+  updateStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
   updateStoredInfoType(
       request?: protos.google.privacy.dlp.v2.IUpdateStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2290,26 +2290,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.updateStoredInfoType(request, options, callback);
   }
-  getStoredInfoType(
-      request?: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IStoredInfoType,
-        protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|undefined, {}|undefined
-      ]>;
-  getStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
-  getStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
-      callback: Callback<
-          protos.google.privacy.dlp.v2.IStoredInfoType,
-          protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a stored infoType.
  * See https://cloud.google.com/dlp/docs/creating-stored-infotypes to
@@ -2331,6 +2311,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.getStoredInfoType(request);
  */
+  getStoredInfoType(
+      request?: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IStoredInfoType,
+        protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|undefined, {}|undefined
+      ]>;
+  getStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
+  getStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
+      callback: Callback<
+          protos.google.privacy.dlp.v2.IStoredInfoType,
+          protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
   getStoredInfoType(
       request?: protos.google.privacy.dlp.v2.IGetStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2365,26 +2365,6 @@ export class DlpServiceClient {
     this.initialize();
     return this.innerApiCalls.getStoredInfoType(request, options, callback);
   }
-  deleteStoredInfoType(
-      request?: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|undefined, {}|undefined
-      ]>;
-  deleteStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteStoredInfoType(
-      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a stored infoType.
  * See https://cloud.google.com/dlp/docs/creating-stored-infotypes to
@@ -2406,6 +2386,26 @@ export class DlpServiceClient {
  * @example
  * const [response] = await client.deleteStoredInfoType(request);
  */
+  deleteStoredInfoType(
+      request?: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|undefined, {}|undefined
+      ]>;
+  deleteStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteStoredInfoType(
+      request: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteStoredInfoType(
       request?: protos.google.privacy.dlp.v2.IDeleteStoredInfoTypeRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -2441,28 +2441,7 @@ export class DlpServiceClient {
     return this.innerApiCalls.deleteStoredInfoType(request, options, callback);
   }
 
-  listInspectTemplates(
-      request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IInspectTemplate[],
-        protos.google.privacy.dlp.v2.IListInspectTemplatesRequest|null,
-        protos.google.privacy.dlp.v2.IListInspectTemplatesResponse
-      ]>;
-  listInspectTemplates(
-      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-          protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IInspectTemplate>): void;
-  listInspectTemplates(
-      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
-          protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IInspectTemplate>): void;
-/**
+ /**
  * Lists InspectTemplates.
  * See https://cloud.google.com/dlp/docs/creating-templates to learn more.
  *
@@ -2507,6 +2486,27 @@ export class DlpServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listInspectTemplates(
+      request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IInspectTemplate[],
+        protos.google.privacy.dlp.v2.IListInspectTemplatesRequest|null,
+        protos.google.privacy.dlp.v2.IListInspectTemplatesResponse
+      ]>;
+  listInspectTemplates(
+      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+          protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IInspectTemplate>): void;
+  listInspectTemplates(
+      request: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
+          protos.google.privacy.dlp.v2.IListInspectTemplatesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IInspectTemplate>): void;
   listInspectTemplates(
       request?: protos.google.privacy.dlp.v2.IListInspectTemplatesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -2679,28 +2679,7 @@ export class DlpServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IInspectTemplate>;
   }
-  listDeidentifyTemplates(
-      request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDeidentifyTemplate[],
-        protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest|null,
-        protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse
-      ]>;
-  listDeidentifyTemplates(
-      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate>): void;
-  listDeidentifyTemplates(
-      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
-          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IDeidentifyTemplate>): void;
-/**
+ /**
  * Lists DeidentifyTemplates.
  * See https://cloud.google.com/dlp/docs/creating-templates-deid to learn
  * more.
@@ -2746,6 +2725,27 @@ export class DlpServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listDeidentifyTemplates(
+      request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDeidentifyTemplate[],
+        protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest|null,
+        protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse
+      ]>;
+  listDeidentifyTemplates(
+      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate>): void;
+  listDeidentifyTemplates(
+      request: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
+          protos.google.privacy.dlp.v2.IListDeidentifyTemplatesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IDeidentifyTemplate>): void;
   listDeidentifyTemplates(
       request?: protos.google.privacy.dlp.v2.IListDeidentifyTemplatesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -2918,28 +2918,7 @@ export class DlpServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDeidentifyTemplate>;
   }
-  listJobTriggers(
-      request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IJobTrigger[],
-        protos.google.privacy.dlp.v2.IListJobTriggersRequest|null,
-        protos.google.privacy.dlp.v2.IListJobTriggersResponse
-      ]>;
-  listJobTriggers(
-      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-          protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IJobTrigger>): void;
-  listJobTriggers(
-      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListJobTriggersRequest,
-          protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IJobTrigger>): void;
-/**
+ /**
  * Lists job triggers.
  * See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
  *
@@ -3010,6 +2989,27 @@ export class DlpServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listJobTriggers(
+      request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IJobTrigger[],
+        protos.google.privacy.dlp.v2.IListJobTriggersRequest|null,
+        protos.google.privacy.dlp.v2.IListJobTriggersResponse
+      ]>;
+  listJobTriggers(
+      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+          protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IJobTrigger>): void;
+  listJobTriggers(
+      request: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListJobTriggersRequest,
+          protos.google.privacy.dlp.v2.IListJobTriggersResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IJobTrigger>): void;
   listJobTriggers(
       request?: protos.google.privacy.dlp.v2.IListJobTriggersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -3234,28 +3234,7 @@ export class DlpServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IJobTrigger>;
   }
-  listDlpJobs(
-      request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IDlpJob[],
-        protos.google.privacy.dlp.v2.IListDlpJobsRequest|null,
-        protos.google.privacy.dlp.v2.IListDlpJobsResponse
-      ]>;
-  listDlpJobs(
-      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-          protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IDlpJob>): void;
-  listDlpJobs(
-      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListDlpJobsRequest,
-          protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IDlpJob>): void;
-/**
+ /**
  * Lists DlpJobs that match the specified filter in the request.
  * See https://cloud.google.com/dlp/docs/inspecting-storage and
  * https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
@@ -3329,6 +3308,27 @@ export class DlpServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listDlpJobs(
+      request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IDlpJob[],
+        protos.google.privacy.dlp.v2.IListDlpJobsRequest|null,
+        protos.google.privacy.dlp.v2.IListDlpJobsResponse
+      ]>;
+  listDlpJobs(
+      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+          protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IDlpJob>): void;
+  listDlpJobs(
+      request: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListDlpJobsRequest,
+          protos.google.privacy.dlp.v2.IListDlpJobsResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IDlpJob>): void;
   listDlpJobs(
       request?: protos.google.privacy.dlp.v2.IListDlpJobsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -3557,28 +3557,7 @@ export class DlpServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDlpJob>;
   }
-  listStoredInfoTypes(
-      request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.privacy.dlp.v2.IStoredInfoType[],
-        protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest|null,
-        protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse
-      ]>;
-  listStoredInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-          protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IStoredInfoType>): void;
-  listStoredInfoTypes(
-      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-      callback: PaginationCallback<
-          protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
-          protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
-          protos.google.privacy.dlp.v2.IStoredInfoType>): void;
-/**
+ /**
  * Lists stored infoTypes.
  * See https://cloud.google.com/dlp/docs/creating-stored-infotypes to
  * learn more.
@@ -3625,6 +3604,27 @@ export class DlpServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listStoredInfoTypes(
+      request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.privacy.dlp.v2.IStoredInfoType[],
+        protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest|null,
+        protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse
+      ]>;
+  listStoredInfoTypes(
+      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+          protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IStoredInfoType>): void;
+  listStoredInfoTypes(
+      request: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+      callback: PaginationCallback<
+          protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
+          protos.google.privacy.dlp.v2.IListStoredInfoTypesResponse|null|undefined,
+          protos.google.privacy.dlp.v2.IStoredInfoType>): void;
   listStoredInfoTypes(
       request?: protos.google.privacy.dlp.v2.IListStoredInfoTypesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -304,6 +304,23 @@ export class KeyManagementServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Returns metadata for a given {@link google.cloud.kms.v1.KeyRing|KeyRing}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The {@link google.cloud.kms.v1.KeyRing.name|name} of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to get.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [KeyRing]{@link google.cloud.kms.v1.KeyRing}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getKeyRing(request);
+ */
   getKeyRing(
       request?: protos.google.cloud.kms.v1.IGetKeyRingRequest,
       options?: CallOptions):
@@ -324,23 +341,6 @@ export class KeyManagementServiceClient {
           protos.google.cloud.kms.v1.IKeyRing,
           protos.google.cloud.kms.v1.IGetKeyRingRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Returns metadata for a given {@link google.cloud.kms.v1.KeyRing|KeyRing}.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The {@link google.cloud.kms.v1.KeyRing.name|name} of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to get.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [KeyRing]{@link google.cloud.kms.v1.KeyRing}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getKeyRing(request);
- */
   getKeyRing(
       request?: protos.google.cloud.kms.v1.IGetKeyRingRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -375,6 +375,24 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.getKeyRing(request, options, callback);
   }
+/**
+ * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKey|CryptoKey}, as well as its
+ * {@link google.cloud.kms.v1.CryptoKey.primary|primary} {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The {@link google.cloud.kms.v1.CryptoKey.name|name} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to get.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [CryptoKey]{@link google.cloud.kms.v1.CryptoKey}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getCryptoKey(request);
+ */
   getCryptoKey(
       request?: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
       options?: CallOptions):
@@ -395,24 +413,6 @@ export class KeyManagementServiceClient {
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IGetCryptoKeyRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKey|CryptoKey}, as well as its
- * {@link google.cloud.kms.v1.CryptoKey.primary|primary} {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The {@link google.cloud.kms.v1.CryptoKey.name|name} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to get.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [CryptoKey]{@link google.cloud.kms.v1.CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getCryptoKey(request);
- */
   getCryptoKey(
       request?: protos.google.cloud.kms.v1.IGetCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -447,6 +447,23 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.getCryptoKey(request, options, callback);
   }
+/**
+ * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The {@link google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to get.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [CryptoKeyVersion]{@link google.cloud.kms.v1.CryptoKeyVersion}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getCryptoKeyVersion(request);
+ */
   getCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
       options?: CallOptions):
@@ -467,23 +484,6 @@ export class KeyManagementServiceClient {
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The {@link google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to get.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [CryptoKeyVersion]{@link google.cloud.kms.v1.CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getCryptoKeyVersion(request);
- */
   getCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IGetCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -518,26 +518,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.getCryptoKeyVersion(request, options, callback);
   }
-  getPublicKey(
-      request?: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IPublicKey,
-        protos.google.cloud.kms.v1.IGetPublicKeyRequest|undefined, {}|undefined
-      ]>;
-  getPublicKey(
-      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IPublicKey,
-          protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
-          {}|null|undefined>): void;
-  getPublicKey(
-      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IPublicKey,
-          protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Returns the public key for the given {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}. The
  * {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
@@ -559,6 +539,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.getPublicKey(request);
  */
+  getPublicKey(
+      request?: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IPublicKey,
+        protos.google.cloud.kms.v1.IGetPublicKeyRequest|undefined, {}|undefined
+      ]>;
+  getPublicKey(
+      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IPublicKey,
+          protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
+          {}|null|undefined>): void;
+  getPublicKey(
+      request: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IPublicKey,
+          protos.google.cloud.kms.v1.IGetPublicKeyRequest|null|undefined,
+          {}|null|undefined>): void;
   getPublicKey(
       request?: protos.google.cloud.kms.v1.IGetPublicKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -593,6 +593,23 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.getPublicKey(request, options, callback);
   }
+/**
+ * Returns metadata for a given {@link google.cloud.kms.v1.ImportJob|ImportJob}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The {@link google.cloud.kms.v1.ImportJob.name|name} of the {@link google.cloud.kms.v1.ImportJob|ImportJob} to get.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ImportJob]{@link google.cloud.kms.v1.ImportJob}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getImportJob(request);
+ */
   getImportJob(
       request?: protos.google.cloud.kms.v1.IGetImportJobRequest,
       options?: CallOptions):
@@ -613,23 +630,6 @@ export class KeyManagementServiceClient {
           protos.google.cloud.kms.v1.IImportJob,
           protos.google.cloud.kms.v1.IGetImportJobRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Returns metadata for a given {@link google.cloud.kms.v1.ImportJob|ImportJob}.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The {@link google.cloud.kms.v1.ImportJob.name|name} of the {@link google.cloud.kms.v1.ImportJob|ImportJob} to get.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [ImportJob]{@link google.cloud.kms.v1.ImportJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getImportJob(request);
- */
   getImportJob(
       request?: protos.google.cloud.kms.v1.IGetImportJobRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -664,26 +664,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.getImportJob(request, options, callback);
   }
-  createKeyRing(
-      request?: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IKeyRing,
-        protos.google.cloud.kms.v1.ICreateKeyRingRequest|undefined, {}|undefined
-      ]>;
-  createKeyRing(
-      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IKeyRing,
-          protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
-          {}|null|undefined>): void;
-  createKeyRing(
-      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IKeyRing,
-          protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a new {@link google.cloud.kms.v1.KeyRing|KeyRing} in a given Project and Location.
  *
@@ -707,6 +687,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.createKeyRing(request);
  */
+  createKeyRing(
+      request?: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IKeyRing,
+        protos.google.cloud.kms.v1.ICreateKeyRingRequest|undefined, {}|undefined
+      ]>;
+  createKeyRing(
+      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IKeyRing,
+          protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
+          {}|null|undefined>): void;
+  createKeyRing(
+      request: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IKeyRing,
+          protos.google.cloud.kms.v1.ICreateKeyRingRequest|null|undefined,
+          {}|null|undefined>): void;
   createKeyRing(
       request?: protos.google.cloud.kms.v1.ICreateKeyRingRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -741,26 +741,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.createKeyRing(request, options, callback);
   }
-  createCryptoKey(
-      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKey,
-        protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|undefined, {}|undefined
-      ]>;
-  createCryptoKey(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKey,
-          protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
-          {}|null|undefined>): void;
-  createCryptoKey(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKey,
-          protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a new {@link google.cloud.kms.v1.CryptoKey|CryptoKey} within a {@link google.cloud.kms.v1.KeyRing|KeyRing}.
  *
@@ -796,6 +776,26 @@ export class KeyManagementServiceClient {
  */
   createCryptoKey(
       request?: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKey,
+        protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|undefined, {}|undefined
+      ]>;
+  createCryptoKey(
+      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKey,
+          protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
+          {}|null|undefined>): void;
+  createCryptoKey(
+      request: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKey,
+          protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
+          {}|null|undefined>): void;
+  createCryptoKey(
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.ICreateCryptoKeyRequest|null|undefined,
@@ -828,26 +828,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.createCryptoKey(request, options, callback);
   }
-  createCryptoKeyVersion(
-      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion,
-        protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|undefined, {}|undefined
-      ]>;
-  createCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  createCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a new {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in a {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *
@@ -872,6 +852,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.createCryptoKeyVersion(request);
  */
+  createCryptoKeyVersion(
+      request?: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion,
+        protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|undefined, {}|undefined
+      ]>;
+  createCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  createCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
   createCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -906,26 +906,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.createCryptoKeyVersion(request, options, callback);
   }
-  importCryptoKeyVersion(
-      request?: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion,
-        protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|undefined, {}|undefined
-      ]>;
-  importCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  importCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Imports a new {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} into an existing {@link google.cloud.kms.v1.CryptoKey|CryptoKey} using the
  * wrapped key material provided in the request.
@@ -977,6 +957,26 @@ export class KeyManagementServiceClient {
  */
   importCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion,
+        protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|undefined, {}|undefined
+      ]>;
+  importCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  importCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  importCryptoKeyVersion(
+      request?: protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.ICryptoKeyVersion,
           protos.google.cloud.kms.v1.IImportCryptoKeyVersionRequest|null|undefined,
@@ -1009,26 +1009,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.importCryptoKeyVersion(request, options, callback);
   }
-  createImportJob(
-      request?: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IImportJob,
-        protos.google.cloud.kms.v1.ICreateImportJobRequest|undefined, {}|undefined
-      ]>;
-  createImportJob(
-      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IImportJob,
-          protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
-          {}|null|undefined>): void;
-  createImportJob(
-      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IImportJob,
-          protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a new {@link google.cloud.kms.v1.ImportJob|ImportJob} within a {@link google.cloud.kms.v1.KeyRing|KeyRing}.
  *
@@ -1054,6 +1034,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.createImportJob(request);
  */
+  createImportJob(
+      request?: protos.google.cloud.kms.v1.ICreateImportJobRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IImportJob,
+        protos.google.cloud.kms.v1.ICreateImportJobRequest|undefined, {}|undefined
+      ]>;
+  createImportJob(
+      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IImportJob,
+          protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
+          {}|null|undefined>): void;
+  createImportJob(
+      request: protos.google.cloud.kms.v1.ICreateImportJobRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IImportJob,
+          protos.google.cloud.kms.v1.ICreateImportJobRequest|null|undefined,
+          {}|null|undefined>): void;
   createImportJob(
       request?: protos.google.cloud.kms.v1.ICreateImportJobRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1088,6 +1088,25 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.createImportJob(request, options, callback);
   }
+/**
+ * Update a {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
+ *   {@link google.cloud.kms.v1.CryptoKey|CryptoKey} with updated values.
+ * @param {google.protobuf.FieldMask} request.updateMask
+ *   Required list of fields to be updated in this request.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [CryptoKey]{@link google.cloud.kms.v1.CryptoKey}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.updateCryptoKey(request);
+ */
   updateCryptoKey(
       request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
       options?: CallOptions):
@@ -1108,25 +1127,6 @@ export class KeyManagementServiceClient {
           protos.google.cloud.kms.v1.ICryptoKey,
           protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Update a {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
- *   {@link google.cloud.kms.v1.CryptoKey|CryptoKey} with updated values.
- * @param {google.protobuf.FieldMask} request.updateMask
- *   Required list of fields to be updated in this request.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [CryptoKey]{@link google.cloud.kms.v1.CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.updateCryptoKey(request);
- */
   updateCryptoKey(
       request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1161,26 +1161,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.updateCryptoKey(request, options, callback);
   }
-  updateCryptoKeyVersion(
-      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion,
-        protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|undefined, {}|undefined
-      ]>;
-  updateCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Update a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}'s metadata.
  *
@@ -1206,6 +1186,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.updateCryptoKeyVersion(request);
  */
+  updateCryptoKeyVersion(
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion,
+        protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|undefined, {}|undefined
+      ]>;
+  updateCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
   updateCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1240,26 +1240,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }
-  encrypt(
-      request?: protos.google.cloud.kms.v1.IEncryptRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IEncryptResponse,
-        protos.google.cloud.kms.v1.IEncryptRequest|undefined, {}|undefined
-      ]>;
-  encrypt(
-      request: protos.google.cloud.kms.v1.IEncryptRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IEncryptResponse,
-          protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
-          {}|null|undefined>): void;
-  encrypt(
-      request: protos.google.cloud.kms.v1.IEncryptRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IEncryptResponse,
-          protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Encrypts data, so that it can only be recovered by a call to {@link google.cloud.kms.v1.KeyManagementService.Decrypt|Decrypt}.
  * The {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
@@ -1304,6 +1284,26 @@ export class KeyManagementServiceClient {
  */
   encrypt(
       request?: protos.google.cloud.kms.v1.IEncryptRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IEncryptResponse,
+        protos.google.cloud.kms.v1.IEncryptRequest|undefined, {}|undefined
+      ]>;
+  encrypt(
+      request: protos.google.cloud.kms.v1.IEncryptRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IEncryptResponse,
+          protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
+          {}|null|undefined>): void;
+  encrypt(
+      request: protos.google.cloud.kms.v1.IEncryptRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IEncryptResponse,
+          protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
+          {}|null|undefined>): void;
+  encrypt(
+      request?: protos.google.cloud.kms.v1.IEncryptRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.kms.v1.IEncryptResponse,
           protos.google.cloud.kms.v1.IEncryptRequest|null|undefined,
@@ -1336,26 +1336,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.encrypt(request, options, callback);
   }
-  decrypt(
-      request?: protos.google.cloud.kms.v1.IDecryptRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IDecryptResponse,
-        protos.google.cloud.kms.v1.IDecryptRequest|undefined, {}|undefined
-      ]>;
-  decrypt(
-      request: protos.google.cloud.kms.v1.IDecryptRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IDecryptResponse,
-          protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
-          {}|null|undefined>): void;
-  decrypt(
-      request: protos.google.cloud.kms.v1.IDecryptRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IDecryptResponse,
-          protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Decrypts data that was protected by {@link google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}. The {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
  * must be {@link google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT|ENCRYPT_DECRYPT}.
@@ -1381,6 +1361,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.decrypt(request);
  */
+  decrypt(
+      request?: protos.google.cloud.kms.v1.IDecryptRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IDecryptResponse,
+        protos.google.cloud.kms.v1.IDecryptRequest|undefined, {}|undefined
+      ]>;
+  decrypt(
+      request: protos.google.cloud.kms.v1.IDecryptRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IDecryptResponse,
+          protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
+          {}|null|undefined>): void;
+  decrypt(
+      request: protos.google.cloud.kms.v1.IDecryptRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IDecryptResponse,
+          protos.google.cloud.kms.v1.IDecryptRequest|null|undefined,
+          {}|null|undefined>): void;
   decrypt(
       request?: protos.google.cloud.kms.v1.IDecryptRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1415,26 +1415,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.decrypt(request, options, callback);
   }
-  asymmetricSign(
-      request?: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IAsymmetricSignResponse,
-        protos.google.cloud.kms.v1.IAsymmetricSignRequest|undefined, {}|undefined
-      ]>;
-  asymmetricSign(
-      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IAsymmetricSignResponse,
-          protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
-          {}|null|undefined>): void;
-  asymmetricSign(
-      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IAsymmetricSignResponse,
-          protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Signs data using a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
  * ASYMMETRIC_SIGN, producing a signature that can be verified with the public
@@ -1458,6 +1438,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.asymmetricSign(request);
  */
+  asymmetricSign(
+      request?: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IAsymmetricSignResponse,
+        protos.google.cloud.kms.v1.IAsymmetricSignRequest|undefined, {}|undefined
+      ]>;
+  asymmetricSign(
+      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IAsymmetricSignResponse,
+          protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
+          {}|null|undefined>): void;
+  asymmetricSign(
+      request: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IAsymmetricSignResponse,
+          protos.google.cloud.kms.v1.IAsymmetricSignRequest|null|undefined,
+          {}|null|undefined>): void;
   asymmetricSign(
       request?: protos.google.cloud.kms.v1.IAsymmetricSignRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1492,26 +1492,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.asymmetricSign(request, options, callback);
   }
-  asymmetricDecrypt(
-      request?: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
-        protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|undefined, {}|undefined
-      ]>;
-  asymmetricDecrypt(
-      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
-          protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
-          {}|null|undefined>): void;
-  asymmetricDecrypt(
-      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
-          protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Decrypts data that was encrypted with a public key retrieved from
  * {@link google.cloud.kms.v1.KeyManagementService.GetPublicKey|GetPublicKey} corresponding to a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with
@@ -1535,6 +1515,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.asymmetricDecrypt(request);
  */
+  asymmetricDecrypt(
+      request?: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
+        protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|undefined, {}|undefined
+      ]>;
+  asymmetricDecrypt(
+      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
+          protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
+          {}|null|undefined>): void;
+  asymmetricDecrypt(
+      request: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.IAsymmetricDecryptResponse,
+          protos.google.cloud.kms.v1.IAsymmetricDecryptRequest|null|undefined,
+          {}|null|undefined>): void;
   asymmetricDecrypt(
       request?: protos.google.cloud.kms.v1.IAsymmetricDecryptRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1569,26 +1569,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.asymmetricDecrypt(request, options, callback);
   }
-  updateCryptoKeyPrimaryVersion(
-      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKey,
-        protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|undefined, {}|undefined
-      ]>;
-  updateCryptoKeyPrimaryVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKey,
-          protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateCryptoKeyPrimaryVersion(
-      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKey,
-          protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Update the version of a {@link google.cloud.kms.v1.CryptoKey|CryptoKey} that will be used in {@link google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}.
  *
@@ -1610,6 +1590,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.updateCryptoKeyPrimaryVersion(request);
  */
+  updateCryptoKeyPrimaryVersion(
+      request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKey,
+        protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|undefined, {}|undefined
+      ]>;
+  updateCryptoKeyPrimaryVersion(
+      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKey,
+          protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateCryptoKeyPrimaryVersion(
+      request: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKey,
+          protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest|null|undefined,
+          {}|null|undefined>): void;
   updateCryptoKeyPrimaryVersion(
       request?: protos.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1644,26 +1644,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.updateCryptoKeyPrimaryVersion(request, options, callback);
   }
-  destroyCryptoKeyVersion(
-      request?: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion,
-        protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|undefined, {}|undefined
-      ]>;
-  destroyCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  destroyCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Schedule a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} for destruction.
  *
@@ -1692,6 +1672,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.destroyCryptoKeyVersion(request);
  */
+  destroyCryptoKeyVersion(
+      request?: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion,
+        protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|undefined, {}|undefined
+      ]>;
+  destroyCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  destroyCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
   destroyCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1726,26 +1726,6 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.innerApiCalls.destroyCryptoKeyVersion(request, options, callback);
   }
-  restoreCryptoKeyVersion(
-      request?: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion,
-        protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|undefined, {}|undefined
-      ]>;
-  restoreCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
-  restoreCryptoKeyVersion(
-      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
-      callback: Callback<
-          protos.google.cloud.kms.v1.ICryptoKeyVersion,
-          protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Restore a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in the
  * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED|DESTROY_SCHEDULED}
@@ -1769,6 +1749,26 @@ export class KeyManagementServiceClient {
  * @example
  * const [response] = await client.restoreCryptoKeyVersion(request);
  */
+  restoreCryptoKeyVersion(
+      request?: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion,
+        protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|undefined, {}|undefined
+      ]>;
+  restoreCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
+  restoreCryptoKeyVersion(
+      request: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
+      callback: Callback<
+          protos.google.cloud.kms.v1.ICryptoKeyVersion,
+          protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest|null|undefined,
+          {}|null|undefined>): void;
   restoreCryptoKeyVersion(
       request?: protos.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1804,28 +1804,7 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.restoreCryptoKeyVersion(request, options, callback);
   }
 
-  listKeyRings(
-      request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IKeyRing[],
-        protos.google.cloud.kms.v1.IListKeyRingsRequest|null,
-        protos.google.cloud.kms.v1.IListKeyRingsResponse
-      ]>;
-  listKeyRings(
-      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListKeyRingsRequest,
-          protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
-          protos.google.cloud.kms.v1.IKeyRing>): void;
-  listKeyRings(
-      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListKeyRingsRequest,
-          protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
-          protos.google.cloud.kms.v1.IKeyRing>): void;
-/**
+ /**
  * Lists {@link google.cloud.kms.v1.KeyRing|KeyRings}.
  *
  * @param {Object} request
@@ -1859,6 +1838,27 @@ export class KeyManagementServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listKeyRings(
+      request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IKeyRing[],
+        protos.google.cloud.kms.v1.IListKeyRingsRequest|null,
+        protos.google.cloud.kms.v1.IListKeyRingsResponse
+      ]>;
+  listKeyRings(
+      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListKeyRingsRequest,
+          protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
+          protos.google.cloud.kms.v1.IKeyRing>): void;
+  listKeyRings(
+      request: protos.google.cloud.kms.v1.IListKeyRingsRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListKeyRingsRequest,
+          protos.google.cloud.kms.v1.IListKeyRingsResponse|null|undefined,
+          protos.google.cloud.kms.v1.IKeyRing>): void;
   listKeyRings(
       request?: protos.google.cloud.kms.v1.IListKeyRingsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -2011,28 +2011,7 @@ export class KeyManagementServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>;
   }
-  listCryptoKeys(
-      request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKey[],
-        protos.google.cloud.kms.v1.IListCryptoKeysRequest|null,
-        protos.google.cloud.kms.v1.IListCryptoKeysResponse
-      ]>;
-  listCryptoKeys(
-      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-          protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
-          protos.google.cloud.kms.v1.ICryptoKey>): void;
-  listCryptoKeys(
-      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListCryptoKeysRequest,
-          protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
-          protos.google.cloud.kms.v1.ICryptoKey>): void;
-/**
+ /**
  * Lists {@link google.cloud.kms.v1.CryptoKey|CryptoKeys}.
  *
  * @param {Object} request
@@ -2068,6 +2047,27 @@ export class KeyManagementServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listCryptoKeys(
+      request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKey[],
+        protos.google.cloud.kms.v1.IListCryptoKeysRequest|null,
+        protos.google.cloud.kms.v1.IListCryptoKeysResponse
+      ]>;
+  listCryptoKeys(
+      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+          protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
+          protos.google.cloud.kms.v1.ICryptoKey>): void;
+  listCryptoKeys(
+      request: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListCryptoKeysRequest,
+          protos.google.cloud.kms.v1.IListCryptoKeysResponse|null|undefined,
+          protos.google.cloud.kms.v1.ICryptoKey>): void;
   listCryptoKeys(
       request?: protos.google.cloud.kms.v1.IListCryptoKeysRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -2224,28 +2224,7 @@ export class KeyManagementServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>;
   }
-  listCryptoKeyVersions(
-      request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.ICryptoKeyVersion[],
-        protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
-        protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse
-      ]>;
-  listCryptoKeyVersions(
-      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-          protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
-          protos.google.cloud.kms.v1.ICryptoKeyVersion>): void;
-  listCryptoKeyVersions(
-      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
-          protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
-          protos.google.cloud.kms.v1.ICryptoKeyVersion>): void;
-/**
+ /**
  * Lists {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}.
  *
  * @param {Object} request
@@ -2282,6 +2261,27 @@ export class KeyManagementServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listCryptoKeyVersions(
+      request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.ICryptoKeyVersion[],
+        protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest|null,
+        protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse
+      ]>;
+  listCryptoKeyVersions(
+      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+          protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
+          protos.google.cloud.kms.v1.ICryptoKeyVersion>): void;
+  listCryptoKeyVersions(
+      request: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
+          protos.google.cloud.kms.v1.IListCryptoKeyVersionsResponse|null|undefined,
+          protos.google.cloud.kms.v1.ICryptoKeyVersion>): void;
   listCryptoKeyVersions(
       request?: protos.google.cloud.kms.v1.IListCryptoKeyVersionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -2440,28 +2440,7 @@ export class KeyManagementServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>;
   }
-  listImportJobs(
-      request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.kms.v1.IImportJob[],
-        protos.google.cloud.kms.v1.IListImportJobsRequest|null,
-        protos.google.cloud.kms.v1.IListImportJobsResponse
-      ]>;
-  listImportJobs(
-      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListImportJobsRequest,
-          protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
-          protos.google.cloud.kms.v1.IImportJob>): void;
-  listImportJobs(
-      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.kms.v1.IListImportJobsRequest,
-          protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
-          protos.google.cloud.kms.v1.IImportJob>): void;
-/**
+ /**
  * Lists {@link google.cloud.kms.v1.ImportJob|ImportJobs}.
  *
  * @param {Object} request
@@ -2495,6 +2474,27 @@ export class KeyManagementServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listImportJobs(
+      request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.kms.v1.IImportJob[],
+        protos.google.cloud.kms.v1.IListImportJobsRequest|null,
+        protos.google.cloud.kms.v1.IListImportJobsResponse
+      ]>;
+  listImportJobs(
+      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListImportJobsRequest,
+          protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
+          protos.google.cloud.kms.v1.IImportJob>): void;
+  listImportJobs(
+      request: protos.google.cloud.kms.v1.IListImportJobsRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.kms.v1.IListImportJobsRequest,
+          protos.google.cloud.kms.v1.IListImportJobsResponse|null|undefined,
+          protos.google.cloud.kms.v1.IImportJob>): void;
   listImportJobs(
       request?: protos.google.cloud.kms.v1.IListImportJobsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -367,26 +367,6 @@ export class ConfigServiceV2Client {
   // -------------------
   // -- Service calls --
   // -------------------
-  getBucket(
-      request?: protos.google.logging.v2.IGetBucketRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogBucket,
-        protos.google.logging.v2.IGetBucketRequest|undefined, {}|undefined
-      ]>;
-  getBucket(
-      request: protos.google.logging.v2.IGetBucketRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogBucket,
-          protos.google.logging.v2.IGetBucketRequest|null|undefined,
-          {}|null|undefined>): void;
-  getBucket(
-      request: protos.google.logging.v2.IGetBucketRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogBucket,
-          protos.google.logging.v2.IGetBucketRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a bucket (Beta).
  *
@@ -412,6 +392,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.getBucket(request);
  */
+  getBucket(
+      request?: protos.google.logging.v2.IGetBucketRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogBucket,
+        protos.google.logging.v2.IGetBucketRequest|undefined, {}|undefined
+      ]>;
+  getBucket(
+      request: protos.google.logging.v2.IGetBucketRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.IGetBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  getBucket(
+      request: protos.google.logging.v2.IGetBucketRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.IGetBucketRequest|null|undefined,
+          {}|null|undefined>): void;
   getBucket(
       request?: protos.google.logging.v2.IGetBucketRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -446,26 +446,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.getBucket(request, options, callback);
   }
-  updateBucket(
-      request?: protos.google.logging.v2.IUpdateBucketRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogBucket,
-        protos.google.logging.v2.IUpdateBucketRequest|undefined, {}|undefined
-      ]>;
-  updateBucket(
-      request: protos.google.logging.v2.IUpdateBucketRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogBucket,
-          protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateBucket(
-      request: protos.google.logging.v2.IUpdateBucketRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogBucket,
-          protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a bucket. This method replaces the following fields in the
  * existing bucket with values from the new bucket: `retention_period`
@@ -516,6 +496,26 @@ export class ConfigServiceV2Client {
  */
   updateBucket(
       request?: protos.google.logging.v2.IUpdateBucketRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogBucket,
+        protos.google.logging.v2.IUpdateBucketRequest|undefined, {}|undefined
+      ]>;
+  updateBucket(
+      request: protos.google.logging.v2.IUpdateBucketRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateBucket(
+      request: protos.google.logging.v2.IUpdateBucketRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateBucket(
+      request?: protos.google.logging.v2.IUpdateBucketRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogBucket,
           protos.google.logging.v2.IUpdateBucketRequest|null|undefined,
@@ -548,26 +548,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.updateBucket(request, options, callback);
   }
-  getSink(
-      request?: protos.google.logging.v2.IGetSinkRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogSink,
-        protos.google.logging.v2.IGetSinkRequest|undefined, {}|undefined
-      ]>;
-  getSink(
-      request: protos.google.logging.v2.IGetSinkRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.IGetSinkRequest|null|undefined,
-          {}|null|undefined>): void;
-  getSink(
-      request: protos.google.logging.v2.IGetSinkRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.IGetSinkRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a sink.
  *
@@ -592,6 +572,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.getSink(request);
  */
+  getSink(
+      request?: protos.google.logging.v2.IGetSinkRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogSink,
+        protos.google.logging.v2.IGetSinkRequest|undefined, {}|undefined
+      ]>;
+  getSink(
+      request: protos.google.logging.v2.IGetSinkRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.IGetSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  getSink(
+      request: protos.google.logging.v2.IGetSinkRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.IGetSinkRequest|null|undefined,
+          {}|null|undefined>): void;
   getSink(
       request?: protos.google.logging.v2.IGetSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -626,26 +626,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.getSink(request, options, callback);
   }
-  createSink(
-      request?: protos.google.logging.v2.ICreateSinkRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogSink,
-        protos.google.logging.v2.ICreateSinkRequest|undefined, {}|undefined
-      ]>;
-  createSink(
-      request: protos.google.logging.v2.ICreateSinkRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.ICreateSinkRequest|null|undefined,
-          {}|null|undefined>): void;
-  createSink(
-      request: protos.google.logging.v2.ICreateSinkRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.ICreateSinkRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a sink that exports specified log entries to a destination. The
  * export of newly-ingested log entries begins immediately, unless the sink's
@@ -690,6 +670,26 @@ export class ConfigServiceV2Client {
  */
   createSink(
       request?: protos.google.logging.v2.ICreateSinkRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogSink,
+        protos.google.logging.v2.ICreateSinkRequest|undefined, {}|undefined
+      ]>;
+  createSink(
+      request: protos.google.logging.v2.ICreateSinkRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.ICreateSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  createSink(
+      request: protos.google.logging.v2.ICreateSinkRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.ICreateSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  createSink(
+      request?: protos.google.logging.v2.ICreateSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.ICreateSinkRequest|null|undefined,
@@ -722,26 +722,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.createSink(request, options, callback);
   }
-  updateSink(
-      request?: protos.google.logging.v2.IUpdateSinkRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogSink,
-        protos.google.logging.v2.IUpdateSinkRequest|undefined, {}|undefined
-      ]>;
-  updateSink(
-      request: protos.google.logging.v2.IUpdateSinkRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateSink(
-      request: protos.google.logging.v2.IUpdateSinkRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogSink,
-          protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a sink. This method replaces the following fields in the existing
  * sink with values from the new sink: `destination`, and `filter`.
@@ -803,6 +783,26 @@ export class ConfigServiceV2Client {
  */
   updateSink(
       request?: protos.google.logging.v2.IUpdateSinkRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogSink,
+        protos.google.logging.v2.IUpdateSinkRequest|undefined, {}|undefined
+      ]>;
+  updateSink(
+      request: protos.google.logging.v2.IUpdateSinkRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateSink(
+      request: protos.google.logging.v2.IUpdateSinkRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogSink,
+          protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateSink(
+      request?: protos.google.logging.v2.IUpdateSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogSink,
           protos.google.logging.v2.IUpdateSinkRequest|null|undefined,
@@ -835,26 +835,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.updateSink(request, options, callback);
   }
-  deleteSink(
-      request?: protos.google.logging.v2.IDeleteSinkRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.logging.v2.IDeleteSinkRequest|undefined, {}|undefined
-      ]>;
-  deleteSink(
-      request: protos.google.logging.v2.IDeleteSinkRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteSink(
-      request: protos.google.logging.v2.IDeleteSinkRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a sink. If the sink has a unique `writer_identity`, then that
  * service account is also deleted.
@@ -881,6 +861,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.deleteSink(request);
  */
+  deleteSink(
+      request?: protos.google.logging.v2.IDeleteSinkRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteSinkRequest|undefined, {}|undefined
+      ]>;
+  deleteSink(
+      request: protos.google.logging.v2.IDeleteSinkRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteSink(
+      request: protos.google.logging.v2.IDeleteSinkRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteSinkRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteSink(
       request?: protos.google.logging.v2.IDeleteSinkRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -915,26 +915,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.deleteSink(request, options, callback);
   }
-  getExclusion(
-      request?: protos.google.logging.v2.IGetExclusionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogExclusion,
-        protos.google.logging.v2.IGetExclusionRequest|undefined, {}|undefined
-      ]>;
-  getExclusion(
-      request: protos.google.logging.v2.IGetExclusionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.IGetExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
-  getExclusion(
-      request: protos.google.logging.v2.IGetExclusionRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.IGetExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets the description of an exclusion.
  *
@@ -959,6 +939,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.getExclusion(request);
  */
+  getExclusion(
+      request?: protos.google.logging.v2.IGetExclusionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogExclusion,
+        protos.google.logging.v2.IGetExclusionRequest|undefined, {}|undefined
+      ]>;
+  getExclusion(
+      request: protos.google.logging.v2.IGetExclusionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.IGetExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
+  getExclusion(
+      request: protos.google.logging.v2.IGetExclusionRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.IGetExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
   getExclusion(
       request?: protos.google.logging.v2.IGetExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -993,26 +993,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.getExclusion(request, options, callback);
   }
-  createExclusion(
-      request?: protos.google.logging.v2.ICreateExclusionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogExclusion,
-        protos.google.logging.v2.ICreateExclusionRequest|undefined, {}|undefined
-      ]>;
-  createExclusion(
-      request: protos.google.logging.v2.ICreateExclusionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
-  createExclusion(
-      request: protos.google.logging.v2.ICreateExclusionRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new exclusion in a specified parent resource.
  * Only log entries belonging to that resource can be excluded.
@@ -1042,6 +1022,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.createExclusion(request);
  */
+  createExclusion(
+      request?: protos.google.logging.v2.ICreateExclusionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogExclusion,
+        protos.google.logging.v2.ICreateExclusionRequest|undefined, {}|undefined
+      ]>;
+  createExclusion(
+      request: protos.google.logging.v2.ICreateExclusionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
+  createExclusion(
+      request: protos.google.logging.v2.ICreateExclusionRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.ICreateExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
   createExclusion(
       request?: protos.google.logging.v2.ICreateExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1076,26 +1076,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.createExclusion(request, options, callback);
   }
-  updateExclusion(
-      request?: protos.google.logging.v2.IUpdateExclusionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogExclusion,
-        protos.google.logging.v2.IUpdateExclusionRequest|undefined, {}|undefined
-      ]>;
-  updateExclusion(
-      request: protos.google.logging.v2.IUpdateExclusionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateExclusion(
-      request: protos.google.logging.v2.IUpdateExclusionRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogExclusion,
-          protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Changes one or more properties of an existing exclusion.
  *
@@ -1133,6 +1113,26 @@ export class ConfigServiceV2Client {
  */
   updateExclusion(
       request?: protos.google.logging.v2.IUpdateExclusionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogExclusion,
+        protos.google.logging.v2.IUpdateExclusionRequest|undefined, {}|undefined
+      ]>;
+  updateExclusion(
+      request: protos.google.logging.v2.IUpdateExclusionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateExclusion(
+      request: protos.google.logging.v2.IUpdateExclusionRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogExclusion,
+          protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateExclusion(
+      request?: protos.google.logging.v2.IUpdateExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ILogExclusion,
           protos.google.logging.v2.IUpdateExclusionRequest|null|undefined,
@@ -1165,26 +1165,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.updateExclusion(request, options, callback);
   }
-  deleteExclusion(
-      request?: protos.google.logging.v2.IDeleteExclusionRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.logging.v2.IDeleteExclusionRequest|undefined, {}|undefined
-      ]>;
-  deleteExclusion(
-      request: protos.google.logging.v2.IDeleteExclusionRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteExclusion(
-      request: protos.google.logging.v2.IDeleteExclusionRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an exclusion.
  *
@@ -1209,6 +1189,26 @@ export class ConfigServiceV2Client {
  * @example
  * const [response] = await client.deleteExclusion(request);
  */
+  deleteExclusion(
+      request?: protos.google.logging.v2.IDeleteExclusionRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteExclusionRequest|undefined, {}|undefined
+      ]>;
+  deleteExclusion(
+      request: protos.google.logging.v2.IDeleteExclusionRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteExclusion(
+      request: protos.google.logging.v2.IDeleteExclusionRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteExclusionRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteExclusion(
       request?: protos.google.logging.v2.IDeleteExclusionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1243,26 +1243,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.deleteExclusion(request, options, callback);
   }
-  getCmekSettings(
-      request?: protos.google.logging.v2.IGetCmekSettingsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ICmekSettings,
-        protos.google.logging.v2.IGetCmekSettingsRequest|undefined, {}|undefined
-      ]>;
-  getCmekSettings(
-      request: protos.google.logging.v2.IGetCmekSettingsRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ICmekSettings,
-          protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
-          {}|null|undefined>): void;
-  getCmekSettings(
-      request: protos.google.logging.v2.IGetCmekSettingsRequest,
-      callback: Callback<
-          protos.google.logging.v2.ICmekSettings,
-          protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets the Logs Router CMEK settings for the given resource.
  *
@@ -1300,6 +1280,26 @@ export class ConfigServiceV2Client {
  */
   getCmekSettings(
       request?: protos.google.logging.v2.IGetCmekSettingsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ICmekSettings,
+        protos.google.logging.v2.IGetCmekSettingsRequest|undefined, {}|undefined
+      ]>;
+  getCmekSettings(
+      request: protos.google.logging.v2.IGetCmekSettingsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ICmekSettings,
+          protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  getCmekSettings(
+      request: protos.google.logging.v2.IGetCmekSettingsRequest,
+      callback: Callback<
+          protos.google.logging.v2.ICmekSettings,
+          protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  getCmekSettings(
+      request?: protos.google.logging.v2.IGetCmekSettingsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IGetCmekSettingsRequest|null|undefined,
@@ -1332,26 +1332,6 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.getCmekSettings(request, options, callback);
   }
-  updateCmekSettings(
-      request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ICmekSettings,
-        protos.google.logging.v2.IUpdateCmekSettingsRequest|undefined, {}|undefined
-      ]>;
-  updateCmekSettings(
-      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ICmekSettings,
-          protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateCmekSettings(
-      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
-      callback: Callback<
-          protos.google.logging.v2.ICmekSettings,
-          protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates the Logs Router CMEK settings for the given resource.
  *
@@ -1408,6 +1388,26 @@ export class ConfigServiceV2Client {
  */
   updateCmekSettings(
       request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ICmekSettings,
+        protos.google.logging.v2.IUpdateCmekSettingsRequest|undefined, {}|undefined
+      ]>;
+  updateCmekSettings(
+      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ICmekSettings,
+          protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateCmekSettings(
+      request: protos.google.logging.v2.IUpdateCmekSettingsRequest,
+      callback: Callback<
+          protos.google.logging.v2.ICmekSettings,
+          protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateCmekSettings(
+      request?: protos.google.logging.v2.IUpdateCmekSettingsRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.ICmekSettings,
           protos.google.logging.v2.IUpdateCmekSettingsRequest|null|undefined,
@@ -1441,28 +1441,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateCmekSettings(request, options, callback);
   }
 
-  listBuckets(
-      request?: protos.google.logging.v2.IListBucketsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogBucket[],
-        protos.google.logging.v2.IListBucketsRequest|null,
-        protos.google.logging.v2.IListBucketsResponse
-      ]>;
-  listBuckets(
-      request: protos.google.logging.v2.IListBucketsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListBucketsRequest,
-          protos.google.logging.v2.IListBucketsResponse|null|undefined,
-          protos.google.logging.v2.ILogBucket>): void;
-  listBuckets(
-      request: protos.google.logging.v2.IListBucketsRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListBucketsRequest,
-          protos.google.logging.v2.IListBucketsResponse|null|undefined,
-          protos.google.logging.v2.ILogBucket>): void;
-/**
+ /**
  * Lists buckets (Beta).
  *
  * @param {Object} request
@@ -1500,6 +1479,27 @@ export class ConfigServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listBuckets(
+      request?: protos.google.logging.v2.IListBucketsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogBucket[],
+        protos.google.logging.v2.IListBucketsRequest|null,
+        protos.google.logging.v2.IListBucketsResponse
+      ]>;
+  listBuckets(
+      request: protos.google.logging.v2.IListBucketsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListBucketsRequest,
+          protos.google.logging.v2.IListBucketsResponse|null|undefined,
+          protos.google.logging.v2.ILogBucket>): void;
+  listBuckets(
+      request: protos.google.logging.v2.IListBucketsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListBucketsRequest,
+          protos.google.logging.v2.IListBucketsResponse|null|undefined,
+          protos.google.logging.v2.ILogBucket>): void;
   listBuckets(
       request?: protos.google.logging.v2.IListBucketsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1660,28 +1660,7 @@ export class ConfigServiceV2Client {
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
   }
-  listSinks(
-      request?: protos.google.logging.v2.IListSinksRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogSink[],
-        protos.google.logging.v2.IListSinksRequest|null,
-        protos.google.logging.v2.IListSinksResponse
-      ]>;
-  listSinks(
-      request: protos.google.logging.v2.IListSinksRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListSinksRequest,
-          protos.google.logging.v2.IListSinksResponse|null|undefined,
-          protos.google.logging.v2.ILogSink>): void;
-  listSinks(
-      request: protos.google.logging.v2.IListSinksRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListSinksRequest,
-          protos.google.logging.v2.IListSinksResponse|null|undefined,
-          protos.google.logging.v2.ILogSink>): void;
-/**
+ /**
  * Lists sinks.
  *
  * @param {Object} request
@@ -1715,6 +1694,27 @@ export class ConfigServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listSinks(
+      request?: protos.google.logging.v2.IListSinksRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogSink[],
+        protos.google.logging.v2.IListSinksRequest|null,
+        protos.google.logging.v2.IListSinksResponse
+      ]>;
+  listSinks(
+      request: protos.google.logging.v2.IListSinksRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListSinksRequest,
+          protos.google.logging.v2.IListSinksResponse|null|undefined,
+          protos.google.logging.v2.ILogSink>): void;
+  listSinks(
+      request: protos.google.logging.v2.IListSinksRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListSinksRequest,
+          protos.google.logging.v2.IListSinksResponse|null|undefined,
+          protos.google.logging.v2.ILogSink>): void;
   listSinks(
       request?: protos.google.logging.v2.IListSinksRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1867,28 +1867,7 @@ export class ConfigServiceV2Client {
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
-  listExclusions(
-      request?: protos.google.logging.v2.IListExclusionsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogExclusion[],
-        protos.google.logging.v2.IListExclusionsRequest|null,
-        protos.google.logging.v2.IListExclusionsResponse
-      ]>;
-  listExclusions(
-      request: protos.google.logging.v2.IListExclusionsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListExclusionsRequest,
-          protos.google.logging.v2.IListExclusionsResponse|null|undefined,
-          protos.google.logging.v2.ILogExclusion>): void;
-  listExclusions(
-      request: protos.google.logging.v2.IListExclusionsRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListExclusionsRequest,
-          protos.google.logging.v2.IListExclusionsResponse|null|undefined,
-          protos.google.logging.v2.ILogExclusion>): void;
-/**
+ /**
  * Lists all the exclusions in a parent resource.
  *
  * @param {Object} request
@@ -1922,6 +1901,27 @@ export class ConfigServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listExclusions(
+      request?: protos.google.logging.v2.IListExclusionsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogExclusion[],
+        protos.google.logging.v2.IListExclusionsRequest|null,
+        protos.google.logging.v2.IListExclusionsResponse
+      ]>;
+  listExclusions(
+      request: protos.google.logging.v2.IListExclusionsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListExclusionsRequest,
+          protos.google.logging.v2.IListExclusionsResponse|null|undefined,
+          protos.google.logging.v2.ILogExclusion>): void;
+  listExclusions(
+      request: protos.google.logging.v2.IListExclusionsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListExclusionsRequest,
+          protos.google.logging.v2.IListExclusionsResponse|null|undefined,
+          protos.google.logging.v2.ILogExclusion>): void;
   listExclusions(
       request?: protos.google.logging.v2.IListExclusionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -383,26 +383,6 @@ export class LoggingServiceV2Client {
   // -------------------
   // -- Service calls --
   // -------------------
-  deleteLog(
-      request?: protos.google.logging.v2.IDeleteLogRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.logging.v2.IDeleteLogRequest|undefined, {}|undefined
-      ]>;
-  deleteLog(
-      request: protos.google.logging.v2.IDeleteLogRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteLogRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteLog(
-      request: protos.google.logging.v2.IDeleteLogRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.logging.v2.IDeleteLogRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes all the log entries in a log. The log reappears if it receives new
  * entries. Log entries written shortly before the delete operation might not
@@ -434,6 +414,26 @@ export class LoggingServiceV2Client {
  * @example
  * const [response] = await client.deleteLog(request);
  */
+  deleteLog(
+      request?: protos.google.logging.v2.IDeleteLogRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteLogRequest|undefined, {}|undefined
+      ]>;
+  deleteLog(
+      request: protos.google.logging.v2.IDeleteLogRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteLogRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteLog(
+      request: protos.google.logging.v2.IDeleteLogRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteLogRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteLog(
       request?: protos.google.logging.v2.IDeleteLogRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -468,26 +468,6 @@ export class LoggingServiceV2Client {
     this.initialize();
     return this.innerApiCalls.deleteLog(request, options, callback);
   }
-  writeLogEntries(
-      request?: protos.google.logging.v2.IWriteLogEntriesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.IWriteLogEntriesResponse,
-        protos.google.logging.v2.IWriteLogEntriesRequest|undefined, {}|undefined
-      ]>;
-  writeLogEntries(
-      request: protos.google.logging.v2.IWriteLogEntriesRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.IWriteLogEntriesResponse,
-          protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
-          {}|null|undefined>): void;
-  writeLogEntries(
-      request: protos.google.logging.v2.IWriteLogEntriesRequest,
-      callback: Callback<
-          protos.google.logging.v2.IWriteLogEntriesResponse,
-          protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Writes log entries to Logging. This API method is the
  * only way to send log entries to Logging. This method
@@ -577,6 +557,26 @@ export class LoggingServiceV2Client {
  */
   writeLogEntries(
       request?: protos.google.logging.v2.IWriteLogEntriesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.IWriteLogEntriesResponse,
+        protos.google.logging.v2.IWriteLogEntriesRequest|undefined, {}|undefined
+      ]>;
+  writeLogEntries(
+      request: protos.google.logging.v2.IWriteLogEntriesRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.IWriteLogEntriesResponse,
+          protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
+          {}|null|undefined>): void;
+  writeLogEntries(
+      request: protos.google.logging.v2.IWriteLogEntriesRequest,
+      callback: Callback<
+          protos.google.logging.v2.IWriteLogEntriesResponse,
+          protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
+          {}|null|undefined>): void;
+  writeLogEntries(
+      request?: protos.google.logging.v2.IWriteLogEntriesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.logging.v2.IWriteLogEntriesResponse,
           protos.google.logging.v2.IWriteLogEntriesRequest|null|undefined,
@@ -603,28 +603,7 @@ export class LoggingServiceV2Client {
     return this.innerApiCalls.writeLogEntries(request, options, callback);
   }
 
-  listLogEntries(
-      request?: protos.google.logging.v2.IListLogEntriesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogEntry[],
-        protos.google.logging.v2.IListLogEntriesRequest|null,
-        protos.google.logging.v2.IListLogEntriesResponse
-      ]>;
-  listLogEntries(
-      request: protos.google.logging.v2.IListLogEntriesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogEntriesRequest,
-          protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
-          protos.google.logging.v2.ILogEntry>): void;
-  listLogEntries(
-      request: protos.google.logging.v2.IListLogEntriesRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogEntriesRequest,
-          protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
-          protos.google.logging.v2.ILogEntry>): void;
-/**
+ /**
  * Lists log entries.  Use this method to retrieve log entries that originated
  * from a project/folder/organization/billing account.  For ways to export log
  * entries, see [Exporting Logs](/logging/docs/export).
@@ -679,6 +658,27 @@ export class LoggingServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listLogEntries(
+      request?: protos.google.logging.v2.IListLogEntriesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogEntry[],
+        protos.google.logging.v2.IListLogEntriesRequest|null,
+        protos.google.logging.v2.IListLogEntriesResponse
+      ]>;
+  listLogEntries(
+      request: protos.google.logging.v2.IListLogEntriesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogEntriesRequest,
+          protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
+          protos.google.logging.v2.ILogEntry>): void;
+  listLogEntries(
+      request: protos.google.logging.v2.IListLogEntriesRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogEntriesRequest,
+          protos.google.logging.v2.IListLogEntriesResponse|null|undefined,
+          protos.google.logging.v2.ILogEntry>): void;
   listLogEntries(
       request?: protos.google.logging.v2.IListLogEntriesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -848,28 +848,7 @@ export class LoggingServiceV2Client {
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogEntry>;
   }
-  listMonitoredResourceDescriptors(
-      request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMonitoredResourceDescriptor[],
-        protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest|null,
-        protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse
-      ]>;
-  listMonitoredResourceDescriptors(
-      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-          protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
-          protos.google.api.IMonitoredResourceDescriptor>): void;
-  listMonitoredResourceDescriptors(
-      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
-          protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
-          protos.google.api.IMonitoredResourceDescriptor>): void;
-/**
+ /**
  * Lists the descriptors for monitored resource types used by Logging.
  *
  * @param {Object} request
@@ -896,6 +875,27 @@ export class LoggingServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listMonitoredResourceDescriptors(
+      request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMonitoredResourceDescriptor[],
+        protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest|null,
+        protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse
+      ]>;
+  listMonitoredResourceDescriptors(
+      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+          protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
+          protos.google.api.IMonitoredResourceDescriptor>): void;
+  listMonitoredResourceDescriptors(
+      request: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
+          protos.google.logging.v2.IListMonitoredResourceDescriptorsResponse|null|undefined,
+          protos.google.api.IMonitoredResourceDescriptor>): void;
   listMonitoredResourceDescriptors(
       request?: protos.google.logging.v2.IListMonitoredResourceDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1013,28 +1013,7 @@ export class LoggingServiceV2Client {
       callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
-  listLogs(
-      request?: protos.google.logging.v2.IListLogsRequest,
-      options?: CallOptions):
-      Promise<[
-        string[],
-        protos.google.logging.v2.IListLogsRequest|null,
-        protos.google.logging.v2.IListLogsResponse
-      ]>;
-  listLogs(
-      request: protos.google.logging.v2.IListLogsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogsRequest,
-          protos.google.logging.v2.IListLogsResponse|null|undefined,
-          string>): void;
-  listLogs(
-      request: protos.google.logging.v2.IListLogsRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogsRequest,
-          protos.google.logging.v2.IListLogsResponse|null|undefined,
-          string>): void;
-/**
+ /**
  * Lists the logs in projects, organizations, folders, or billing accounts.
  * Only logs that have entries are listed.
  *
@@ -1069,6 +1048,27 @@ export class LoggingServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listLogs(
+      request?: protos.google.logging.v2.IListLogsRequest,
+      options?: CallOptions):
+      Promise<[
+        string[],
+        protos.google.logging.v2.IListLogsRequest|null,
+        protos.google.logging.v2.IListLogsResponse
+      ]>;
+  listLogs(
+      request: protos.google.logging.v2.IListLogsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogsRequest,
+          protos.google.logging.v2.IListLogsResponse|null|undefined,
+          string>): void;
+  listLogs(
+      request: protos.google.logging.v2.IListLogsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogsRequest,
+          protos.google.logging.v2.IListLogsResponse|null|undefined,
+          string>): void;
   listLogs(
       request?: protos.google.logging.v2.IListLogsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -361,6 +361,25 @@ export class MetricsServiceV2Client {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a logs-based metric.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.metricName
+ *   Required. The resource name of the desired metric:
+ *
+ *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getLogMetric(request);
+ */
   getLogMetric(
       request?: protos.google.logging.v2.IGetLogMetricRequest,
       options?: CallOptions):
@@ -381,25 +400,6 @@ export class MetricsServiceV2Client {
           protos.google.logging.v2.ILogMetric,
           protos.google.logging.v2.IGetLogMetricRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a logs-based metric.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.metricName
- *   Required. The resource name of the desired metric:
- *
- *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [LogMetric]{@link google.logging.v2.LogMetric}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getLogMetric(request);
- */
   getLogMetric(
       request?: protos.google.logging.v2.IGetLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -434,26 +434,6 @@ export class MetricsServiceV2Client {
     this.initialize();
     return this.innerApiCalls.getLogMetric(request, options, callback);
   }
-  createLogMetric(
-      request?: protos.google.logging.v2.ICreateLogMetricRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogMetric,
-        protos.google.logging.v2.ICreateLogMetricRequest|undefined, {}|undefined
-      ]>;
-  createLogMetric(
-      request: protos.google.logging.v2.ICreateLogMetricRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogMetric,
-          protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
-          {}|null|undefined>): void;
-  createLogMetric(
-      request: protos.google.logging.v2.ICreateLogMetricRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogMetric,
-          protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a logs-based metric.
  *
@@ -478,6 +458,26 @@ export class MetricsServiceV2Client {
  * @example
  * const [response] = await client.createLogMetric(request);
  */
+  createLogMetric(
+      request?: protos.google.logging.v2.ICreateLogMetricRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogMetric,
+        protos.google.logging.v2.ICreateLogMetricRequest|undefined, {}|undefined
+      ]>;
+  createLogMetric(
+      request: protos.google.logging.v2.ICreateLogMetricRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogMetric,
+          protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
+          {}|null|undefined>): void;
+  createLogMetric(
+      request: protos.google.logging.v2.ICreateLogMetricRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogMetric,
+          protos.google.logging.v2.ICreateLogMetricRequest|null|undefined,
+          {}|null|undefined>): void;
   createLogMetric(
       request?: protos.google.logging.v2.ICreateLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -512,26 +512,6 @@ export class MetricsServiceV2Client {
     this.initialize();
     return this.innerApiCalls.createLogMetric(request, options, callback);
   }
-  updateLogMetric(
-      request?: protos.google.logging.v2.IUpdateLogMetricRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogMetric,
-        protos.google.logging.v2.IUpdateLogMetricRequest|undefined, {}|undefined
-      ]>;
-  updateLogMetric(
-      request: protos.google.logging.v2.IUpdateLogMetricRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.logging.v2.ILogMetric,
-          protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateLogMetric(
-      request: protos.google.logging.v2.IUpdateLogMetricRequest,
-      callback: Callback<
-          protos.google.logging.v2.ILogMetric,
-          protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates or updates a logs-based metric.
  *
@@ -557,6 +537,26 @@ export class MetricsServiceV2Client {
  * @example
  * const [response] = await client.updateLogMetric(request);
  */
+  updateLogMetric(
+      request?: protos.google.logging.v2.IUpdateLogMetricRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogMetric,
+        protos.google.logging.v2.IUpdateLogMetricRequest|undefined, {}|undefined
+      ]>;
+  updateLogMetric(
+      request: protos.google.logging.v2.IUpdateLogMetricRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogMetric,
+          protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateLogMetric(
+      request: protos.google.logging.v2.IUpdateLogMetricRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogMetric,
+          protos.google.logging.v2.IUpdateLogMetricRequest|null|undefined,
+          {}|null|undefined>): void;
   updateLogMetric(
       request?: protos.google.logging.v2.IUpdateLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -591,6 +591,25 @@ export class MetricsServiceV2Client {
     this.initialize();
     return this.innerApiCalls.updateLogMetric(request, options, callback);
   }
+/**
+ * Deletes a logs-based metric.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.metricName
+ *   Required. The resource name of the metric to delete:
+ *
+ *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteLogMetric(request);
+ */
   deleteLogMetric(
       request?: protos.google.logging.v2.IDeleteLogMetricRequest,
       options?: CallOptions):
@@ -611,25 +630,6 @@ export class MetricsServiceV2Client {
           protos.google.protobuf.IEmpty,
           protos.google.logging.v2.IDeleteLogMetricRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a logs-based metric.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.metricName
- *   Required. The resource name of the metric to delete:
- *
- *       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteLogMetric(request);
- */
   deleteLogMetric(
       request?: protos.google.logging.v2.IDeleteLogMetricRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -665,28 +665,7 @@ export class MetricsServiceV2Client {
     return this.innerApiCalls.deleteLogMetric(request, options, callback);
   }
 
-  listLogMetrics(
-      request?: protos.google.logging.v2.IListLogMetricsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.logging.v2.ILogMetric[],
-        protos.google.logging.v2.IListLogMetricsRequest|null,
-        protos.google.logging.v2.IListLogMetricsResponse
-      ]>;
-  listLogMetrics(
-      request: protos.google.logging.v2.IListLogMetricsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogMetricsRequest,
-          protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
-          protos.google.logging.v2.ILogMetric>): void;
-  listLogMetrics(
-      request: protos.google.logging.v2.IListLogMetricsRequest,
-      callback: PaginationCallback<
-          protos.google.logging.v2.IListLogMetricsRequest,
-          protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
-          protos.google.logging.v2.ILogMetric>): void;
-/**
+ /**
  * Lists logs-based metrics.
  *
  * @param {Object} request
@@ -717,6 +696,27 @@ export class MetricsServiceV2Client {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listLogMetrics(
+      request?: protos.google.logging.v2.IListLogMetricsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogMetric[],
+        protos.google.logging.v2.IListLogMetricsRequest|null,
+        protos.google.logging.v2.IListLogMetricsResponse
+      ]>;
+  listLogMetrics(
+      request: protos.google.logging.v2.IListLogMetricsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogMetricsRequest,
+          protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
+          protos.google.logging.v2.ILogMetric>): void;
+  listLogMetrics(
+      request: protos.google.logging.v2.IListLogMetricsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListLogMetricsRequest,
+          protos.google.logging.v2.IListLogMetricsResponse|null|undefined,
+          protos.google.logging.v2.ILogMetric>): void;
   listLogMetrics(
       request?: protos.google.logging.v2.IListLogMetricsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -373,6 +373,25 @@ export class AlertPolicyServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a single alerting policy.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The alerting policy to retrieve. The format is
+ *
+ *       projects/[PROJECT_ID]/alertPolicies/[ALERT_POLICY_ID]
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [AlertPolicy]{@link google.monitoring.v3.AlertPolicy}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getAlertPolicy(request);
+ */
   getAlertPolicy(
       request?: protos.google.monitoring.v3.IGetAlertPolicyRequest,
       options?: CallOptions):
@@ -393,25 +412,6 @@ export class AlertPolicyServiceClient {
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IGetAlertPolicyRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a single alerting policy.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The alerting policy to retrieve. The format is
- *
- *       projects/[PROJECT_ID]/alertPolicies/[ALERT_POLICY_ID]
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AlertPolicy]{@link google.monitoring.v3.AlertPolicy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getAlertPolicy(request);
- */
   getAlertPolicy(
       request?: protos.google.monitoring.v3.IGetAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -446,26 +446,6 @@ export class AlertPolicyServiceClient {
     this.initialize();
     return this.innerApiCalls.getAlertPolicy(request, options, callback);
   }
-  createAlertPolicy(
-      request?: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IAlertPolicy,
-        protos.google.monitoring.v3.ICreateAlertPolicyRequest|undefined, {}|undefined
-      ]>;
-  createAlertPolicy(
-      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IAlertPolicy,
-          protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
-  createAlertPolicy(
-      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IAlertPolicy,
-          protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new alerting policy.
  *
@@ -494,6 +474,26 @@ export class AlertPolicyServiceClient {
  * @example
  * const [response] = await client.createAlertPolicy(request);
  */
+  createAlertPolicy(
+      request?: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IAlertPolicy,
+        protos.google.monitoring.v3.ICreateAlertPolicyRequest|undefined, {}|undefined
+      ]>;
+  createAlertPolicy(
+      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IAlertPolicy,
+          protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  createAlertPolicy(
+      request: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IAlertPolicy,
+          protos.google.monitoring.v3.ICreateAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
   createAlertPolicy(
       request?: protos.google.monitoring.v3.ICreateAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -528,26 +528,6 @@ export class AlertPolicyServiceClient {
     this.initialize();
     return this.innerApiCalls.createAlertPolicy(request, options, callback);
   }
-  deleteAlertPolicy(
-      request?: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.IDeleteAlertPolicyRequest|undefined, {}|undefined
-      ]>;
-  deleteAlertPolicy(
-      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteAlertPolicy(
-      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an alerting policy.
  *
@@ -569,6 +549,26 @@ export class AlertPolicyServiceClient {
  * @example
  * const [response] = await client.deleteAlertPolicy(request);
  */
+  deleteAlertPolicy(
+      request?: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.IDeleteAlertPolicyRequest|undefined, {}|undefined
+      ]>;
+  deleteAlertPolicy(
+      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteAlertPolicy(
+      request: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteAlertPolicy(
       request?: protos.google.monitoring.v3.IDeleteAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -603,26 +603,6 @@ export class AlertPolicyServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteAlertPolicy(request, options, callback);
   }
-  updateAlertPolicy(
-      request?: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IAlertPolicy,
-        protos.google.monitoring.v3.IUpdateAlertPolicyRequest|undefined, {}|undefined
-      ]>;
-  updateAlertPolicy(
-      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IAlertPolicy,
-          protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateAlertPolicy(
-      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IAlertPolicy,
-          protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates an alerting policy. You can either replace the entire policy with
  * a new one or replace only certain fields in the current alerting policy by
@@ -670,6 +650,26 @@ export class AlertPolicyServiceClient {
  */
   updateAlertPolicy(
       request?: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IAlertPolicy,
+        protos.google.monitoring.v3.IUpdateAlertPolicyRequest|undefined, {}|undefined
+      ]>;
+  updateAlertPolicy(
+      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IAlertPolicy,
+          protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateAlertPolicy(
+      request: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IAlertPolicy,
+          protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateAlertPolicy(
+      request?: protos.google.monitoring.v3.IUpdateAlertPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IAlertPolicy,
           protos.google.monitoring.v3.IUpdateAlertPolicyRequest|null|undefined,
@@ -703,28 +703,7 @@ export class AlertPolicyServiceClient {
     return this.innerApiCalls.updateAlertPolicy(request, options, callback);
   }
 
-  listAlertPolicies(
-      request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IAlertPolicy[],
-        protos.google.monitoring.v3.IListAlertPoliciesRequest|null,
-        protos.google.monitoring.v3.IListAlertPoliciesResponse
-      ]>;
-  listAlertPolicies(
-      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListAlertPoliciesRequest,
-          protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
-          protos.google.monitoring.v3.IAlertPolicy>): void;
-  listAlertPolicies(
-      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListAlertPoliciesRequest,
-          protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
-          protos.google.monitoring.v3.IAlertPolicy>): void;
-/**
+ /**
  * Lists the existing alerting policies for the project.
  *
  * @param {Object} request
@@ -771,6 +750,27 @@ export class AlertPolicyServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listAlertPolicies(
+      request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IAlertPolicy[],
+        protos.google.monitoring.v3.IListAlertPoliciesRequest|null,
+        protos.google.monitoring.v3.IListAlertPoliciesResponse
+      ]>;
+  listAlertPolicies(
+      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListAlertPoliciesRequest,
+          protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
+          protos.google.monitoring.v3.IAlertPolicy>): void;
+  listAlertPolicies(
+      request: protos.google.monitoring.v3.IListAlertPoliciesRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListAlertPoliciesRequest,
+          protos.google.monitoring.v3.IListAlertPoliciesResponse|null|undefined,
+          protos.google.monitoring.v3.IAlertPolicy>): void;
   listAlertPolicies(
       request?: protos.google.monitoring.v3.IListAlertPoliciesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -378,6 +378,24 @@ export class GroupServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a single group.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The group to retrieve. The format is
+ *   `"projects/{project_id_or_number}/groups/{group_id}"`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Group]{@link google.monitoring.v3.Group}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getGroup(request);
+ */
   getGroup(
       request?: protos.google.monitoring.v3.IGetGroupRequest,
       options?: CallOptions):
@@ -398,24 +416,6 @@ export class GroupServiceClient {
           protos.google.monitoring.v3.IGroup,
           protos.google.monitoring.v3.IGetGroupRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a single group.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The group to retrieve. The format is
- *   `"projects/{project_id_or_number}/groups/{group_id}"`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Group]{@link google.monitoring.v3.Group}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getGroup(request);
- */
   getGroup(
       request?: protos.google.monitoring.v3.IGetGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -450,26 +450,6 @@ export class GroupServiceClient {
     this.initialize();
     return this.innerApiCalls.getGroup(request, options, callback);
   }
-  createGroup(
-      request?: protos.google.monitoring.v3.ICreateGroupRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IGroup,
-        protos.google.monitoring.v3.ICreateGroupRequest|undefined, {}|undefined
-      ]>;
-  createGroup(
-      request: protos.google.monitoring.v3.ICreateGroupRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IGroup,
-          protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
-          {}|null|undefined>): void;
-  createGroup(
-      request: protos.google.monitoring.v3.ICreateGroupRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IGroup,
-          protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new group.
  *
@@ -493,6 +473,26 @@ export class GroupServiceClient {
  * @example
  * const [response] = await client.createGroup(request);
  */
+  createGroup(
+      request?: protos.google.monitoring.v3.ICreateGroupRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IGroup,
+        protos.google.monitoring.v3.ICreateGroupRequest|undefined, {}|undefined
+      ]>;
+  createGroup(
+      request: protos.google.monitoring.v3.ICreateGroupRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IGroup,
+          protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
+          {}|null|undefined>): void;
+  createGroup(
+      request: protos.google.monitoring.v3.ICreateGroupRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IGroup,
+          protos.google.monitoring.v3.ICreateGroupRequest|null|undefined,
+          {}|null|undefined>): void;
   createGroup(
       request?: protos.google.monitoring.v3.ICreateGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -527,26 +527,6 @@ export class GroupServiceClient {
     this.initialize();
     return this.innerApiCalls.createGroup(request, options, callback);
   }
-  updateGroup(
-      request?: protos.google.monitoring.v3.IUpdateGroupRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IGroup,
-        protos.google.monitoring.v3.IUpdateGroupRequest|undefined, {}|undefined
-      ]>;
-  updateGroup(
-      request: protos.google.monitoring.v3.IUpdateGroupRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IGroup,
-          protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateGroup(
-      request: protos.google.monitoring.v3.IUpdateGroupRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IGroup,
-          protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates an existing group.
  * You can change any group attributes except `name`.
@@ -568,6 +548,26 @@ export class GroupServiceClient {
  * @example
  * const [response] = await client.updateGroup(request);
  */
+  updateGroup(
+      request?: protos.google.monitoring.v3.IUpdateGroupRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IGroup,
+        protos.google.monitoring.v3.IUpdateGroupRequest|undefined, {}|undefined
+      ]>;
+  updateGroup(
+      request: protos.google.monitoring.v3.IUpdateGroupRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IGroup,
+          protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateGroup(
+      request: protos.google.monitoring.v3.IUpdateGroupRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IGroup,
+          protos.google.monitoring.v3.IUpdateGroupRequest|null|undefined,
+          {}|null|undefined>): void;
   updateGroup(
       request?: protos.google.monitoring.v3.IUpdateGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -602,26 +602,6 @@ export class GroupServiceClient {
     this.initialize();
     return this.innerApiCalls.updateGroup(request, options, callback);
   }
-  deleteGroup(
-      request?: protos.google.monitoring.v3.IDeleteGroupRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.IDeleteGroupRequest|undefined, {}|undefined
-      ]>;
-  deleteGroup(
-      request: protos.google.monitoring.v3.IDeleteGroupRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteGroup(
-      request: protos.google.monitoring.v3.IDeleteGroupRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an existing group.
  *
@@ -644,6 +624,26 @@ export class GroupServiceClient {
  * @example
  * const [response] = await client.deleteGroup(request);
  */
+  deleteGroup(
+      request?: protos.google.monitoring.v3.IDeleteGroupRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.IDeleteGroupRequest|undefined, {}|undefined
+      ]>;
+  deleteGroup(
+      request: protos.google.monitoring.v3.IDeleteGroupRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteGroup(
+      request: protos.google.monitoring.v3.IDeleteGroupRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteGroupRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteGroup(
       request?: protos.google.monitoring.v3.IDeleteGroupRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -679,28 +679,7 @@ export class GroupServiceClient {
     return this.innerApiCalls.deleteGroup(request, options, callback);
   }
 
-  listGroups(
-      request?: protos.google.monitoring.v3.IListGroupsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IGroup[],
-        protos.google.monitoring.v3.IListGroupsRequest|null,
-        protos.google.monitoring.v3.IListGroupsResponse
-      ]>;
-  listGroups(
-      request: protos.google.monitoring.v3.IListGroupsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListGroupsRequest,
-          protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
-          protos.google.monitoring.v3.IGroup>): void;
-  listGroups(
-      request: protos.google.monitoring.v3.IListGroupsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListGroupsRequest,
-          protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
-          protos.google.monitoring.v3.IGroup>): void;
-/**
+ /**
  * Lists the existing groups.
  *
  * @param {Object} request
@@ -742,6 +721,27 @@ export class GroupServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listGroups(
+      request?: protos.google.monitoring.v3.IListGroupsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IGroup[],
+        protos.google.monitoring.v3.IListGroupsRequest|null,
+        protos.google.monitoring.v3.IListGroupsResponse
+      ]>;
+  listGroups(
+      request: protos.google.monitoring.v3.IListGroupsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListGroupsRequest,
+          protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
+          protos.google.monitoring.v3.IGroup>): void;
+  listGroups(
+      request: protos.google.monitoring.v3.IListGroupsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListGroupsRequest,
+          protos.google.monitoring.v3.IListGroupsResponse|null|undefined,
+          protos.google.monitoring.v3.IGroup>): void;
   listGroups(
       request?: protos.google.monitoring.v3.IListGroupsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -910,28 +910,7 @@ export class GroupServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IGroup>;
   }
-  listGroupMembers(
-      request?: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMonitoredResource[],
-        protos.google.monitoring.v3.IListGroupMembersRequest|null,
-        protos.google.monitoring.v3.IListGroupMembersResponse
-      ]>;
-  listGroupMembers(
-      request: protos.google.monitoring.v3.IListGroupMembersRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListGroupMembersRequest,
-          protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
-          protos.google.api.IMonitoredResource>): void;
-  listGroupMembers(
-      request: protos.google.monitoring.v3.IListGroupMembersRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListGroupMembersRequest,
-          protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
-          protos.google.api.IMonitoredResource>): void;
-/**
+ /**
  * Lists the monitored resources that are members of a group.
  *
  * @param {Object} request
@@ -971,6 +950,27 @@ export class GroupServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listGroupMembers(
+      request?: protos.google.monitoring.v3.IListGroupMembersRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMonitoredResource[],
+        protos.google.monitoring.v3.IListGroupMembersRequest|null,
+        protos.google.monitoring.v3.IListGroupMembersResponse
+      ]>;
+  listGroupMembers(
+      request: protos.google.monitoring.v3.IListGroupMembersRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListGroupMembersRequest,
+          protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
+          protos.google.api.IMonitoredResource>): void;
+  listGroupMembers(
+      request: protos.google.monitoring.v3.IListGroupMembersRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListGroupMembersRequest,
+          protos.google.monitoring.v3.IListGroupMembersResponse|null|undefined,
+          protos.google.api.IMonitoredResource>): void;
   listGroupMembers(
       request?: protos.google.monitoring.v3.IListGroupMembersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -389,26 +389,6 @@ export class MetricServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  getMonitoredResourceDescriptor(
-      request?: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMonitoredResourceDescriptor,
-        protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|undefined, {}|undefined
-      ]>;
-  getMonitoredResourceDescriptor(
-      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.api.IMonitoredResourceDescriptor,
-          protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
-  getMonitoredResourceDescriptor(
-      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
-      callback: Callback<
-          protos.google.api.IMonitoredResourceDescriptor,
-          protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a single monitored resource descriptor. This method does not require a Stackdriver account.
  *
@@ -429,6 +409,26 @@ export class MetricServiceClient {
  * @example
  * const [response] = await client.getMonitoredResourceDescriptor(request);
  */
+  getMonitoredResourceDescriptor(
+      request?: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMonitoredResourceDescriptor,
+        protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|undefined, {}|undefined
+      ]>;
+  getMonitoredResourceDescriptor(
+      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.api.IMonitoredResourceDescriptor,
+          protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
+  getMonitoredResourceDescriptor(
+      request: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
+      callback: Callback<
+          protos.google.api.IMonitoredResourceDescriptor,
+          protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
   getMonitoredResourceDescriptor(
       request?: protos.google.monitoring.v3.IGetMonitoredResourceDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -463,26 +463,6 @@ export class MetricServiceClient {
     this.initialize();
     return this.innerApiCalls.getMonitoredResourceDescriptor(request, options, callback);
   }
-  getMetricDescriptor(
-      request?: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMetricDescriptor,
-        protos.google.monitoring.v3.IGetMetricDescriptorRequest|undefined, {}|undefined
-      ]>;
-  getMetricDescriptor(
-      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.api.IMetricDescriptor,
-          protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
-  getMetricDescriptor(
-      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
-      callback: Callback<
-          protos.google.api.IMetricDescriptor,
-          protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a single metric descriptor. This method does not require a Stackdriver account.
  *
@@ -503,6 +483,26 @@ export class MetricServiceClient {
  * @example
  * const [response] = await client.getMetricDescriptor(request);
  */
+  getMetricDescriptor(
+      request?: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMetricDescriptor,
+        protos.google.monitoring.v3.IGetMetricDescriptorRequest|undefined, {}|undefined
+      ]>;
+  getMetricDescriptor(
+      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.api.IMetricDescriptor,
+          protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
+  getMetricDescriptor(
+      request: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
+      callback: Callback<
+          protos.google.api.IMetricDescriptor,
+          protos.google.monitoring.v3.IGetMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
   getMetricDescriptor(
       request?: protos.google.monitoring.v3.IGetMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -537,26 +537,6 @@ export class MetricServiceClient {
     this.initialize();
     return this.innerApiCalls.getMetricDescriptor(request, options, callback);
   }
-  createMetricDescriptor(
-      request?: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMetricDescriptor,
-        protos.google.monitoring.v3.ICreateMetricDescriptorRequest|undefined, {}|undefined
-      ]>;
-  createMetricDescriptor(
-      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.api.IMetricDescriptor,
-          protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
-  createMetricDescriptor(
-      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
-      callback: Callback<
-          protos.google.api.IMetricDescriptor,
-          protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new metric descriptor.
  * User-created metric descriptors define
@@ -580,6 +560,26 @@ export class MetricServiceClient {
  * @example
  * const [response] = await client.createMetricDescriptor(request);
  */
+  createMetricDescriptor(
+      request?: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMetricDescriptor,
+        protos.google.monitoring.v3.ICreateMetricDescriptorRequest|undefined, {}|undefined
+      ]>;
+  createMetricDescriptor(
+      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.api.IMetricDescriptor,
+          protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
+  createMetricDescriptor(
+      request: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
+      callback: Callback<
+          protos.google.api.IMetricDescriptor,
+          protos.google.monitoring.v3.ICreateMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
   createMetricDescriptor(
       request?: protos.google.monitoring.v3.ICreateMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -614,26 +614,6 @@ export class MetricServiceClient {
     this.initialize();
     return this.innerApiCalls.createMetricDescriptor(request, options, callback);
   }
-  deleteMetricDescriptor(
-      request?: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|undefined, {}|undefined
-      ]>;
-  deleteMetricDescriptor(
-      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteMetricDescriptor(
-      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a metric descriptor. Only user-created
  * [custom metrics](/monitoring/custom-metrics) can be deleted.
@@ -655,6 +635,26 @@ export class MetricServiceClient {
  * @example
  * const [response] = await client.deleteMetricDescriptor(request);
  */
+  deleteMetricDescriptor(
+      request?: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|undefined, {}|undefined
+      ]>;
+  deleteMetricDescriptor(
+      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteMetricDescriptor(
+      request: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteMetricDescriptorRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteMetricDescriptor(
       request?: protos.google.monitoring.v3.IDeleteMetricDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -689,26 +689,6 @@ export class MetricServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteMetricDescriptor(request, options, callback);
   }
-  createTimeSeries(
-      request?: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.ICreateTimeSeriesRequest|undefined, {}|undefined
-      ]>;
-  createTimeSeries(
-      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
-          {}|null|undefined>): void;
-  createTimeSeries(
-      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates or adds data to one or more time series.
  * The response is empty if all time series in the request were written.
@@ -738,6 +718,26 @@ export class MetricServiceClient {
  * @example
  * const [response] = await client.createTimeSeries(request);
  */
+  createTimeSeries(
+      request?: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.ICreateTimeSeriesRequest|undefined, {}|undefined
+      ]>;
+  createTimeSeries(
+      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
+          {}|null|undefined>): void;
+  createTimeSeries(
+      request: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.ICreateTimeSeriesRequest|null|undefined,
+          {}|null|undefined>): void;
   createTimeSeries(
       request?: protos.google.monitoring.v3.ICreateTimeSeriesRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -773,28 +773,7 @@ export class MetricServiceClient {
     return this.innerApiCalls.createTimeSeries(request, options, callback);
   }
 
-  listMonitoredResourceDescriptors(
-      request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMonitoredResourceDescriptor[],
-        protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest|null,
-        protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse
-      ]>;
-  listMonitoredResourceDescriptors(
-      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
-          protos.google.api.IMonitoredResourceDescriptor>): void;
-  listMonitoredResourceDescriptors(
-      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
-          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
-          protos.google.api.IMonitoredResourceDescriptor>): void;
-/**
+ /**
  * Lists monitored resource descriptors that match a filter. This method does not require a Stackdriver account.
  *
  * @param {Object} request
@@ -829,6 +808,27 @@ export class MetricServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listMonitoredResourceDescriptors(
+      request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMonitoredResourceDescriptor[],
+        protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest|null,
+        protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse
+      ]>;
+  listMonitoredResourceDescriptors(
+      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
+          protos.google.api.IMonitoredResourceDescriptor>): void;
+  listMonitoredResourceDescriptors(
+      request: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
+          protos.google.monitoring.v3.IListMonitoredResourceDescriptorsResponse|null|undefined,
+          protos.google.api.IMonitoredResourceDescriptor>): void;
   listMonitoredResourceDescriptors(
       request?: protos.google.monitoring.v3.IListMonitoredResourceDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -983,28 +983,7 @@ export class MetricServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
-  listMetricDescriptors(
-      request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.api.IMetricDescriptor[],
-        protos.google.monitoring.v3.IListMetricDescriptorsRequest|null,
-        protos.google.monitoring.v3.IListMetricDescriptorsResponse
-      ]>;
-  listMetricDescriptors(
-      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-          protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
-          protos.google.api.IMetricDescriptor>): void;
-  listMetricDescriptors(
-      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListMetricDescriptorsRequest,
-          protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
-          protos.google.api.IMetricDescriptor>): void;
-/**
+ /**
  * Lists metric descriptors that match a filter. This method does not require a Stackdriver account.
  *
  * @param {Object} request
@@ -1040,6 +1019,27 @@ export class MetricServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listMetricDescriptors(
+      request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.api.IMetricDescriptor[],
+        protos.google.monitoring.v3.IListMetricDescriptorsRequest|null,
+        protos.google.monitoring.v3.IListMetricDescriptorsResponse
+      ]>;
+  listMetricDescriptors(
+      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+          protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
+          protos.google.api.IMetricDescriptor>): void;
+  listMetricDescriptors(
+      request: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListMetricDescriptorsRequest,
+          protos.google.monitoring.v3.IListMetricDescriptorsResponse|null|undefined,
+          protos.google.api.IMetricDescriptor>): void;
   listMetricDescriptors(
       request?: protos.google.monitoring.v3.IListMetricDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1196,28 +1196,7 @@ export class MetricServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.api.IMetricDescriptor>;
   }
-  listTimeSeries(
-      request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.ITimeSeries[],
-        protos.google.monitoring.v3.IListTimeSeriesRequest|null,
-        protos.google.monitoring.v3.IListTimeSeriesResponse
-      ]>;
-  listTimeSeries(
-      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListTimeSeriesRequest,
-          protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
-          protos.google.monitoring.v3.ITimeSeries>): void;
-  listTimeSeries(
-      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListTimeSeriesRequest,
-          protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
-          protos.google.monitoring.v3.ITimeSeries>): void;
-/**
+ /**
  * Lists time series that match a filter. This method does not require a Stackdriver account.
  *
  * @param {Object} request
@@ -1271,6 +1250,27 @@ export class MetricServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listTimeSeries(
+      request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.ITimeSeries[],
+        protos.google.monitoring.v3.IListTimeSeriesRequest|null,
+        protos.google.monitoring.v3.IListTimeSeriesResponse
+      ]>;
+  listTimeSeries(
+      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListTimeSeriesRequest,
+          protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
+          protos.google.monitoring.v3.ITimeSeries>): void;
+  listTimeSeries(
+      request: protos.google.monitoring.v3.IListTimeSeriesRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListTimeSeriesRequest,
+          protos.google.monitoring.v3.IListTimeSeriesResponse|null|undefined,
+          protos.google.monitoring.v3.ITimeSeries>): void;
   listTimeSeries(
       request?: protos.google.monitoring.v3.IListTimeSeriesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -368,6 +368,25 @@ export class NotificationChannelServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a single channel descriptor. The descriptor indicates which fields
+ * are expected / permitted for a notification channel of the given type.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The channel type for which to execute the request. The format is
+ *   `projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [NotificationChannelDescriptor]{@link google.monitoring.v3.NotificationChannelDescriptor}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getNotificationChannelDescriptor(request);
+ */
   getNotificationChannelDescriptor(
       request?: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
       options?: CallOptions):
@@ -388,25 +407,6 @@ export class NotificationChannelServiceClient {
           protos.google.monitoring.v3.INotificationChannelDescriptor,
           protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a single channel descriptor. The descriptor indicates which fields
- * are expected / permitted for a notification channel of the given type.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The channel type for which to execute the request. The format is
- *   `projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [NotificationChannelDescriptor]{@link google.monitoring.v3.NotificationChannelDescriptor}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getNotificationChannelDescriptor(request);
- */
   getNotificationChannelDescriptor(
       request?: protos.google.monitoring.v3.IGetNotificationChannelDescriptorRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -441,26 +441,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.getNotificationChannelDescriptor(request, options, callback);
   }
-  getNotificationChannel(
-      request?: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannel,
-        protos.google.monitoring.v3.IGetNotificationChannelRequest|undefined, {}|undefined
-      ]>;
-  getNotificationChannel(
-      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
-  getNotificationChannel(
-      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a single notification channel. The channel includes the relevant
  * configuration details with which the channel was created. However, the
@@ -483,6 +463,26 @@ export class NotificationChannelServiceClient {
  * @example
  * const [response] = await client.getNotificationChannel(request);
  */
+  getNotificationChannel(
+      request?: protos.google.monitoring.v3.IGetNotificationChannelRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannel,
+        protos.google.monitoring.v3.IGetNotificationChannelRequest|undefined, {}|undefined
+      ]>;
+  getNotificationChannel(
+      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
+  getNotificationChannel(
+      request: protos.google.monitoring.v3.IGetNotificationChannelRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IGetNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
   getNotificationChannel(
       request?: protos.google.monitoring.v3.IGetNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -517,26 +517,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.getNotificationChannel(request, options, callback);
   }
-  createNotificationChannel(
-      request?: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannel,
-        protos.google.monitoring.v3.ICreateNotificationChannelRequest|undefined, {}|undefined
-      ]>;
-  createNotificationChannel(
-      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
-  createNotificationChannel(
-      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new notification channel, representing a single notification
  * endpoint such as an email address, SMS number, or PagerDuty service.
@@ -564,6 +544,26 @@ export class NotificationChannelServiceClient {
  * @example
  * const [response] = await client.createNotificationChannel(request);
  */
+  createNotificationChannel(
+      request?: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannel,
+        protos.google.monitoring.v3.ICreateNotificationChannelRequest|undefined, {}|undefined
+      ]>;
+  createNotificationChannel(
+      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
+  createNotificationChannel(
+      request: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.ICreateNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
   createNotificationChannel(
       request?: protos.google.monitoring.v3.ICreateNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -598,26 +598,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.createNotificationChannel(request, options, callback);
   }
-  updateNotificationChannel(
-      request?: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannel,
-        protos.google.monitoring.v3.IUpdateNotificationChannelRequest|undefined, {}|undefined
-      ]>;
-  updateNotificationChannel(
-      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateNotificationChannel(
-      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a notification channel. Fields not specified in the field mask
  * remain unchanged.
@@ -641,6 +621,26 @@ export class NotificationChannelServiceClient {
  * @example
  * const [response] = await client.updateNotificationChannel(request);
  */
+  updateNotificationChannel(
+      request?: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannel,
+        protos.google.monitoring.v3.IUpdateNotificationChannelRequest|undefined, {}|undefined
+      ]>;
+  updateNotificationChannel(
+      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateNotificationChannel(
+      request: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IUpdateNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
   updateNotificationChannel(
       request?: protos.google.monitoring.v3.IUpdateNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -675,26 +675,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.updateNotificationChannel(request, options, callback);
   }
-  deleteNotificationChannel(
-      request?: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.IDeleteNotificationChannelRequest|undefined, {}|undefined
-      ]>;
-  deleteNotificationChannel(
-      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteNotificationChannel(
-      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a notification channel.
  *
@@ -718,6 +698,26 @@ export class NotificationChannelServiceClient {
  * @example
  * const [response] = await client.deleteNotificationChannel(request);
  */
+  deleteNotificationChannel(
+      request?: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.IDeleteNotificationChannelRequest|undefined, {}|undefined
+      ]>;
+  deleteNotificationChannel(
+      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteNotificationChannel(
+      request: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteNotificationChannel(
       request?: protos.google.monitoring.v3.IDeleteNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -752,6 +752,24 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteNotificationChannel(request, options, callback);
   }
+/**
+ * Causes a verification code to be delivered to the channel. The code
+ * can then be supplied in `VerifyNotificationChannel` to verify the channel.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The notification channel to which to send a verification code.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.sendNotificationChannelVerificationCode(request);
+ */
   sendNotificationChannelVerificationCode(
       request?: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
       options?: CallOptions):
@@ -772,24 +790,6 @@ export class NotificationChannelServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Causes a verification code to be delivered to the channel. The code
- * can then be supplied in `VerifyNotificationChannel` to verify the channel.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The notification channel to which to send a verification code.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.sendNotificationChannelVerificationCode(request);
- */
   sendNotificationChannelVerificationCode(
       request?: protos.google.monitoring.v3.ISendNotificationChannelVerificationCodeRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -824,26 +824,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.sendNotificationChannelVerificationCode(request, options, callback);
   }
-  getNotificationChannelVerificationCode(
-      request?: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
-        protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|undefined, {}|undefined
-      ]>;
-  getNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
-          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
-          {}|null|undefined>): void;
-  getNotificationChannelVerificationCode(
-      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
-          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Requests a verification code for an already verified channel that can then
  * be used in a call to VerifyNotificationChannel() on a different channel
@@ -895,6 +875,26 @@ export class NotificationChannelServiceClient {
  */
   getNotificationChannelVerificationCode(
       request?: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
+        protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|undefined, {}|undefined
+      ]>;
+  getNotificationChannelVerificationCode(
+      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
+          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
+          {}|null|undefined>): void;
+  getNotificationChannelVerificationCode(
+      request: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
+          protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
+          {}|null|undefined>): void;
+  getNotificationChannelVerificationCode(
+      request?: protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeResponse,
           protos.google.monitoring.v3.IGetNotificationChannelVerificationCodeRequest|null|undefined,
@@ -927,26 +927,6 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.innerApiCalls.getNotificationChannelVerificationCode(request, options, callback);
   }
-  verifyNotificationChannel(
-      request?: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannel,
-        protos.google.monitoring.v3.IVerifyNotificationChannelRequest|undefined, {}|undefined
-      ]>;
-  verifyNotificationChannel(
-      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
-  verifyNotificationChannel(
-      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.INotificationChannel,
-          protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Verifies a `NotificationChannel` by proving receipt of the code
  * delivered to the channel as a result of calling
@@ -974,6 +954,26 @@ export class NotificationChannelServiceClient {
  * @example
  * const [response] = await client.verifyNotificationChannel(request);
  */
+  verifyNotificationChannel(
+      request?: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannel,
+        protos.google.monitoring.v3.IVerifyNotificationChannelRequest|undefined, {}|undefined
+      ]>;
+  verifyNotificationChannel(
+      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
+  verifyNotificationChannel(
+      request: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.INotificationChannel,
+          protos.google.monitoring.v3.IVerifyNotificationChannelRequest|null|undefined,
+          {}|null|undefined>): void;
   verifyNotificationChannel(
       request?: protos.google.monitoring.v3.IVerifyNotificationChannelRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1009,28 +1009,7 @@ export class NotificationChannelServiceClient {
     return this.innerApiCalls.verifyNotificationChannel(request, options, callback);
   }
 
-  listNotificationChannelDescriptors(
-      request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannelDescriptor[],
-        protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest|null,
-        protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse
-      ]>;
-  listNotificationChannelDescriptors(
-      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-          protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
-          protos.google.monitoring.v3.INotificationChannelDescriptor>): void;
-  listNotificationChannelDescriptors(
-      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
-          protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
-          protos.google.monitoring.v3.INotificationChannelDescriptor>): void;
-/**
+ /**
  * Lists the descriptors for supported channel types. The use of descriptors
  * makes it possible for new channel types to be dynamically added.
  *
@@ -1067,6 +1046,27 @@ export class NotificationChannelServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listNotificationChannelDescriptors(
+      request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannelDescriptor[],
+        protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest|null,
+        protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse
+      ]>;
+  listNotificationChannelDescriptors(
+      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+          protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
+          protos.google.monitoring.v3.INotificationChannelDescriptor>): void;
+  listNotificationChannelDescriptors(
+      request: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
+          protos.google.monitoring.v3.IListNotificationChannelDescriptorsResponse|null|undefined,
+          protos.google.monitoring.v3.INotificationChannelDescriptor>): void;
   listNotificationChannelDescriptors(
       request?: protos.google.monitoring.v3.IListNotificationChannelDescriptorsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1223,28 +1223,7 @@ export class NotificationChannelServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannelDescriptor>;
   }
-  listNotificationChannels(
-      request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.INotificationChannel[],
-        protos.google.monitoring.v3.IListNotificationChannelsRequest|null,
-        protos.google.monitoring.v3.IListNotificationChannelsResponse
-      ]>;
-  listNotificationChannels(
-      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListNotificationChannelsRequest,
-          protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
-          protos.google.monitoring.v3.INotificationChannel>): void;
-  listNotificationChannels(
-      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListNotificationChannelsRequest,
-          protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
-          protos.google.monitoring.v3.INotificationChannel>): void;
-/**
+ /**
  * Lists the notification channels that have been created for the project.
  *
  * @param {Object} request
@@ -1291,6 +1270,27 @@ export class NotificationChannelServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listNotificationChannels(
+      request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.INotificationChannel[],
+        protos.google.monitoring.v3.IListNotificationChannelsRequest|null,
+        protos.google.monitoring.v3.IListNotificationChannelsResponse
+      ]>;
+  listNotificationChannels(
+      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListNotificationChannelsRequest,
+          protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
+          protos.google.monitoring.v3.INotificationChannel>): void;
+  listNotificationChannels(
+      request: protos.google.monitoring.v3.IListNotificationChannelsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListNotificationChannelsRequest,
+          protos.google.monitoring.v3.IListNotificationChannelsResponse|null|undefined,
+          protos.google.monitoring.v3.INotificationChannel>): void;
   listNotificationChannels(
       request?: protos.google.monitoring.v3.IListNotificationChannelsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -370,26 +370,6 @@ export class ServiceMonitoringServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  createService(
-      request?: protos.google.monitoring.v3.ICreateServiceRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IService,
-        protos.google.monitoring.v3.ICreateServiceRequest|undefined, {}|undefined
-      ]>;
-  createService(
-      request: protos.google.monitoring.v3.ICreateServiceRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IService,
-          protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
-          {}|null|undefined>): void;
-  createService(
-      request: protos.google.monitoring.v3.ICreateServiceRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IService,
-          protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a `Service`.
  *
@@ -413,6 +393,26 @@ export class ServiceMonitoringServiceClient {
  * @example
  * const [response] = await client.createService(request);
  */
+  createService(
+      request?: protos.google.monitoring.v3.ICreateServiceRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IService,
+        protos.google.monitoring.v3.ICreateServiceRequest|undefined, {}|undefined
+      ]>;
+  createService(
+      request: protos.google.monitoring.v3.ICreateServiceRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IService,
+          protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
+          {}|null|undefined>): void;
+  createService(
+      request: protos.google.monitoring.v3.ICreateServiceRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IService,
+          protos.google.monitoring.v3.ICreateServiceRequest|null|undefined,
+          {}|null|undefined>): void;
   createService(
       request?: protos.google.monitoring.v3.ICreateServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -447,6 +447,24 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.createService(request, options, callback);
   }
+/**
+ * Get the named `Service`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the `Service`.
+ *   Of the form `projects/{project_id}/services/{service_id}`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Service]{@link google.monitoring.v3.Service}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getService(request);
+ */
   getService(
       request?: protos.google.monitoring.v3.IGetServiceRequest,
       options?: CallOptions):
@@ -467,24 +485,6 @@ export class ServiceMonitoringServiceClient {
           protos.google.monitoring.v3.IService,
           protos.google.monitoring.v3.IGetServiceRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Get the named `Service`.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the `Service`.
- *   Of the form `projects/{project_id}/services/{service_id}`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Service]{@link google.monitoring.v3.Service}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getService(request);
- */
   getService(
       request?: protos.google.monitoring.v3.IGetServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -519,26 +519,6 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.getService(request, options, callback);
   }
-  updateService(
-      request?: protos.google.monitoring.v3.IUpdateServiceRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IService,
-        protos.google.monitoring.v3.IUpdateServiceRequest|undefined, {}|undefined
-      ]>;
-  updateService(
-      request: protos.google.monitoring.v3.IUpdateServiceRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IService,
-          protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateService(
-      request: protos.google.monitoring.v3.IUpdateServiceRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IService,
-          protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Update this `Service`.
  *
@@ -559,6 +539,26 @@ export class ServiceMonitoringServiceClient {
  * @example
  * const [response] = await client.updateService(request);
  */
+  updateService(
+      request?: protos.google.monitoring.v3.IUpdateServiceRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IService,
+        protos.google.monitoring.v3.IUpdateServiceRequest|undefined, {}|undefined
+      ]>;
+  updateService(
+      request: protos.google.monitoring.v3.IUpdateServiceRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IService,
+          protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateService(
+      request: protos.google.monitoring.v3.IUpdateServiceRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IService,
+          protos.google.monitoring.v3.IUpdateServiceRequest|null|undefined,
+          {}|null|undefined>): void;
   updateService(
       request?: protos.google.monitoring.v3.IUpdateServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -593,6 +593,24 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.updateService(request, options, callback);
   }
+/**
+ * Soft delete this `Service`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the `Service` to delete.
+ *   Of the form `projects/{project_id}/services/{service_id}`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteService(request);
+ */
   deleteService(
       request?: protos.google.monitoring.v3.IDeleteServiceRequest,
       options?: CallOptions):
@@ -613,24 +631,6 @@ export class ServiceMonitoringServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Soft delete this `Service`.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the `Service` to delete.
- *   Of the form `projects/{project_id}/services/{service_id}`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteService(request);
- */
   deleteService(
       request?: protos.google.monitoring.v3.IDeleteServiceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -665,26 +665,6 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteService(request, options, callback);
   }
-  createServiceLevelObjective(
-      request?: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IServiceLevelObjective,
-        protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|undefined, {}|undefined
-      ]>;
-  createServiceLevelObjective(
-      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
-  createServiceLevelObjective(
-      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Create a `ServiceLevelObjective` for the given `Service`.
  *
@@ -711,6 +691,26 @@ export class ServiceMonitoringServiceClient {
  * @example
  * const [response] = await client.createServiceLevelObjective(request);
  */
+  createServiceLevelObjective(
+      request?: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IServiceLevelObjective,
+        protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|undefined, {}|undefined
+      ]>;
+  createServiceLevelObjective(
+      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
+  createServiceLevelObjective(
+      request: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
   createServiceLevelObjective(
       request?: protos.google.monitoring.v3.ICreateServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -745,26 +745,6 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.createServiceLevelObjective(request, options, callback);
   }
-  getServiceLevelObjective(
-      request?: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IServiceLevelObjective,
-        protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|undefined, {}|undefined
-      ]>;
-  getServiceLevelObjective(
-      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
-  getServiceLevelObjective(
-      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Get a `ServiceLevelObjective` by name.
  *
@@ -789,6 +769,26 @@ export class ServiceMonitoringServiceClient {
  * @example
  * const [response] = await client.getServiceLevelObjective(request);
  */
+  getServiceLevelObjective(
+      request?: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IServiceLevelObjective,
+        protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|undefined, {}|undefined
+      ]>;
+  getServiceLevelObjective(
+      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
+  getServiceLevelObjective(
+      request: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
   getServiceLevelObjective(
       request?: protos.google.monitoring.v3.IGetServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -823,26 +823,6 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.getServiceLevelObjective(request, options, callback);
   }
-  updateServiceLevelObjective(
-      request?: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IServiceLevelObjective,
-        protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|undefined, {}|undefined
-      ]>;
-  updateServiceLevelObjective(
-      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateServiceLevelObjective(
-      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IServiceLevelObjective,
-          protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Update the given `ServiceLevelObjective`.
  *
@@ -863,6 +843,26 @@ export class ServiceMonitoringServiceClient {
  * @example
  * const [response] = await client.updateServiceLevelObjective(request);
  */
+  updateServiceLevelObjective(
+      request?: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IServiceLevelObjective,
+        protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|undefined, {}|undefined
+      ]>;
+  updateServiceLevelObjective(
+      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateServiceLevelObjective(
+      request: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IServiceLevelObjective,
+          protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest|null|undefined,
+          {}|null|undefined>): void;
   updateServiceLevelObjective(
       request?: protos.google.monitoring.v3.IUpdateServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -897,6 +897,25 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.innerApiCalls.updateServiceLevelObjective(request, options, callback);
   }
+/**
+ * Delete the given `ServiceLevelObjective`.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Resource name of the `ServiceLevelObjective` to delete.
+ *   Of the form
+ *   `projects/{project_id}/services/{service_id}/serviceLevelObjectives/{slo_name}`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteServiceLevelObjective(request);
+ */
   deleteServiceLevelObjective(
       request?: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
       options?: CallOptions):
@@ -917,25 +936,6 @@ export class ServiceMonitoringServiceClient {
           protos.google.protobuf.IEmpty,
           protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Delete the given `ServiceLevelObjective`.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Resource name of the `ServiceLevelObjective` to delete.
- *   Of the form
- *   `projects/{project_id}/services/{service_id}/serviceLevelObjectives/{slo_name}`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteServiceLevelObjective(request);
- */
   deleteServiceLevelObjective(
       request?: protos.google.monitoring.v3.IDeleteServiceLevelObjectiveRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -971,28 +971,7 @@ export class ServiceMonitoringServiceClient {
     return this.innerApiCalls.deleteServiceLevelObjective(request, options, callback);
   }
 
-  listServices(
-      request?: protos.google.monitoring.v3.IListServicesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IService[],
-        protos.google.monitoring.v3.IListServicesRequest|null,
-        protos.google.monitoring.v3.IListServicesResponse
-      ]>;
-  listServices(
-      request: protos.google.monitoring.v3.IListServicesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListServicesRequest,
-          protos.google.monitoring.v3.IListServicesResponse|null|undefined,
-          protos.google.monitoring.v3.IService>): void;
-  listServices(
-      request: protos.google.monitoring.v3.IListServicesRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListServicesRequest,
-          protos.google.monitoring.v3.IListServicesResponse|null|undefined,
-          protos.google.monitoring.v3.IService>): void;
-/**
+ /**
  * List `Service`s for this workspace.
  *
  * @param {Object} request
@@ -1036,6 +1015,27 @@ export class ServiceMonitoringServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listServices(
+      request?: protos.google.monitoring.v3.IListServicesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IService[],
+        protos.google.monitoring.v3.IListServicesRequest|null,
+        protos.google.monitoring.v3.IListServicesResponse
+      ]>;
+  listServices(
+      request: protos.google.monitoring.v3.IListServicesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListServicesRequest,
+          protos.google.monitoring.v3.IListServicesResponse|null|undefined,
+          protos.google.monitoring.v3.IService>): void;
+  listServices(
+      request: protos.google.monitoring.v3.IListServicesRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListServicesRequest,
+          protos.google.monitoring.v3.IListServicesResponse|null|undefined,
+          protos.google.monitoring.v3.IService>): void;
   listServices(
       request?: protos.google.monitoring.v3.IListServicesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1208,28 +1208,7 @@ export class ServiceMonitoringServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IService>;
   }
-  listServiceLevelObjectives(
-      request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IServiceLevelObjective[],
-        protos.google.monitoring.v3.IListServiceLevelObjectivesRequest|null,
-        protos.google.monitoring.v3.IListServiceLevelObjectivesResponse
-      ]>;
-  listServiceLevelObjectives(
-      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-          protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
-          protos.google.monitoring.v3.IServiceLevelObjective>): void;
-  listServiceLevelObjectives(
-      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
-          protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
-          protos.google.monitoring.v3.IServiceLevelObjective>): void;
-/**
+ /**
  * List the `ServiceLevelObjective`s for the given `Service`.
  *
  * @param {Object} request
@@ -1264,6 +1243,27 @@ export class ServiceMonitoringServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listServiceLevelObjectives(
+      request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IServiceLevelObjective[],
+        protos.google.monitoring.v3.IListServiceLevelObjectivesRequest|null,
+        protos.google.monitoring.v3.IListServiceLevelObjectivesResponse
+      ]>;
+  listServiceLevelObjectives(
+      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+          protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
+          protos.google.monitoring.v3.IServiceLevelObjective>): void;
+  listServiceLevelObjectives(
+      request: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
+          protos.google.monitoring.v3.IListServiceLevelObjectivesResponse|null|undefined,
+          protos.google.monitoring.v3.IServiceLevelObjective>): void;
   listServiceLevelObjectives(
       request?: protos.google.monitoring.v3.IListServiceLevelObjectivesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -374,6 +374,24 @@ export class UptimeCheckServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a single Uptime check configuration.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The Uptime check configuration to retrieve. The format
+ *     is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [UptimeCheckConfig]{@link google.monitoring.v3.UptimeCheckConfig}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getUptimeCheckConfig(request);
+ */
   getUptimeCheckConfig(
       request?: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
       options?: CallOptions):
@@ -394,24 +412,6 @@ export class UptimeCheckServiceClient {
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IGetUptimeCheckConfigRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a single Uptime check configuration.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The Uptime check configuration to retrieve. The format
- *     is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [UptimeCheckConfig]{@link google.monitoring.v3.UptimeCheckConfig}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getUptimeCheckConfig(request);
- */
   getUptimeCheckConfig(
       request?: protos.google.monitoring.v3.IGetUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -446,26 +446,6 @@ export class UptimeCheckServiceClient {
     this.initialize();
     return this.innerApiCalls.getUptimeCheckConfig(request, options, callback);
   }
-  createUptimeCheckConfig(
-      request?: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IUptimeCheckConfig,
-        protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|undefined, {}|undefined
-      ]>;
-  createUptimeCheckConfig(
-      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IUptimeCheckConfig,
-          protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
-  createUptimeCheckConfig(
-      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IUptimeCheckConfig,
-          protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a new Uptime check configuration.
  *
@@ -486,6 +466,26 @@ export class UptimeCheckServiceClient {
  * @example
  * const [response] = await client.createUptimeCheckConfig(request);
  */
+  createUptimeCheckConfig(
+      request?: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IUptimeCheckConfig,
+        protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|undefined, {}|undefined
+      ]>;
+  createUptimeCheckConfig(
+      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IUptimeCheckConfig,
+          protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
+  createUptimeCheckConfig(
+      request: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IUptimeCheckConfig,
+          protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
   createUptimeCheckConfig(
       request?: protos.google.monitoring.v3.ICreateUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -520,26 +520,6 @@ export class UptimeCheckServiceClient {
     this.initialize();
     return this.innerApiCalls.createUptimeCheckConfig(request, options, callback);
   }
-  updateUptimeCheckConfig(
-      request?: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IUptimeCheckConfig,
-        protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|undefined, {}|undefined
-      ]>;
-  updateUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.monitoring.v3.IUptimeCheckConfig,
-          protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
-      callback: Callback<
-          protos.google.monitoring.v3.IUptimeCheckConfig,
-          protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates an Uptime check configuration. You can either replace the entire
  * configuration with a new one or replace only certain fields in the current
@@ -577,6 +557,26 @@ export class UptimeCheckServiceClient {
  */
   updateUptimeCheckConfig(
       request?: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IUptimeCheckConfig,
+        protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|undefined, {}|undefined
+      ]>;
+  updateUptimeCheckConfig(
+      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.monitoring.v3.IUptimeCheckConfig,
+          protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateUptimeCheckConfig(
+      request: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
+      callback: Callback<
+          protos.google.monitoring.v3.IUptimeCheckConfig,
+          protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateUptimeCheckConfig(
+      request?: protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.monitoring.v3.IUptimeCheckConfig,
           protos.google.monitoring.v3.IUpdateUptimeCheckConfigRequest|null|undefined,
@@ -609,26 +609,6 @@ export class UptimeCheckServiceClient {
     this.initialize();
     return this.innerApiCalls.updateUptimeCheckConfig(request, options, callback);
   }
-  deleteUptimeCheckConfig(
-      request?: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|undefined, {}|undefined
-      ]>;
-  deleteUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteUptimeCheckConfig(
-      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes an Uptime check configuration. Note that this method will fail
  * if the Uptime check configuration is referenced by an alert policy or
@@ -649,6 +629,26 @@ export class UptimeCheckServiceClient {
  * @example
  * const [response] = await client.deleteUptimeCheckConfig(request);
  */
+  deleteUptimeCheckConfig(
+      request?: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|undefined, {}|undefined
+      ]>;
+  deleteUptimeCheckConfig(
+      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteUptimeCheckConfig(
+      request: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteUptimeCheckConfig(
       request?: protos.google.monitoring.v3.IDeleteUptimeCheckConfigRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -684,28 +684,7 @@ export class UptimeCheckServiceClient {
     return this.innerApiCalls.deleteUptimeCheckConfig(request, options, callback);
   }
 
-  listUptimeCheckConfigs(
-      request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IUptimeCheckConfig[],
-        protos.google.monitoring.v3.IListUptimeCheckConfigsRequest|null,
-        protos.google.monitoring.v3.IListUptimeCheckConfigsResponse
-      ]>;
-  listUptimeCheckConfigs(
-      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-          protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
-          protos.google.monitoring.v3.IUptimeCheckConfig>): void;
-  listUptimeCheckConfigs(
-      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
-          protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
-          protos.google.monitoring.v3.IUptimeCheckConfig>): void;
-/**
+ /**
  * Lists the existing valid Uptime check configurations for the project
  * (leaving out any invalid configurations).
  *
@@ -736,6 +715,27 @@ export class UptimeCheckServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listUptimeCheckConfigs(
+      request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IUptimeCheckConfig[],
+        protos.google.monitoring.v3.IListUptimeCheckConfigsRequest|null,
+        protos.google.monitoring.v3.IListUptimeCheckConfigsResponse
+      ]>;
+  listUptimeCheckConfigs(
+      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+          protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
+          protos.google.monitoring.v3.IUptimeCheckConfig>): void;
+  listUptimeCheckConfigs(
+      request: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
+          protos.google.monitoring.v3.IListUptimeCheckConfigsResponse|null|undefined,
+          protos.google.monitoring.v3.IUptimeCheckConfig>): void;
   listUptimeCheckConfigs(
       request?: protos.google.monitoring.v3.IListUptimeCheckConfigsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -880,28 +880,7 @@ export class UptimeCheckServiceClient {
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckConfig>;
   }
-  listUptimeCheckIps(
-      request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.monitoring.v3.IUptimeCheckIp[],
-        protos.google.monitoring.v3.IListUptimeCheckIpsRequest|null,
-        protos.google.monitoring.v3.IListUptimeCheckIpsResponse
-      ]>;
-  listUptimeCheckIps(
-      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-          protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
-          protos.google.monitoring.v3.IUptimeCheckIp>): void;
-  listUptimeCheckIps(
-      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-      callback: PaginationCallback<
-          protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
-          protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
-          protos.google.monitoring.v3.IUptimeCheckIp>): void;
-/**
+ /**
  * Returns the list of IP addresses that checkers run from
  *
  * @param {Object} request
@@ -930,6 +909,27 @@ export class UptimeCheckServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listUptimeCheckIps(
+      request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.monitoring.v3.IUptimeCheckIp[],
+        protos.google.monitoring.v3.IListUptimeCheckIpsRequest|null,
+        protos.google.monitoring.v3.IListUptimeCheckIpsResponse
+      ]>;
+  listUptimeCheckIps(
+      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+          protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
+          protos.google.monitoring.v3.IUptimeCheckIp>): void;
+  listUptimeCheckIps(
+      request: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+      callback: PaginationCallback<
+          protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
+          protos.google.monitoring.v3.IListUptimeCheckIpsResponse|null|undefined,
+          protos.google.monitoring.v3.IUptimeCheckIp>): void;
   listUptimeCheckIps(
       request?: protos.google.monitoring.v3.IListUptimeCheckIpsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -306,6 +306,20 @@ export class NamingClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.paginatedMethodStream(request);
+ */
   paginatedMethodStream(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -326,20 +340,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.paginatedMethodStream(request);
- */
   paginatedMethodStream(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -367,6 +367,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.paginatedMethodStream(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.paginatedMethodAsync(request);
+ */
   paginatedMethodAsync(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -387,20 +401,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.paginatedMethodAsync(request);
- */
   paginatedMethodAsync(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -428,6 +428,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.paginatedMethodAsync(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.checkLongRunningProgress(request);
+ */
   checkLongRunningProgress(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -448,20 +462,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.checkLongRunningProgress(request);
- */
   checkLongRunningProgress(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -489,6 +489,21 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.checkLongRunningProgress(request, options, callback);
   }
+/**
+ * Problem #3: RPCs that conflict with auto-generated methods
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.initialize(request);
+ */
   initialize(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -509,21 +524,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- * Problem #3: RPCs that conflict with auto-generated methods
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.initialize(request);
- */
   initialize(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -551,6 +551,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.initialize(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.servicePath(request);
+ */
   servicePath(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -571,20 +585,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.servicePath(request);
- */
   servicePath(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -612,6 +612,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.servicePath(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.apiEndpoint(request);
+ */
   apiEndpoint(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -632,20 +646,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.apiEndpoint(request);
- */
   apiEndpoint(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -673,6 +673,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.apiEndpoint(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.port(request);
+ */
   port(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -693,20 +707,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.port(request);
- */
   port(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -734,6 +734,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.port(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.scopes(request);
+ */
   scopes(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -754,20 +768,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.scopes(request);
- */
   scopes(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -795,6 +795,20 @@ export class NamingClient {
     this.initialize1();
     return this.innerApiCalls.scopes(request, options, callback);
   }
+/**
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getProjectId(request);
+ */
   getProjectId(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -815,20 +829,6 @@ export class NamingClient {
           protos.google.protobuf.IEmpty,
           protos.google.protobuf.IEmpty|null|undefined,
           {}|null|undefined>): void;
-/**
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getProjectId(request);
- */
   getProjectId(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -857,6 +857,24 @@ export class NamingClient {
     return this.innerApiCalls.getProjectId(request, options, callback);
   }
 
+/**
+ * Problem #2: long running method generates extra method check*Progress()
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing
+ *   a long running operation. Its `promise()` method returns a promise
+ *   you can `await` for.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   for more details and examples.
+ * @example
+ * const [operation] = await client.longRunning(request);
+ * const [response] = await operation.promise();
+ */
   longRunning(
       request?: protos.google.protobuf.IEmpty,
       options?: CallOptions):
@@ -877,24 +895,6 @@ export class NamingClient {
           LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>,
           protos.google.longrunning.IOperation|null|undefined,
           {}|null|undefined>): void;
-/**
- * Problem #2: long running method generates extra method check*Progress()
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing
- *   a long running operation. Its `promise()` method returns a promise
- *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
- *   for more details and examples.
- * @example
- * const [operation] = await client.longRunning(request);
- * const [response] = await operation.promise();
- */
   longRunning(
       request?: protos.google.protobuf.IEmpty,
       optionsOrCallback?: CallOptions|Callback<
@@ -943,28 +943,7 @@ export class NamingClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.longRunning, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>;
   }
-  paginatedMethod(
-      request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty[],
-        protos.google.naming.v1beta1.IPaginatedMethodRequest|null,
-        protos.google.naming.v1beta1.IPaginatedMethodResponse
-      ]>;
-  paginatedMethod(
-      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.naming.v1beta1.IPaginatedMethodRequest,
-          protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
-          protos.google.protobuf.IEmpty>): void;
-  paginatedMethod(
-      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
-      callback: PaginationCallback<
-          protos.google.naming.v1beta1.IPaginatedMethodRequest,
-          protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
-          protos.google.protobuf.IEmpty>): void;
-/**
+ /**
  * Problem #1: paginated method generates extra methods *Stream() and
  * *Async(), which might conflict with unary methods with the same names.
  *
@@ -986,6 +965,27 @@ export class NamingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  paginatedMethod(
+      request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty[],
+        protos.google.naming.v1beta1.IPaginatedMethodRequest|null,
+        protos.google.naming.v1beta1.IPaginatedMethodResponse
+      ]>;
+  paginatedMethod(
+      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.naming.v1beta1.IPaginatedMethodRequest,
+          protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
+          protos.google.protobuf.IEmpty>): void;
+  paginatedMethod(
+      request: protos.google.naming.v1beta1.IPaginatedMethodRequest,
+      callback: PaginationCallback<
+          protos.google.naming.v1beta1.IPaginatedMethodRequest,
+          protos.google.naming.v1beta1.IPaginatedMethodResponse|null|undefined,
+          protos.google.protobuf.IEmpty>): void;
   paginatedMethod(
       request?: protos.google.naming.v1beta1.IPaginatedMethodRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -375,6 +375,25 @@ export class CloudRedisClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets the details of a specific Redis instance.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Redis instance resource name using the form:
+ *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+ *   where `location_id` refers to a GCP region.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Instance]{@link google.cloud.redis.v1beta1.Instance}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getInstance(request);
+ */
   getInstance(
       request?: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
       options?: CallOptions):
@@ -395,25 +414,6 @@ export class CloudRedisClient {
           protos.google.cloud.redis.v1beta1.IInstance,
           protos.google.cloud.redis.v1beta1.IGetInstanceRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets the details of a specific Redis instance.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. Redis instance resource name using the form:
- *       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
- *   where `location_id` refers to a GCP region.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Instance]{@link google.cloud.redis.v1beta1.Instance}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getInstance(request);
- */
   getInstance(
       request?: protos.google.cloud.redis.v1beta1.IGetInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -449,26 +449,6 @@ export class CloudRedisClient {
     return this.innerApiCalls.getInstance(request, options, callback);
   }
 
-  createInstance(
-      request?: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  createInstance(
-      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  createInstance(
-      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a Redis instance based on the specified tier and memory size.
  *
@@ -513,6 +493,26 @@ export class CloudRedisClient {
  * const [operation] = await client.createInstance(request);
  * const [response] = await operation.promise();
  */
+  createInstance(
+      request?: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  createInstance(
+      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  createInstance(
+      request: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   createInstance(
       request?: protos.google.cloud.redis.v1beta1.ICreateInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -568,26 +568,6 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
-  updateInstance(
-      request?: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  updateInstance(
-      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  updateInstance(
-      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates the metadata and configuration of a specific Redis instance.
  *
@@ -622,6 +602,26 @@ export class CloudRedisClient {
  * const [operation] = await client.updateInstance(request);
  * const [response] = await operation.promise();
  */
+  updateInstance(
+      request?: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  updateInstance(
+      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  updateInstance(
+      request: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   updateInstance(
       request?: protos.google.cloud.redis.v1beta1.IUpdateInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -677,26 +677,6 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.updateInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
-  importInstance(
-      request?: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  importInstance(
-      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  importInstance(
-      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
  *
@@ -728,6 +708,26 @@ export class CloudRedisClient {
  * const [operation] = await client.importInstance(request);
  * const [response] = await operation.promise();
  */
+  importInstance(
+      request?: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  importInstance(
+      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  importInstance(
+      request: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   importInstance(
       request?: protos.google.cloud.redis.v1beta1.IImportInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -783,26 +783,6 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.importInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
-  exportInstance(
-      request?: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  exportInstance(
-      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  exportInstance(
-      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Export Redis instance data into a Redis RDB format file in Cloud Storage.
  *
@@ -832,6 +812,26 @@ export class CloudRedisClient {
  * const [operation] = await client.exportInstance(request);
  * const [response] = await operation.promise();
  */
+  exportInstance(
+      request?: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  exportInstance(
+      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  exportInstance(
+      request: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   exportInstance(
       request?: protos.google.cloud.redis.v1beta1.IExportInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -887,26 +887,6 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
-  failoverInstance(
-      request?: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  failoverInstance(
-      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  failoverInstance(
-      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Initiates a failover of the master node to current replica node for a
  * specific STANDARD tier Cloud Memorystore for Redis instance.
@@ -933,6 +913,26 @@ export class CloudRedisClient {
  * const [operation] = await client.failoverInstance(request);
  * const [response] = await operation.promise();
  */
+  failoverInstance(
+      request?: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  failoverInstance(
+      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  failoverInstance(
+      request: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   failoverInstance(
       request?: protos.google.cloud.redis.v1beta1.IFailoverInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -988,26 +988,6 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.failoverInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
-  deleteInstance(
-      request?: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  deleteInstance(
-      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  deleteInstance(
-      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
-      callback: Callback<
-          LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a specific Redis instance.  Instance stops serving and data is
  * deleted.
@@ -1031,6 +1011,26 @@ export class CloudRedisClient {
  * const [operation] = await client.deleteInstance(request);
  * const [response] = await operation.promise();
  */
+  deleteInstance(
+      request?: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  deleteInstance(
+      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  deleteInstance(
+      request: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
+      callback: Callback<
+          LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   deleteInstance(
       request?: protos.google.cloud.redis.v1beta1.IDeleteInstanceRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1086,28 +1086,7 @@ export class CloudRedisClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteInstance, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>;
   }
-  listInstances(
-      request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.redis.v1beta1.IInstance[],
-        protos.google.cloud.redis.v1beta1.IListInstancesRequest|null,
-        protos.google.cloud.redis.v1beta1.IListInstancesResponse
-      ]>;
-  listInstances(
-      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-          protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
-          protos.google.cloud.redis.v1beta1.IInstance>): void;
-  listInstances(
-      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.redis.v1beta1.IListInstancesRequest,
-          protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
-          protos.google.cloud.redis.v1beta1.IInstance>): void;
-/**
+ /**
  * Lists all Redis instances owned by a project in either the specified
  * location (region) or all locations.
  *
@@ -1147,6 +1126,27 @@ export class CloudRedisClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listInstances(
+      request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.redis.v1beta1.IInstance[],
+        protos.google.cloud.redis.v1beta1.IListInstancesRequest|null,
+        protos.google.cloud.redis.v1beta1.IListInstancesResponse
+      ]>;
+  listInstances(
+      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+          protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
+          protos.google.cloud.redis.v1beta1.IInstance>): void;
+  listInstances(
+      request: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.redis.v1beta1.IListInstancesRequest,
+          protos.google.cloud.redis.v1beta1.IListInstancesResponse|null|undefined,
+          protos.google.cloud.redis.v1beta1.IInstance>): void;
   listInstances(
       request?: protos.google.cloud.redis.v1beta1.IListInstancesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -312,6 +312,23 @@ export class EchoClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.content
+ *   The content to be echoed by the server.
+ * @param {google.rpc.Status} request.error
+ *   The error to be thrown by the server.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.echo(request);
+ */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       options?: CallOptions):
@@ -332,23 +349,6 @@ export class EchoClient {
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.content
- *   The content to be echoed by the server.
- * @param {google.rpc.Status} request.error
- *   The error to be thrown by the server.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.echo(request);
- */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -376,26 +376,6 @@ export class EchoClient {
     this.initialize();
     return this.innerApiCalls.echo(request, options, callback);
   }
-  block(
-      request?: protos.google.showcase.v1beta1.IBlockRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlockResponse,
-        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
-      ]>;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will block (wait) for the requested amount of time
  * and then return the response or error.
@@ -420,6 +400,26 @@ export class EchoClient {
  * @example
  * const [response] = await client.block(request);
  */
+  block(
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlockResponse,
+        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
+      ]>;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
   block(
       request?: protos.google.showcase.v1beta1.IBlockRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -480,19 +480,6 @@ export class EchoClient {
     return this.innerApiCalls.expand(request, options);
   }
 
-  collect(
-      options?: CallOptions,
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
-  collect(
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
 /**
  * This method will collect the words given to it. When the stream is closed
  * by the client, this method will return the a concatenation of the strings
@@ -510,6 +497,19 @@ export class EchoClient {
  * stream.write(request);
  * stream.end();
  */
+  collect(
+      options?: CallOptions,
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
+  collect(
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
   collect(
       optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
@@ -557,26 +557,6 @@ export class EchoClient {
     return this.innerApiCalls.chat(options);
   }
 
-  wait(
-      request?: protos.google.showcase.v1beta1.IWaitRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will wait the requested amount of and then return.
  * This method showcases how a client handles a request timing out.
@@ -605,6 +585,26 @@ export class EchoClient {
  * const [operation] = await client.wait(request);
  * const [response] = await operation.promise();
  */
+  wait(
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   wait(
       request?: protos.google.showcase.v1beta1.IWaitRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -653,28 +653,7 @@ export class EchoClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
-  pagedExpand(
-      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IEchoResponse[],
-        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
-        protos.google.showcase.v1beta1.IPagedExpandResponse
-      ]>;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-/**
+ /**
  * This is similar to the Expand method but instead of returning a stream of
  * expanded words, this method returns a paged list of expanded words.
  *
@@ -699,6 +678,27 @@ export class EchoClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  pagedExpand(
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IEchoResponse[],
+        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
+        protos.google.showcase.v1beta1.IPagedExpandResponse
+      ]>;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
   pagedExpand(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -359,6 +359,23 @@ export class EchoClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.content
+ *   The content to be echoed by the server.
+ * @param {google.rpc.Status} request.error
+ *   The error to be thrown by the server.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.echo(request);
+ */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       options?: CallOptions):
@@ -379,23 +396,6 @@ export class EchoClient {
           protos.google.showcase.v1beta1.IEchoResponse,
           protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.content
- *   The content to be echoed by the server.
- * @param {google.rpc.Status} request.error
- *   The error to be thrown by the server.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [EchoResponse]{@link google.showcase.v1beta1.EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.echo(request);
- */
   echo(
       request?: protos.google.showcase.v1beta1.IEchoRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -423,26 +423,6 @@ export class EchoClient {
     this.initialize();
     return this.innerApiCalls.echo(request, options, callback);
   }
-  block(
-      request?: protos.google.showcase.v1beta1.IBlockRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlockResponse,
-        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
-      ]>;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
-  block(
-      request: protos.google.showcase.v1beta1.IBlockRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlockResponse,
-          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will block (wait) for the requested amount of time
  * and then return the response or error.
@@ -467,6 +447,26 @@ export class EchoClient {
  * @example
  * const [response] = await client.block(request);
  */
+  block(
+      request?: protos.google.showcase.v1beta1.IBlockRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlockResponse,
+        protos.google.showcase.v1beta1.IBlockRequest|undefined, {}|undefined
+      ]>;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
+  block(
+      request: protos.google.showcase.v1beta1.IBlockRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlockResponse,
+          protos.google.showcase.v1beta1.IBlockRequest|null|undefined,
+          {}|null|undefined>): void;
   block(
       request?: protos.google.showcase.v1beta1.IBlockRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -527,19 +527,6 @@ export class EchoClient {
     return this.innerApiCalls.expand(request, options);
   }
 
-  collect(
-      options?: CallOptions,
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
-  collect(
-      callback?: Callback<
-        protos.google.showcase.v1beta1.IEchoResponse,
-        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
 /**
  * This method will collect the words given to it. When the stream is closed
  * by the client, this method will return the a concatenation of the strings
@@ -557,6 +544,19 @@ export class EchoClient {
  * stream.write(request);
  * stream.end();
  */
+  collect(
+      options?: CallOptions,
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
+  collect(
+      callback?: Callback<
+        protos.google.showcase.v1beta1.IEchoResponse,
+        protos.google.showcase.v1beta1.IEchoRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
   collect(
       optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.IEchoResponse,
@@ -604,26 +604,6 @@ export class EchoClient {
     return this.innerApiCalls.chat(options);
   }
 
-  wait(
-      request?: protos.google.showcase.v1beta1.IWaitRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  wait(
-      request: protos.google.showcase.v1beta1.IWaitRequest,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method will wait the requested amount of and then return.
  * This method showcases how a client handles a request timing out.
@@ -652,6 +632,26 @@ export class EchoClient {
  * const [operation] = await client.wait(request);
  * const [response] = await operation.promise();
  */
+  wait(
+      request?: protos.google.showcase.v1beta1.IWaitRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  wait(
+      request: protos.google.showcase.v1beta1.IWaitRequest,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   wait(
       request?: protos.google.showcase.v1beta1.IWaitRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -700,28 +700,7 @@ export class EchoClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
-  pagedExpand(
-      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IEchoResponse[],
-        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
-        protos.google.showcase.v1beta1.IPagedExpandResponse
-      ]>;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-  pagedExpand(
-      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IPagedExpandRequest,
-          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
-          protos.google.showcase.v1beta1.IEchoResponse>): void;
-/**
+ /**
  * This is similar to the Expand method but instead of returning a stream of
  * expanded words, this method returns a paged list of expanded words.
  *
@@ -746,6 +725,27 @@ export class EchoClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  pagedExpand(
+      request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IEchoResponse[],
+        protos.google.showcase.v1beta1.IPagedExpandRequest|null,
+        protos.google.showcase.v1beta1.IPagedExpandResponse
+      ]>;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
+  pagedExpand(
+      request: protos.google.showcase.v1beta1.IPagedExpandRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IPagedExpandRequest,
+          protos.google.showcase.v1beta1.IPagedExpandResponse|null|undefined,
+          protos.google.showcase.v1beta1.IEchoResponse>): void;
   pagedExpand(
       request?: protos.google.showcase.v1beta1.IPagedExpandRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -334,6 +334,23 @@ export class IdentityClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a user.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.User} request.user
+ *   The user to create.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createUser(request);
+ */
   createUser(
       request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       options?: CallOptions):
@@ -354,23 +371,6 @@ export class IdentityClient {
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.ICreateUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a user.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.User} request.user
- *   The user to create.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createUser(request);
- */
   createUser(
       request?: protos.google.showcase.v1beta1.ICreateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -398,6 +398,23 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.createUser(request, options, callback);
   }
+/**
+ * Retrieves the User with the given uri.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested user.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getUser(request);
+ */
   getUser(
       request?: protos.google.showcase.v1beta1.IGetUserRequest,
       options?: CallOptions):
@@ -418,23 +435,6 @@ export class IdentityClient {
           protos.google.showcase.v1beta1.IUser,
           protos.google.showcase.v1beta1.IGetUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the User with the given uri.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested user.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [User]{@link google.showcase.v1beta1.User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getUser(request);
- */
   getUser(
       request?: protos.google.showcase.v1beta1.IGetUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -469,26 +469,6 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.getUser(request, options, callback);
   }
-  updateUser(
-      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IUser,
-        protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
-      ]>;
-  updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IUser,
-          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateUser(
-      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IUser,
-          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a user.
  *
@@ -509,6 +489,26 @@ export class IdentityClient {
  * @example
  * const [response] = await client.updateUser(request);
  */
+  updateUser(
+      request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IUser,
+        protos.google.showcase.v1beta1.IUpdateUserRequest|undefined, {}|undefined
+      ]>;
+  updateUser(
+      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IUser,
+          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateUser(
+      request: protos.google.showcase.v1beta1.IUpdateUserRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IUser,
+          protos.google.showcase.v1beta1.IUpdateUserRequest|null|undefined,
+          {}|null|undefined>): void;
   updateUser(
       request?: protos.google.showcase.v1beta1.IUpdateUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -543,6 +543,23 @@ export class IdentityClient {
     this.initialize();
     return this.innerApiCalls.updateUser(request, options, callback);
   }
+/**
+ * Deletes a user, their profile, and all of their authored messages.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the user to delete.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteUser(request);
+ */
   deleteUser(
       request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       options?: CallOptions):
@@ -563,23 +580,6 @@ export class IdentityClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteUserRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a user, their profile, and all of their authored messages.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the user to delete.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteUser(request);
- */
   deleteUser(
       request?: protos.google.showcase.v1beta1.IDeleteUserRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -615,28 +615,7 @@ export class IdentityClient {
     return this.innerApiCalls.deleteUser(request, options, callback);
   }
 
-  listUsers(
-      request?: protos.google.showcase.v1beta1.IListUsersRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IUser[],
-        protos.google.showcase.v1beta1.IListUsersRequest|null,
-        protos.google.showcase.v1beta1.IListUsersResponse
-      ]>;
-  listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListUsersRequest,
-          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
-          protos.google.showcase.v1beta1.IUser>): void;
-  listUsers(
-      request: protos.google.showcase.v1beta1.IListUsersRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListUsersRequest,
-          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
-          protos.google.showcase.v1beta1.IUser>): void;
-/**
+ /**
  * Lists all users.
  *
  * @param {Object} request
@@ -661,6 +640,27 @@ export class IdentityClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listUsers(
+      request?: protos.google.showcase.v1beta1.IListUsersRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IUser[],
+        protos.google.showcase.v1beta1.IListUsersRequest|null,
+        protos.google.showcase.v1beta1.IListUsersResponse
+      ]>;
+  listUsers(
+      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListUsersRequest,
+          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
+          protos.google.showcase.v1beta1.IUser>): void;
+  listUsers(
+      request: protos.google.showcase.v1beta1.IListUsersRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListUsersRequest,
+          protos.google.showcase.v1beta1.IListUsersResponse|null|undefined,
+          protos.google.showcase.v1beta1.IUser>): void;
   listUsers(
       request?: protos.google.showcase.v1beta1.IListUsersRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -360,6 +360,23 @@ export class MessagingClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a room.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.Room} request.room
+ *   The room to create.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createRoom(request);
+ */
   createRoom(
       request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       options?: CallOptions):
@@ -380,23 +397,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.ICreateRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a room.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.Room} request.room
- *   The room to create.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createRoom(request);
- */
   createRoom(
       request?: protos.google.showcase.v1beta1.ICreateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -424,6 +424,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.createRoom(request, options, callback);
   }
+/**
+ * Retrieves the Room with the given resource name.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested room.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getRoom(request);
+ */
   getRoom(
       request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       options?: CallOptions):
@@ -444,23 +461,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IRoom,
           protos.google.showcase.v1beta1.IGetRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the Room with the given resource name.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested room.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Room]{@link google.showcase.v1beta1.Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getRoom(request);
- */
   getRoom(
       request?: protos.google.showcase.v1beta1.IGetRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -495,26 +495,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.getRoom(request, options, callback);
   }
-  updateRoom(
-      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IRoom,
-        protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
-      ]>;
-  updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IRoom,
-          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateRoom(
-      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IRoom,
-          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a room.
  *
@@ -535,6 +515,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.updateRoom(request);
  */
+  updateRoom(
+      request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IRoom,
+        protos.google.showcase.v1beta1.IUpdateRoomRequest|undefined, {}|undefined
+      ]>;
+  updateRoom(
+      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IRoom,
+          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateRoom(
+      request: protos.google.showcase.v1beta1.IUpdateRoomRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IRoom,
+          protos.google.showcase.v1beta1.IUpdateRoomRequest|null|undefined,
+          {}|null|undefined>): void;
   updateRoom(
       request?: protos.google.showcase.v1beta1.IUpdateRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -569,6 +569,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.updateRoom(request, options, callback);
   }
+/**
+ * Deletes a room and all of its blurbs.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested room.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteRoom(request);
+ */
   deleteRoom(
       request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       options?: CallOptions):
@@ -589,23 +606,6 @@ export class MessagingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteRoomRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a room and all of its blurbs.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested room.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteRoom(request);
- */
   deleteRoom(
       request?: protos.google.showcase.v1beta1.IDeleteRoomRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -640,26 +640,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.deleteRoom(request, options, callback);
   }
-  createBlurb(
-      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
-      ]>;
-  createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
-  createBlurb(
-      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a blurb. If the parent is a room, the blurb is understood to be a
  * message in that room. If the parent is a profile, the blurb is understood
@@ -682,6 +662,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.createBlurb(request);
  */
+  createBlurb(
+      request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|undefined, {}|undefined
+      ]>;
+  createBlurb(
+      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
+  createBlurb(
+      request: protos.google.showcase.v1beta1.ICreateBlurbRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
   createBlurb(
       request?: protos.google.showcase.v1beta1.ICreateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -716,6 +716,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.createBlurb(request, options, callback);
   }
+/**
+ * Retrieves the Blurb with the given resource name.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested blurb.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Blurb]{@link google.showcase.v1beta1.Blurb}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getBlurb(request);
+ */
   getBlurb(
       request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       options?: CallOptions):
@@ -736,23 +753,6 @@ export class MessagingClient {
           protos.google.showcase.v1beta1.IBlurb,
           protos.google.showcase.v1beta1.IGetBlurbRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Retrieves the Blurb with the given resource name.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested blurb.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Blurb]{@link google.showcase.v1beta1.Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getBlurb(request);
- */
   getBlurb(
       request?: protos.google.showcase.v1beta1.IGetBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -787,26 +787,6 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.getBlurb(request, options, callback);
   }
-  updateBlurb(
-      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb,
-        protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
-      ]>;
-  updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateBlurb(
-      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IBlurb,
-          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a blurb.
  *
@@ -827,6 +807,26 @@ export class MessagingClient {
  * @example
  * const [response] = await client.updateBlurb(request);
  */
+  updateBlurb(
+      request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb,
+        protos.google.showcase.v1beta1.IUpdateBlurbRequest|undefined, {}|undefined
+      ]>;
+  updateBlurb(
+      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateBlurb(
+      request: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IBlurb,
+          protos.google.showcase.v1beta1.IUpdateBlurbRequest|null|undefined,
+          {}|null|undefined>): void;
   updateBlurb(
       request?: protos.google.showcase.v1beta1.IUpdateBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -861,6 +861,23 @@ export class MessagingClient {
     this.initialize();
     return this.innerApiCalls.updateBlurb(request, options, callback);
   }
+/**
+ * Deletes a blurb.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The resource name of the requested blurb.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteBlurb(request);
+ */
   deleteBlurb(
       request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       options?: CallOptions):
@@ -881,23 +898,6 @@ export class MessagingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteBlurbRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Deletes a blurb.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The resource name of the requested blurb.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteBlurb(request);
- */
   deleteBlurb(
       request?: protos.google.showcase.v1beta1.IDeleteBlurbRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -972,19 +972,6 @@ export class MessagingClient {
     return this.innerApiCalls.streamBlurbs(request, options);
   }
 
-  sendBlurbs(
-      options?: CallOptions,
-      callback?: Callback<
-        protos.google.showcase.v1beta1.ISendBlurbsResponse,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
-  sendBlurbs(
-      callback?: Callback<
-        protos.google.showcase.v1beta1.ISendBlurbsResponse,
-        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
-        {}|null|undefined>):
-    gax.CancellableStream;
 /**
  * This is a stream to create multiple blurbs. If an invalid blurb is
  * requested to be created, the stream will close with an error.
@@ -1001,6 +988,19 @@ export class MessagingClient {
  * stream.write(request);
  * stream.end();
  */
+  sendBlurbs(
+      options?: CallOptions,
+      callback?: Callback<
+        protos.google.showcase.v1beta1.ISendBlurbsResponse,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
+  sendBlurbs(
+      callback?: Callback<
+        protos.google.showcase.v1beta1.ISendBlurbsResponse,
+        protos.google.showcase.v1beta1.ICreateBlurbRequest|null|undefined,
+        {}|null|undefined>):
+    gax.CancellableStream;
   sendBlurbs(
       optionsOrCallback?: CallOptions|Callback<
         protos.google.showcase.v1beta1.ISendBlurbsResponse,
@@ -1049,26 +1049,6 @@ export class MessagingClient {
     return this.innerApiCalls.connect(options);
   }
 
-  searchBlurbs(
-      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  searchBlurbs(
-      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
-      callback: Callback<
-          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * This method searches through all blurbs across all rooms and profiles
  * for blurbs containing to words found in the query. Only posts that
@@ -1104,6 +1084,26 @@ export class MessagingClient {
  * const [operation] = await client.searchBlurbs(request);
  * const [response] = await operation.promise();
  */
+  searchBlurbs(
+      request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  searchBlurbs(
+      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  searchBlurbs(
+      request: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
+      callback: Callback<
+          LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   searchBlurbs(
       request?: protos.google.showcase.v1beta1.ISearchBlurbsRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1159,28 +1159,7 @@ export class MessagingClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
-  listRooms(
-      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IRoom[],
-        protos.google.showcase.v1beta1.IListRoomsRequest|null,
-        protos.google.showcase.v1beta1.IListRoomsResponse
-      ]>;
-  listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListRoomsRequest,
-          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IRoom>): void;
-  listRooms(
-      request: protos.google.showcase.v1beta1.IListRoomsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListRoomsRequest,
-          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IRoom>): void;
-/**
+ /**
  * Lists all chat rooms.
  *
  * @param {Object} request
@@ -1205,6 +1184,27 @@ export class MessagingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listRooms(
+      request?: protos.google.showcase.v1beta1.IListRoomsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IRoom[],
+        protos.google.showcase.v1beta1.IListRoomsRequest|null,
+        protos.google.showcase.v1beta1.IListRoomsResponse
+      ]>;
+  listRooms(
+      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListRoomsRequest,
+          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IRoom>): void;
+  listRooms(
+      request: protos.google.showcase.v1beta1.IListRoomsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListRoomsRequest,
+          protos.google.showcase.v1beta1.IListRoomsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IRoom>): void;
   listRooms(
       request?: protos.google.showcase.v1beta1.IListRoomsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1318,28 +1318,7 @@ export class MessagingClient {
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
-  listBlurbs(
-      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IBlurb[],
-        protos.google.showcase.v1beta1.IListBlurbsRequest|null,
-        protos.google.showcase.v1beta1.IListBlurbsResponse
-      ]>;
-  listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListBlurbsRequest,
-          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IBlurb>): void;
-  listBlurbs(
-      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListBlurbsRequest,
-          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
-          protos.google.showcase.v1beta1.IBlurb>): void;
-/**
+ /**
  * Lists blurbs for a specific chat room or user profile depending on the
  * parent resource name.
  *
@@ -1368,6 +1347,27 @@ export class MessagingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listBlurbs(
+      request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IBlurb[],
+        protos.google.showcase.v1beta1.IListBlurbsRequest|null,
+        protos.google.showcase.v1beta1.IListBlurbsResponse
+      ]>;
+  listBlurbs(
+      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListBlurbsRequest,
+          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IBlurb>): void;
+  listBlurbs(
+      request: protos.google.showcase.v1beta1.IListBlurbsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListBlurbsRequest,
+          protos.google.showcase.v1beta1.IListBlurbsResponse|null|undefined,
+          protos.google.showcase.v1beta1.IBlurb>): void;
   listBlurbs(
       request?: protos.google.showcase.v1beta1.IListBlurbsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -337,6 +337,25 @@ export class TestingClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Creates a new testing session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {google.showcase.v1beta1.Session} request.session
+ *   The session to be created.
+ *   Sessions are immutable once they are created (although they can
+ *   be deleted).
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.createSession(request);
+ */
   createSession(
       request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       options?: CallOptions):
@@ -357,25 +376,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.ICreateSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Creates a new testing session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {google.showcase.v1beta1.Session} request.session
- *   The session to be created.
- *   Sessions are immutable once they are created (although they can
- *   be deleted).
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.createSession(request);
- */
   createSession(
       request?: protos.google.showcase.v1beta1.ICreateSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -403,6 +403,23 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.createSession(request, options, callback);
   }
+/**
+ * Gets a testing session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be retrieved.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getSession(request);
+ */
   getSession(
       request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       options?: CallOptions):
@@ -423,23 +440,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.ISession,
           protos.google.showcase.v1beta1.IGetSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a testing session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be retrieved.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Session]{@link google.showcase.v1beta1.Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getSession(request);
- */
   getSession(
       request?: protos.google.showcase.v1beta1.IGetSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -474,6 +474,23 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.getSession(request, options, callback);
   }
+/**
+ * Delete a test session.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be deleted.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.deleteSession(request);
+ */
   deleteSession(
       request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       options?: CallOptions):
@@ -494,23 +511,6 @@ export class TestingClient {
           protos.google.protobuf.IEmpty,
           protos.google.showcase.v1beta1.IDeleteSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Delete a test session.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be deleted.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.deleteSession(request);
- */
   deleteSession(
       request?: protos.google.showcase.v1beta1.IDeleteSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -545,6 +545,25 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.deleteSession(request, options, callback);
   }
+/**
+ * Report on the status of a session.
+ * This generates a report detailing which tests have been completed,
+ * and an overall rollup.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The session to be reported on.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [ReportSessionResponse]{@link google.showcase.v1beta1.ReportSessionResponse}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.reportSession(request);
+ */
   reportSession(
       request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       options?: CallOptions):
@@ -565,25 +584,6 @@ export class TestingClient {
           protos.google.showcase.v1beta1.IReportSessionResponse,
           protos.google.showcase.v1beta1.IReportSessionRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Report on the status of a session.
- * This generates a report detailing which tests have been completed,
- * and an overall rollup.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The session to be reported on.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [ReportSessionResponse]{@link google.showcase.v1beta1.ReportSessionResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.reportSession(request);
- */
   reportSession(
       request?: protos.google.showcase.v1beta1.IReportSessionRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -618,26 +618,6 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.reportSession(request, options, callback);
   }
-  deleteTest(
-      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
-      ]>;
-  deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteTest(
-      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Explicitly decline to implement a test.
  *
@@ -660,6 +640,26 @@ export class TestingClient {
  * @example
  * const [response] = await client.deleteTest(request);
  */
+  deleteTest(
+      request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.showcase.v1beta1.IDeleteTestRequest|undefined, {}|undefined
+      ]>;
+  deleteTest(
+      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteTest(
+      request: protos.google.showcase.v1beta1.IDeleteTestRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.showcase.v1beta1.IDeleteTestRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteTest(
       request?: protos.google.showcase.v1beta1.IDeleteTestRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -694,26 +694,6 @@ export class TestingClient {
     this.initialize();
     return this.innerApiCalls.deleteTest(request, options, callback);
   }
-  verifyTest(
-      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.IVerifyTestResponse,
-        protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
-      ]>;
-  verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IVerifyTestResponse,
-          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
-          {}|null|undefined>): void;
-  verifyTest(
-      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
-      callback: Callback<
-          protos.google.showcase.v1beta1.IVerifyTestResponse,
-          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Register a response to a test.
  *
@@ -738,6 +718,26 @@ export class TestingClient {
  * @example
  * const [response] = await client.verifyTest(request);
  */
+  verifyTest(
+      request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.IVerifyTestResponse,
+        protos.google.showcase.v1beta1.IVerifyTestRequest|undefined, {}|undefined
+      ]>;
+  verifyTest(
+      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IVerifyTestResponse,
+          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
+          {}|null|undefined>): void;
+  verifyTest(
+      request: protos.google.showcase.v1beta1.IVerifyTestRequest,
+      callback: Callback<
+          protos.google.showcase.v1beta1.IVerifyTestResponse,
+          protos.google.showcase.v1beta1.IVerifyTestRequest|null|undefined,
+          {}|null|undefined>): void;
   verifyTest(
       request?: protos.google.showcase.v1beta1.IVerifyTestRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -773,28 +773,7 @@ export class TestingClient {
     return this.innerApiCalls.verifyTest(request, options, callback);
   }
 
-  listSessions(
-      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.ISession[],
-        protos.google.showcase.v1beta1.IListSessionsRequest|null,
-        protos.google.showcase.v1beta1.IListSessionsResponse
-      ]>;
-  listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListSessionsRequest,
-          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ISession>): void;
-  listSessions(
-      request: protos.google.showcase.v1beta1.IListSessionsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListSessionsRequest,
-          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ISession>): void;
-/**
+ /**
  * Lists the current test sessions.
  *
  * @param {Object} request
@@ -816,6 +795,27 @@ export class TestingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listSessions(
+      request?: protos.google.showcase.v1beta1.IListSessionsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.ISession[],
+        protos.google.showcase.v1beta1.IListSessionsRequest|null,
+        protos.google.showcase.v1beta1.IListSessionsResponse
+      ]>;
+  listSessions(
+      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListSessionsRequest,
+          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ISession>): void;
+  listSessions(
+      request: protos.google.showcase.v1beta1.IListSessionsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListSessionsRequest,
+          protos.google.showcase.v1beta1.IListSessionsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ISession>): void;
   listSessions(
       request?: protos.google.showcase.v1beta1.IListSessionsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -923,28 +923,7 @@ export class TestingClient {
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
-  listTests(
-      request?: protos.google.showcase.v1beta1.IListTestsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.showcase.v1beta1.ITest[],
-        protos.google.showcase.v1beta1.IListTestsRequest|null,
-        protos.google.showcase.v1beta1.IListTestsResponse
-      ]>;
-  listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListTestsRequest,
-          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ITest>): void;
-  listTests(
-      request: protos.google.showcase.v1beta1.IListTestsRequest,
-      callback: PaginationCallback<
-          protos.google.showcase.v1beta1.IListTestsRequest,
-          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
-          protos.google.showcase.v1beta1.ITest>): void;
-/**
+ /**
  * List the tests of a sessesion.
  *
  * @param {Object} request
@@ -968,6 +947,27 @@ export class TestingClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listTests(
+      request?: protos.google.showcase.v1beta1.IListTestsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.showcase.v1beta1.ITest[],
+        protos.google.showcase.v1beta1.IListTestsRequest|null,
+        protos.google.showcase.v1beta1.IListTestsResponse
+      ]>;
+  listTests(
+      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListTestsRequest,
+          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ITest>): void;
+  listTests(
+      request: protos.google.showcase.v1beta1.IListTestsRequest,
+      callback: PaginationCallback<
+          protos.google.showcase.v1beta1.IListTestsRequest,
+          protos.google.showcase.v1beta1.IListTestsResponse|null|undefined,
+          protos.google.showcase.v1beta1.ITest>): void;
   listTests(
       request?: protos.google.showcase.v1beta1.IListTestsRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -300,6 +300,24 @@ export class CloudTasksClient {
   // -------------------
   // -- Service calls --
   // -------------------
+/**
+ * Gets a queue.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The resource name of the queue. For example:
+ *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Queue]{@link google.cloud.tasks.v2.Queue}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getQueue(request);
+ */
   getQueue(
       request?: protos.google.cloud.tasks.v2.IGetQueueRequest,
       options?: CallOptions):
@@ -320,24 +338,6 @@ export class CloudTasksClient {
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IGetQueueRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a queue.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The resource name of the queue. For example:
- *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Queue]{@link google.cloud.tasks.v2.Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getQueue(request);
- */
   getQueue(
       request?: protos.google.cloud.tasks.v2.IGetQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -372,26 +372,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.getQueue(request, options, callback);
   }
-  createQueue(
-      request?: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue,
-        protos.google.cloud.tasks.v2.ICreateQueueRequest|undefined, {}|undefined
-      ]>;
-  createQueue(
-      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  createQueue(
-      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a queue.
  *
@@ -431,6 +411,26 @@ export class CloudTasksClient {
  */
   createQueue(
       request?: protos.google.cloud.tasks.v2.ICreateQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue,
+        protos.google.cloud.tasks.v2.ICreateQueueRequest|undefined, {}|undefined
+      ]>;
+  createQueue(
+      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  createQueue(
+      request: protos.google.cloud.tasks.v2.ICreateQueueRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  createQueue(
+      request?: protos.google.cloud.tasks.v2.ICreateQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.ICreateQueueRequest|null|undefined,
@@ -463,26 +463,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.createQueue(request, options, callback);
   }
-  updateQueue(
-      request?: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue,
-        protos.google.cloud.tasks.v2.IUpdateQueueRequest|undefined, {}|undefined
-      ]>;
-  updateQueue(
-      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  updateQueue(
-      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Updates a queue.
  *
@@ -526,6 +506,26 @@ export class CloudTasksClient {
  */
   updateQueue(
       request?: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue,
+        protos.google.cloud.tasks.v2.IUpdateQueueRequest|undefined, {}|undefined
+      ]>;
+  updateQueue(
+      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateQueue(
+      request: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateQueue(
+      request?: protos.google.cloud.tasks.v2.IUpdateQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.IQueue,
           protos.google.cloud.tasks.v2.IUpdateQueueRequest|null|undefined,
@@ -558,26 +558,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.updateQueue(request, options, callback);
   }
-  deleteQueue(
-      request?: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.cloud.tasks.v2.IDeleteQueueRequest|undefined, {}|undefined
-      ]>;
-  deleteQueue(
-      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteQueue(
-      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a queue.
  *
@@ -608,6 +588,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.deleteQueue(request);
  */
+  deleteQueue(
+      request?: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.cloud.tasks.v2.IDeleteQueueRequest|undefined, {}|undefined
+      ]>;
+  deleteQueue(
+      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteQueue(
+      request: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.tasks.v2.IDeleteQueueRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteQueue(
       request?: protos.google.cloud.tasks.v2.IDeleteQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -642,26 +642,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.deleteQueue(request, options, callback);
   }
-  purgeQueue(
-      request?: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue,
-        protos.google.cloud.tasks.v2.IPurgeQueueRequest|undefined, {}|undefined
-      ]>;
-  purgeQueue(
-      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  purgeQueue(
-      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Purges a queue by deleting all of its tasks.
  *
@@ -685,6 +665,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.purgeQueue(request);
  */
+  purgeQueue(
+      request?: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue,
+        protos.google.cloud.tasks.v2.IPurgeQueueRequest|undefined, {}|undefined
+      ]>;
+  purgeQueue(
+      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  purgeQueue(
+      request: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IPurgeQueueRequest|null|undefined,
+          {}|null|undefined>): void;
   purgeQueue(
       request?: protos.google.cloud.tasks.v2.IPurgeQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -719,26 +719,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.purgeQueue(request, options, callback);
   }
-  pauseQueue(
-      request?: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue,
-        protos.google.cloud.tasks.v2.IPauseQueueRequest|undefined, {}|undefined
-      ]>;
-  pauseQueue(
-      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  pauseQueue(
-      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Pauses the queue.
  *
@@ -763,6 +743,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.pauseQueue(request);
  */
+  pauseQueue(
+      request?: protos.google.cloud.tasks.v2.IPauseQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue,
+        protos.google.cloud.tasks.v2.IPauseQueueRequest|undefined, {}|undefined
+      ]>;
+  pauseQueue(
+      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  pauseQueue(
+      request: protos.google.cloud.tasks.v2.IPauseQueueRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IPauseQueueRequest|null|undefined,
+          {}|null|undefined>): void;
   pauseQueue(
       request?: protos.google.cloud.tasks.v2.IPauseQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -797,26 +797,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.pauseQueue(request, options, callback);
   }
-  resumeQueue(
-      request?: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue,
-        protos.google.cloud.tasks.v2.IResumeQueueRequest|undefined, {}|undefined
-      ]>;
-  resumeQueue(
-      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
-          {}|null|undefined>): void;
-  resumeQueue(
-      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.IQueue,
-          protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Resume a queue.
  *
@@ -847,6 +827,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.resumeQueue(request);
  */
+  resumeQueue(
+      request?: protos.google.cloud.tasks.v2.IResumeQueueRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue,
+        protos.google.cloud.tasks.v2.IResumeQueueRequest|undefined, {}|undefined
+      ]>;
+  resumeQueue(
+      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
+          {}|null|undefined>): void;
+  resumeQueue(
+      request: protos.google.cloud.tasks.v2.IResumeQueueRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.IQueue,
+          protos.google.cloud.tasks.v2.IResumeQueueRequest|null|undefined,
+          {}|null|undefined>): void;
   resumeQueue(
       request?: protos.google.cloud.tasks.v2.IResumeQueueRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -881,26 +881,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.resumeQueue(request, options, callback);
   }
-  getIamPolicy(
-      request?: protos.google.iam.v1.IGetIamPolicyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.iam.v1.IPolicy,
-        protos.google.iam.v1.IGetIamPolicyRequest|undefined, {}|undefined
-      ]>;
-  getIamPolicy(
-      request: protos.google.iam.v1.IGetIamPolicyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.iam.v1.IPolicy,
-          protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
-  getIamPolicy(
-      request: protos.google.iam.v1.IGetIamPolicyRequest,
-      callback: Callback<
-          protos.google.iam.v1.IPolicy,
-          protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets the access control policy for a {@link google.cloud.tasks.v2.Queue|Queue}.
  * Returns an empty policy if the resource exists and does not have a policy
@@ -930,6 +910,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.getIamPolicy(request);
  */
+  getIamPolicy(
+      request?: protos.google.iam.v1.IGetIamPolicyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.iam.v1.IPolicy,
+        protos.google.iam.v1.IGetIamPolicyRequest|undefined, {}|undefined
+      ]>;
+  getIamPolicy(
+      request: protos.google.iam.v1.IGetIamPolicyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.iam.v1.IPolicy,
+          protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  getIamPolicy(
+      request: protos.google.iam.v1.IGetIamPolicyRequest,
+      callback: Callback<
+          protos.google.iam.v1.IPolicy,
+          protos.google.iam.v1.IGetIamPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
   getIamPolicy(
       request?: protos.google.iam.v1.IGetIamPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -964,26 +964,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.getIamPolicy(request, options, callback);
   }
-  setIamPolicy(
-      request?: protos.google.iam.v1.ISetIamPolicyRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.iam.v1.IPolicy,
-        protos.google.iam.v1.ISetIamPolicyRequest|undefined, {}|undefined
-      ]>;
-  setIamPolicy(
-      request: protos.google.iam.v1.ISetIamPolicyRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.iam.v1.IPolicy,
-          protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
-  setIamPolicy(
-      request: protos.google.iam.v1.ISetIamPolicyRequest,
-      callback: Callback<
-          protos.google.iam.v1.IPolicy,
-          protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Sets the access control policy for a {@link google.cloud.tasks.v2.Queue|Queue}. Replaces any existing
  * policy.
@@ -1019,6 +999,26 @@ export class CloudTasksClient {
  */
   setIamPolicy(
       request?: protos.google.iam.v1.ISetIamPolicyRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.iam.v1.IPolicy,
+        protos.google.iam.v1.ISetIamPolicyRequest|undefined, {}|undefined
+      ]>;
+  setIamPolicy(
+      request: protos.google.iam.v1.ISetIamPolicyRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.iam.v1.IPolicy,
+          protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  setIamPolicy(
+      request: protos.google.iam.v1.ISetIamPolicyRequest,
+      callback: Callback<
+          protos.google.iam.v1.IPolicy,
+          protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
+          {}|null|undefined>): void;
+  setIamPolicy(
+      request?: protos.google.iam.v1.ISetIamPolicyRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.iam.v1.IPolicy,
           protos.google.iam.v1.ISetIamPolicyRequest|null|undefined,
@@ -1051,26 +1051,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.setIamPolicy(request, options, callback);
   }
-  testIamPermissions(
-      request?: protos.google.iam.v1.ITestIamPermissionsRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.iam.v1.ITestIamPermissionsResponse,
-        protos.google.iam.v1.ITestIamPermissionsRequest|undefined, {}|undefined
-      ]>;
-  testIamPermissions(
-      request: protos.google.iam.v1.ITestIamPermissionsRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.iam.v1.ITestIamPermissionsResponse,
-          protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
-          {}|null|undefined>): void;
-  testIamPermissions(
-      request: protos.google.iam.v1.ITestIamPermissionsRequest,
-      callback: Callback<
-          protos.google.iam.v1.ITestIamPermissionsResponse,
-          protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Returns permissions that a caller has on a {@link google.cloud.tasks.v2.Queue|Queue}.
  * If the resource does not exist, this will return an empty set of
@@ -1100,6 +1080,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.testIamPermissions(request);
  */
+  testIamPermissions(
+      request?: protos.google.iam.v1.ITestIamPermissionsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.iam.v1.ITestIamPermissionsResponse,
+        protos.google.iam.v1.ITestIamPermissionsRequest|undefined, {}|undefined
+      ]>;
+  testIamPermissions(
+      request: protos.google.iam.v1.ITestIamPermissionsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.iam.v1.ITestIamPermissionsResponse,
+          protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
+          {}|null|undefined>): void;
+  testIamPermissions(
+      request: protos.google.iam.v1.ITestIamPermissionsRequest,
+      callback: Callback<
+          protos.google.iam.v1.ITestIamPermissionsResponse,
+          protos.google.iam.v1.ITestIamPermissionsRequest|null|undefined,
+          {}|null|undefined>): void;
   testIamPermissions(
       request?: protos.google.iam.v1.ITestIamPermissionsRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1134,26 +1134,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.testIamPermissions(request, options, callback);
   }
-  getTask(
-      request?: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.ITask,
-        protos.google.cloud.tasks.v2.IGetTaskRequest|undefined, {}|undefined
-      ]>;
-  getTask(
-      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
-          {}|null|undefined>): void;
-  getTask(
-      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Gets a task.
  *
@@ -1185,6 +1165,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.getTask(request);
  */
+  getTask(
+      request?: protos.google.cloud.tasks.v2.IGetTaskRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.ITask,
+        protos.google.cloud.tasks.v2.IGetTaskRequest|undefined, {}|undefined
+      ]>;
+  getTask(
+      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  getTask(
+      request: protos.google.cloud.tasks.v2.IGetTaskRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.IGetTaskRequest|null|undefined,
+          {}|null|undefined>): void;
   getTask(
       request?: protos.google.cloud.tasks.v2.IGetTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1219,26 +1219,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.getTask(request, options, callback);
   }
-  createTask(
-      request?: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.ITask,
-        protos.google.cloud.tasks.v2.ICreateTaskRequest|undefined, {}|undefined
-      ]>;
-  createTask(
-      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
-          {}|null|undefined>): void;
-  createTask(
-      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a task and adds it to a queue.
  *
@@ -1312,6 +1292,26 @@ export class CloudTasksClient {
  */
   createTask(
       request?: protos.google.cloud.tasks.v2.ICreateTaskRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.ITask,
+        protos.google.cloud.tasks.v2.ICreateTaskRequest|undefined, {}|undefined
+      ]>;
+  createTask(
+      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  createTask(
+      request: protos.google.cloud.tasks.v2.ICreateTaskRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  createTask(
+      request?: protos.google.cloud.tasks.v2.ICreateTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.ICreateTaskRequest|null|undefined,
@@ -1344,26 +1344,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.createTask(request, options, callback);
   }
-  deleteTask(
-      request?: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.protobuf.IEmpty,
-        protos.google.cloud.tasks.v2.IDeleteTaskRequest|undefined, {}|undefined
-      ]>;
-  deleteTask(
-      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
-          {}|null|undefined>): void;
-  deleteTask(
-      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
-      callback: Callback<
-          protos.google.protobuf.IEmpty,
-          protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a task.
  *
@@ -1386,6 +1366,26 @@ export class CloudTasksClient {
  * @example
  * const [response] = await client.deleteTask(request);
  */
+  deleteTask(
+      request?: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.cloud.tasks.v2.IDeleteTaskRequest|undefined, {}|undefined
+      ]>;
+  deleteTask(
+      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteTask(
+      request: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.cloud.tasks.v2.IDeleteTaskRequest|null|undefined,
+          {}|null|undefined>): void;
   deleteTask(
       request?: protos.google.cloud.tasks.v2.IDeleteTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1420,26 +1420,6 @@ export class CloudTasksClient {
     this.initialize();
     return this.innerApiCalls.deleteTask(request, options, callback);
   }
-  runTask(
-      request?: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.ITask,
-        protos.google.cloud.tasks.v2.IRunTaskRequest|undefined, {}|undefined
-      ]>;
-  runTask(
-      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
-          {}|null|undefined>): void;
-  runTask(
-      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
-      callback: Callback<
-          protos.google.cloud.tasks.v2.ITask,
-          protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Forces a task to run now.
  *
@@ -1496,6 +1476,26 @@ export class CloudTasksClient {
  */
   runTask(
       request?: protos.google.cloud.tasks.v2.IRunTaskRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.ITask,
+        protos.google.cloud.tasks.v2.IRunTaskRequest|undefined, {}|undefined
+      ]>;
+  runTask(
+      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  runTask(
+      request: protos.google.cloud.tasks.v2.IRunTaskRequest,
+      callback: Callback<
+          protos.google.cloud.tasks.v2.ITask,
+          protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
+          {}|null|undefined>): void;
+  runTask(
+      request?: protos.google.cloud.tasks.v2.IRunTaskRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.tasks.v2.ITask,
           protos.google.cloud.tasks.v2.IRunTaskRequest|null|undefined,
@@ -1529,28 +1529,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.runTask(request, options, callback);
   }
 
-  listQueues(
-      request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.IQueue[],
-        protos.google.cloud.tasks.v2.IListQueuesRequest|null,
-        protos.google.cloud.tasks.v2.IListQueuesResponse
-      ]>;
-  listQueues(
-      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.tasks.v2.IListQueuesRequest,
-          protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
-          protos.google.cloud.tasks.v2.IQueue>): void;
-  listQueues(
-      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.tasks.v2.IListQueuesRequest,
-          protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
-          protos.google.cloud.tasks.v2.IQueue>): void;
-/**
+ /**
  * Lists queues.
  *
  * Queues are returned in lexicographical order.
@@ -1602,6 +1581,27 @@ export class CloudTasksClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listQueues(
+      request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.IQueue[],
+        protos.google.cloud.tasks.v2.IListQueuesRequest|null,
+        protos.google.cloud.tasks.v2.IListQueuesResponse
+      ]>;
+  listQueues(
+      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.tasks.v2.IListQueuesRequest,
+          protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
+          protos.google.cloud.tasks.v2.IQueue>): void;
+  listQueues(
+      request: protos.google.cloud.tasks.v2.IListQueuesRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.tasks.v2.IListQueuesRequest,
+          protos.google.cloud.tasks.v2.IListQueuesResponse|null|undefined,
+          protos.google.cloud.tasks.v2.IQueue>): void;
   listQueues(
       request?: protos.google.cloud.tasks.v2.IListQueuesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<
@@ -1786,28 +1786,7 @@ export class CloudTasksClient {
       callSettings
     ) as AsyncIterable<protos.google.cloud.tasks.v2.IQueue>;
   }
-  listTasks(
-      request?: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.tasks.v2.ITask[],
-        protos.google.cloud.tasks.v2.IListTasksRequest|null,
-        protos.google.cloud.tasks.v2.IListTasksResponse
-      ]>;
-  listTasks(
-      request: protos.google.cloud.tasks.v2.IListTasksRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.tasks.v2.IListTasksRequest,
-          protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
-          protos.google.cloud.tasks.v2.ITask>): void;
-  listTasks(
-      request: protos.google.cloud.tasks.v2.IListTasksRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.tasks.v2.IListTasksRequest,
-          protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
-          protos.google.cloud.tasks.v2.ITask>): void;
-/**
+ /**
  * Lists the tasks in a queue.
  *
  * By default, only the {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC} view is retrieved
@@ -1868,6 +1847,27 @@ export class CloudTasksClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listTasks(
+      request?: protos.google.cloud.tasks.v2.IListTasksRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.tasks.v2.ITask[],
+        protos.google.cloud.tasks.v2.IListTasksRequest|null,
+        protos.google.cloud.tasks.v2.IListTasksResponse
+      ]>;
+  listTasks(
+      request: protos.google.cloud.tasks.v2.IListTasksRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.tasks.v2.IListTasksRequest,
+          protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
+          protos.google.cloud.tasks.v2.ITask>): void;
+  listTasks(
+      request: protos.google.cloud.tasks.v2.IListTasksRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.tasks.v2.IListTasksRequest,
+          protos.google.cloud.tasks.v2.IListTasksResponse|null|undefined,
+          protos.google.cloud.tasks.v2.ITask>): void;
   listTasks(
       request?: protos.google.cloud.tasks.v2.IListTasksRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -273,26 +273,6 @@ export class TextToSpeechClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  listVoices(
-      request?: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.texttospeech.v1.IListVoicesResponse,
-        protos.google.cloud.texttospeech.v1.IListVoicesRequest|undefined, {}|undefined
-      ]>;
-  listVoices(
-      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.texttospeech.v1.IListVoicesResponse,
-          protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
-          {}|null|undefined>): void;
-  listVoices(
-      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
-      callback: Callback<
-          protos.google.cloud.texttospeech.v1.IListVoicesResponse,
-          protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Returns a list of Voice supported for synthesis.
  *
@@ -317,6 +297,26 @@ export class TextToSpeechClient {
  * @example
  * const [response] = await client.listVoices(request);
  */
+  listVoices(
+      request?: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.texttospeech.v1.IListVoicesResponse,
+        protos.google.cloud.texttospeech.v1.IListVoicesRequest|undefined, {}|undefined
+      ]>;
+  listVoices(
+      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.texttospeech.v1.IListVoicesResponse,
+          protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
+          {}|null|undefined>): void;
+  listVoices(
+      request: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
+      callback: Callback<
+          protos.google.cloud.texttospeech.v1.IListVoicesResponse,
+          protos.google.cloud.texttospeech.v1.IListVoicesRequest|null|undefined,
+          {}|null|undefined>): void;
   listVoices(
       request?: protos.google.cloud.texttospeech.v1.IListVoicesRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -344,26 +344,6 @@ export class TextToSpeechClient {
     this.initialize();
     return this.innerApiCalls.listVoices(request, options, callback);
   }
-  synthesizeSpeech(
-      request?: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
-        protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|undefined, {}|undefined
-      ]>;
-  synthesizeSpeech(
-      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
-          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
-          {}|null|undefined>): void;
-  synthesizeSpeech(
-      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
-      callback: Callback<
-          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
-          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Synthesizes speech synchronously: receive results after all text input
  * has been processed.
@@ -386,6 +366,26 @@ export class TextToSpeechClient {
  * @example
  * const [response] = await client.synthesizeSpeech(request);
  */
+  synthesizeSpeech(
+      request?: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
+        protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|undefined, {}|undefined
+      ]>;
+  synthesizeSpeech(
+      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
+          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
+          {}|null|undefined>): void;
+  synthesizeSpeech(
+      request: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
+      callback: Callback<
+          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechResponse,
+          protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest|null|undefined,
+          {}|null|undefined>): void;
   synthesizeSpeech(
       request?: protos.google.cloud.texttospeech.v1.ISynthesizeSpeechRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -338,26 +338,6 @@ export class TranslationServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  translateText(
-      request?: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
-        protos.google.cloud.translation.v3beta1.ITranslateTextRequest|undefined, {}|undefined
-      ]>;
-  translateText(
-      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
-          protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
-          {}|null|undefined>): void;
-  translateText(
-      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
-          protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Translates input text and returns translated text.
  *
@@ -437,6 +417,26 @@ export class TranslationServiceClient {
  */
   translateText(
       request?: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
+        protos.google.cloud.translation.v3beta1.ITranslateTextRequest|undefined, {}|undefined
+      ]>;
+  translateText(
+      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
+          protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
+          {}|null|undefined>): void;
+  translateText(
+      request: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
+          protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
+          {}|null|undefined>): void;
+  translateText(
+      request?: protos.google.cloud.translation.v3beta1.ITranslateTextRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ITranslateTextResponse,
           protos.google.cloud.translation.v3beta1.ITranslateTextRequest|null|undefined,
@@ -469,26 +469,6 @@ export class TranslationServiceClient {
     this.initialize();
     return this.innerApiCalls.translateText(request, options, callback);
   }
-  detectLanguage(
-      request?: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
-        protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|undefined, {}|undefined
-      ]>;
-  detectLanguage(
-      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
-          protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
-          {}|null|undefined>): void;
-  detectLanguage(
-      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
-          protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Detects the language of text within a request.
  *
@@ -542,6 +522,26 @@ export class TranslationServiceClient {
  */
   detectLanguage(
       request?: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
+        protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|undefined, {}|undefined
+      ]>;
+  detectLanguage(
+      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
+          protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
+          {}|null|undefined>): void;
+  detectLanguage(
+      request: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
+          protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
+          {}|null|undefined>): void;
+  detectLanguage(
+      request?: protos.google.cloud.translation.v3beta1.IDetectLanguageRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.IDetectLanguageResponse,
           protos.google.cloud.translation.v3beta1.IDetectLanguageRequest|null|undefined,
@@ -574,26 +574,6 @@ export class TranslationServiceClient {
     this.initialize();
     return this.innerApiCalls.detectLanguage(request, options, callback);
   }
-  getSupportedLanguages(
-      request?: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.translation.v3beta1.ISupportedLanguages,
-        protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|undefined, {}|undefined
-      ]>;
-  getSupportedLanguages(
-      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      options: CallOptions,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.ISupportedLanguages,
-          protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
-          {}|null|undefined>): void;
-  getSupportedLanguages(
-      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
-      callback: Callback<
-          protos.google.cloud.translation.v3beta1.ISupportedLanguages,
-          protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Returns a list of supported languages for translation.
  *
@@ -644,6 +624,26 @@ export class TranslationServiceClient {
  */
   getSupportedLanguages(
       request?: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.translation.v3beta1.ISupportedLanguages,
+        protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|undefined, {}|undefined
+      ]>;
+  getSupportedLanguages(
+      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.ISupportedLanguages,
+          protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
+          {}|null|undefined>): void;
+  getSupportedLanguages(
+      request: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
+      callback: Callback<
+          protos.google.cloud.translation.v3beta1.ISupportedLanguages,
+          protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
+          {}|null|undefined>): void;
+  getSupportedLanguages(
+      request?: protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest,
       optionsOrCallback?: CallOptions|Callback<
           protos.google.cloud.translation.v3beta1.ISupportedLanguages,
           protos.google.cloud.translation.v3beta1.IGetSupportedLanguagesRequest|null|undefined,
@@ -676,6 +676,24 @@ export class TranslationServiceClient {
     this.initialize();
     return this.innerApiCalls.getSupportedLanguages(request, options, callback);
   }
+/**
+ * Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
+ * exist.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The name of the glossary to retrieve.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Glossary]{@link google.cloud.translation.v3beta1.Glossary}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example
+ * const [response] = await client.getGlossary(request);
+ */
   getGlossary(
       request?: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
       options?: CallOptions):
@@ -696,24 +714,6 @@ export class TranslationServiceClient {
           protos.google.cloud.translation.v3beta1.IGlossary,
           protos.google.cloud.translation.v3beta1.IGetGlossaryRequest|null|undefined,
           {}|null|undefined>): void;
-/**
- * Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
- * exist.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   Required. The name of the glossary to retrieve.
- * @param {object} [options]
- *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Glossary]{@link google.cloud.translation.v3beta1.Glossary}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
- *   for more details and examples.
- * @example
- * const [response] = await client.getGlossary(request);
- */
   getGlossary(
       request?: protos.google.cloud.translation.v3beta1.IGetGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -749,26 +749,6 @@ export class TranslationServiceClient {
     return this.innerApiCalls.getGlossary(request, options, callback);
   }
 
-  batchTranslateText(
-      request?: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  batchTranslateText(
-      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  batchTranslateText(
-      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Translates a large volume of text in asynchronous batch mode.
  * This function provides real-time output as the inputs are being processed.
@@ -847,6 +827,26 @@ export class TranslationServiceClient {
  */
   batchTranslateText(
       request?: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  batchTranslateText(
+      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  batchTranslateText(
+      request: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  batchTranslateText(
+      request?: protos.google.cloud.translation.v3beta1.IBatchTranslateTextRequest,
       optionsOrCallback?: CallOptions|Callback<
           LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>,
           protos.google.longrunning.IOperation|null|undefined,
@@ -900,26 +900,6 @@ export class TranslationServiceClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.batchTranslateText, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>;
   }
-  createGlossary(
-      request?: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  createGlossary(
-      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  createGlossary(
-      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Creates a glossary and returns the long-running operation. Returns
  * NOT_FOUND, if the project doesn't exist.
@@ -943,6 +923,26 @@ export class TranslationServiceClient {
  * const [operation] = await client.createGlossary(request);
  * const [response] = await operation.promise();
  */
+  createGlossary(
+      request?: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  createGlossary(
+      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  createGlossary(
+      request: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   createGlossary(
       request?: protos.google.cloud.translation.v3beta1.ICreateGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -998,26 +998,6 @@ export class TranslationServiceClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createGlossary, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>;
   }
-  deleteGlossary(
-      request?: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  deleteGlossary(
-      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  deleteGlossary(
-      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Deletes a glossary, or cancels glossary construction
  * if the glossary isn't created yet.
@@ -1040,6 +1020,26 @@ export class TranslationServiceClient {
  * const [operation] = await client.deleteGlossary(request);
  * const [response] = await operation.promise();
  */
+  deleteGlossary(
+      request?: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  deleteGlossary(
+      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  deleteGlossary(
+      request: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   deleteGlossary(
       request?: protos.google.cloud.translation.v3beta1.IDeleteGlossaryRequest,
       optionsOrCallback?: CallOptions|Callback<
@@ -1095,28 +1095,7 @@ export class TranslationServiceClient {
     const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteGlossary, gax.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>;
   }
-  listGlossaries(
-      request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options?: CallOptions):
-      Promise<[
-        protos.google.cloud.translation.v3beta1.IGlossary[],
-        protos.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
-        protos.google.cloud.translation.v3beta1.IListGlossariesResponse
-      ]>;
-  listGlossaries(
-      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      options: CallOptions,
-      callback: PaginationCallback<
-          protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-          protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
-          protos.google.cloud.translation.v3beta1.IGlossary>): void;
-  listGlossaries(
-      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-      callback: PaginationCallback<
-          protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
-          protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
-          protos.google.cloud.translation.v3beta1.IGlossary>): void;
-/**
+ /**
  * Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
  * exist.
  *
@@ -1149,6 +1128,27 @@ export class TranslationServiceClient {
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
  *   for more details and examples.
  */
+  listGlossaries(
+      request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.cloud.translation.v3beta1.IGlossary[],
+        protos.google.cloud.translation.v3beta1.IListGlossariesRequest|null,
+        protos.google.cloud.translation.v3beta1.IListGlossariesResponse
+      ]>;
+  listGlossaries(
+      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+          protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
+          protos.google.cloud.translation.v3beta1.IGlossary>): void;
+  listGlossaries(
+      request: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+      callback: PaginationCallback<
+          protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
+          protos.google.cloud.translation.v3beta1.IListGlossariesResponse|null|undefined,
+          protos.google.cloud.translation.v3beta1.IGlossary>): void;
   listGlossaries(
       request?: protos.google.cloud.translation.v3beta1.IListGlossariesRequest,
       optionsOrCallback?: CallOptions|PaginationCallback<

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -298,26 +298,6 @@ export class VideoIntelligenceServiceClient {
   // -- Service calls --
   // -------------------
 
-  annotateVideo(
-      request?: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      options?: CallOptions):
-      Promise<[
-        LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
-        protos.google.longrunning.IOperation|undefined, {}|undefined
-      ]>;
-  annotateVideo(
-      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      options: CallOptions,
-      callback: Callback<
-          LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
-  annotateVideo(
-      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
-      callback: Callback<
-          LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
-          protos.google.longrunning.IOperation|null|undefined,
-          {}|null|undefined>): void;
 /**
  * Performs asynchronous video annotation. Progress and results can be
  * retrieved through the `google.longrunning.Operations` interface.
@@ -369,6 +349,26 @@ export class VideoIntelligenceServiceClient {
  * const [operation] = await client.annotateVideo(request);
  * const [response] = await operation.promise();
  */
+  annotateVideo(
+      request?: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  annotateVideo(
+      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  annotateVideo(
+      request: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
+      callback: Callback<
+          LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
   annotateVideo(
       request?: protos.google.cloud.videointelligence.v1.IAnnotateVideoRequest,
       optionsOrCallback?: CallOptions|Callback<

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -493,6 +493,12 @@ export class {{ service.name }}Client {
   // -------------------
 
 {%- for method in service.simpleMethods %}
+/**
+{{- util.printComments(method, service) }}
+ {%- if method.options and method.options.deprecated %}
+ * @deprecated {{method.name}} is deprecated and may be removed in a future version.
+ {%- endif %}
+ */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
@@ -520,12 +526,6 @@ export class {{ service.name }}Client {
           {{ util.toInterface(method.outputInterface) }},
           {{ util.toInterface(method.inputInterface) }}|null|undefined,
           {}|null|undefined>): void;
-/**
-{{- util.printComments(method, service) }}
- {%- if method.options and method.options.deprecated %}
- * @deprecated {{method.name}} is deprecated and may be removed in a future version.
- {%- endif %}
- */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|Callback<
@@ -611,6 +611,12 @@ export class {{ service.name }}Client {
     return this.innerApiCalls.{{ method.name.toCamelCase() }}(request, options);
   }
 {%- elif method.clientStreaming %}
+/**
+{{- util.printComments(method, service) }}
+ {%- if method.options and method.options.deprecated %}
+ * @deprecated {{method.name}} is deprecated and may be removed in a future version.
+ {%- endif %}
+ */
   {{ method.name.toCamelCase() }}(
       options?: CallOptions,
       callback?: Callback<
@@ -624,12 +630,6 @@ export class {{ service.name }}Client {
         {{ util.toInterface(method.inputInterface) }}|null|undefined,
         {}|null|undefined>):
     gax.CancellableStream;
-/**
-{{- util.printComments(method, service) }}
- {%- if method.options and method.options.deprecated %}
- * @deprecated {{method.name}} is deprecated and may be removed in a future version.
- {%- endif %}
- */
   {{ method.name.toCamelCase() }}(
       optionsOrCallback?: CallOptions|Callback<
         {{ util.toInterface(method.outputInterface) }},
@@ -654,6 +654,12 @@ export class {{ service.name }}Client {
 {%- endif %}
 {% endfor %}
 {%- for method in service.longRunning %}
+/**
+{{- util.printComments(method, service) }}
+ {%- if method.options and method.options.deprecated %}
+ * @deprecated {{method.name}} is deprecated and may be removed in a future version.
+ {%- endif %}
+ */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
@@ -674,12 +680,6 @@ export class {{ service.name }}Client {
           LROperation<{{ util.toInterface(method.longRunningResponseType, method.inputType) }}, {{ util.toInterface(method.longRunningMetadataType, method.inputType)  }}>,
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
           {}|null|undefined>): void;
-/**
-{{- util.printComments(method, service) }}
- {%- if method.options and method.options.deprecated %}
- * @deprecated {{method.name}} is deprecated and may be removed in a future version.
- {%- endif %}
- */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|Callback<
@@ -729,6 +729,12 @@ export class {{ service.name }}Client {
 {%- endfor %}
 {%- for method in service.paging %}
 {%- if not method.pagingMapResponseType %}
+ /**
+{{- util.printComments(method, service, id.get(method.name.toCamelCase() + "Async")) }}
+ {%- if method.options and method.options.deprecated %}
+ * @deprecated {{method.name}} is deprecated and may be removed in a future version.
+ {%- endif %}
+ */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       options?: CallOptions):
@@ -750,12 +756,6 @@ export class {{ service.name }}Client {
           {{ util.toInterface(method.inputInterface) }},
           {{ util.toInterface(method.outputInterface) }}|null|undefined,
           {{ util.toInterface(method.pagingResponseType) }}>): void;
-/**
-{{- util.printComments(method, service, id.get(method.name.toCamelCase() + "Async")) }}
- {%- if method.options and method.options.deprecated %}
- * @deprecated {{method.name}} is deprecated and may be removed in a future version.
- {%- endif %}
- */
   {{ method.name.toCamelCase() }}(
       request?: {{ util.toInterface(method.inputInterface) }},
       optionsOrCallback?: CallOptions|PaginationCallback<


### PR DESCRIPTION
Google is moving reference docs to cloud.google.com, which relies on TSDoc rather than JSDoc.

TSDoc expects comments before the first overloaded function, we currently have those on the last function. Those comments don't make it into the d.ts files. We need to move comments to the first overloaded function rather than the last one.

This update moves the comments ahead of the first function instead of the last one with the same name.

See for example https://github.com/googleapis/nodejs-secret-manager/commit/980b0fdfd48b5282d450de16af26daef80f53e70

