### PR TITLE
fix: add null request for bi_di stream call

### DIFF
--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -593,7 +593,7 @@ export class EchoClient {
       options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
-    return this.innerApiCalls.chat(options);
+    return this.innerApiCalls.chat(null, options);
   }
 
 /**

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -1034,7 +1034,7 @@ export class MessagingClient {
       options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
-    return this.innerApiCalls.connect(options);
+    return this.innerApiCalls.connect(null, options);
   }
 
 /**

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -521,7 +521,7 @@ describe('v1beta1.EchoClient', () => {
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -547,7 +547,7 @@ describe('v1beta1.EchoClient', () => {
             });
             await assert.rejects(promise, expectedError);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1103,7 +1103,7 @@ describe('v1beta1.MessagingClient', () => {
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.connect as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -1129,7 +1129,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             await assert.rejects(promise, expectedError);
             assert((client.innerApiCalls.connect as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -552,7 +552,7 @@ export class EchoClient {
       options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
-    return this.innerApiCalls.chat(options);
+    return this.innerApiCalls.chat(null, options);
   }
 
 /**

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -514,7 +514,7 @@ describe('v1beta1.EchoClient', () => {
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -540,7 +540,7 @@ describe('v1beta1.EchoClient', () => {
             });
             await assert.rejects(promise, expectedError);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -599,7 +599,7 @@ export class EchoClient {
       options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
-    return this.innerApiCalls.chat(options);
+    return this.innerApiCalls.chat(null, options);
   }
 
 /**

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -1040,7 +1040,7 @@ export class MessagingClient {
       options?: CallOptions):
     gax.CancellableStream {
     this.initialize();
-    return this.innerApiCalls.connect(options);
+    return this.innerApiCalls.connect(null, options);
   }
 
 /**

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -521,7 +521,7 @@ describe('v1beta1.EchoClient', () => {
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -547,7 +547,7 @@ describe('v1beta1.EchoClient', () => {
             });
             await assert.rejects(promise, expectedError);
             assert((client.innerApiCalls.chat as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1103,7 +1103,7 @@ describe('v1beta1.MessagingClient', () => {
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.connect as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -1129,7 +1129,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             await assert.rejects(promise, expectedError);
             assert((client.innerApiCalls.connect as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -593,7 +593,7 @@ export class {{ service.name }}Client {
     {%- if method.options and method.options.deprecated %}
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
-    return this.innerApiCalls.{{ method.name.toCamelCase() }}(options);
+    return this.innerApiCalls.{{ method.name.toCamelCase() }}(null, options);
   }
 {%- elif method.serverStreaming %}
 /**

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -548,7 +548,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -578,7 +578,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
-                .getCall(0).calledWithExactly(undefined));
+                .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
         });


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#657.

`appendRows` bi-di stream call in `nodejs-bigquery-storage` fail to pass in the options.
```
        let options = {}
        options.otherArgs = {};
        options.otherArgs.headers = {};
        options.otherArgs.headers['x-goog-request-params'] = writeStream
        const stream = await storageClient.appendRows(options);
```

Because bi-direction stream call treat `options` as `request` when [`createAPICall` ]https://github.com/googleapis/gax-nodejs/blob/be8175624624648a32d535c3f6495814c163eb18/src/createApiCall.ts#L73)

Fix: Similar to [client stream](https://github.com/googleapis/gapic-generator-typescript/blob/main/templates/typescript_gapic/src/%24version/%24service_client.ts.njk#L660), we could pass `null` as request before `options`.
```
return this.innerApiCalls.{{ method.name.toCamelCase() }}(null, options);
```
