### PR TITLE
fix: update test template for dynamic routing header

### DIFF
--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -126,6 +126,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -148,6 +149,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -181,6 +183,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -204,6 +207,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -226,6 +230,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -259,6 +264,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -282,6 +288,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -304,6 +311,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -337,6 +345,7 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const expectedHeaderRequestParams = "";
             const expectedOptions = {
                 otherArgs: {
                     headers: {

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -287,7 +287,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
 
 {%- macro initRequestWithHeaderParam(method) -%}
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
-{%- if method.headerRequestParams.length > 0 %}
+{%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
 {%- set expectedRequestParamJoiner = joiner("&") -%}
 {%- set expectedRequestParams = "" %}
 {%- for requestParam in method.headerRequestParams %}


### PR DESCRIPTION
This fix updates the test template for methods with a dynamic routing header. 