### PR TITLE
test: retry errors when crawling links

### DIFF
--- a/baselines/asset/linkinator.config.json.baseline
+++ b/baselines/asset/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/asset/linkinator.config.json.baseline
+++ b/baselines/asset/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/bigquery-storage/linkinator.config.json.baseline
+++ b/baselines/bigquery-storage/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/bigquery-storage/linkinator.config.json.baseline
+++ b/baselines/bigquery-storage/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/compute/linkinator.config.json.baseline
+++ b/baselines/compute/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/compute/linkinator.config.json.baseline
+++ b/baselines/compute/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/deprecatedtest/linkinator.config.json.baseline
+++ b/baselines/deprecatedtest/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/deprecatedtest/linkinator.config.json.baseline
+++ b/baselines/deprecatedtest/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/disable-packing-test/linkinator.config.json.baseline
+++ b/baselines/disable-packing-test/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/disable-packing-test/linkinator.config.json.baseline
+++ b/baselines/disable-packing-test/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/dlp/linkinator.config.json.baseline
+++ b/baselines/dlp/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/dlp/linkinator.config.json.baseline
+++ b/baselines/dlp/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/kms/linkinator.config.json.baseline
+++ b/baselines/kms/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/kms/linkinator.config.json.baseline
+++ b/baselines/kms/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/logging/linkinator.config.json.baseline
+++ b/baselines/logging/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/logging/linkinator.config.json.baseline
+++ b/baselines/logging/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/monitoring/linkinator.config.json.baseline
+++ b/baselines/monitoring/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/monitoring/linkinator.config.json.baseline
+++ b/baselines/monitoring/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/naming/linkinator.config.json.baseline
+++ b/baselines/naming/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/naming/linkinator.config.json.baseline
+++ b/baselines/naming/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/redis/linkinator.config.json.baseline
+++ b/baselines/redis/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/redis/linkinator.config.json.baseline
+++ b/baselines/redis/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/routingtest/linkinator.config.json.baseline
+++ b/baselines/routingtest/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/routingtest/linkinator.config.json.baseline
+++ b/baselines/routingtest/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/showcase-legacy/linkinator.config.json.baseline
+++ b/baselines/showcase-legacy/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/showcase-legacy/linkinator.config.json.baseline
+++ b/baselines/showcase-legacy/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/showcase/linkinator.config.json.baseline
+++ b/baselines/showcase/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/showcase/linkinator.config.json.baseline
+++ b/baselines/showcase/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/tasks/linkinator.config.json.baseline
+++ b/baselines/tasks/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/tasks/linkinator.config.json.baseline
+++ b/baselines/tasks/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/texttospeech/linkinator.config.json.baseline
+++ b/baselines/texttospeech/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/texttospeech/linkinator.config.json.baseline
+++ b/baselines/texttospeech/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/translate/linkinator.config.json.baseline
+++ b/baselines/translate/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/translate/linkinator.config.json.baseline
+++ b/baselines/translate/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/baselines/videointelligence/linkinator.config.json.baseline
+++ b/baselines/videointelligence/linkinator.config.json.baseline
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/baselines/videointelligence/linkinator.config.json.baseline
+++ b/baselines/videointelligence/linkinator.config.json.baseline
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,

--- a/templates/typescript_gapic/linkinator.config.json.njk
+++ b/templates/typescript_gapic/linkinator.config.json.njk
@@ -6,5 +6,9 @@
     "img.shields.io"
   ],
   "silent": true,
-  "concurrency": 5
+  "concurrency": 5,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 5,
+  "retryErrorsJitter": 3000
 }

--- a/templates/typescript_gapic/linkinator.config.json.njk
+++ b/templates/typescript_gapic/linkinator.config.json.njk
@@ -3,7 +3,8 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io"
+    "img.shields.io",
+    "https://console.cloud.google.com/cloudshell"
   ],
   "silent": true,
   "concurrency": 5,


### PR DESCRIPTION
Add support for exponential backoff when crawling links, hopes that this will reduce failed docs test runs we've seen in GitHub actions.