### PR TITLE
fix: change dynamic routing header field to camelCase

### DIFF
--- a/baselines/routingtest/protos/google/routingtest/v1/routingtest_service.proto.baseline
+++ b/baselines/routingtest/protos/google/routingtest/v1/routingtest_service.proto.baseline
@@ -52,6 +52,10 @@ service TestService {
       routing_parameters {
         field: "name"
       }
+      routing_parameters {
+        field: "name"
+        path_template: "{routing_id=**}"
+      }
     };
   };
 
@@ -64,15 +68,15 @@ service TestService {
     // This routing annotation is only for baseline testing purposes.
     option (google.api.routing) = {
       routing_parameters {
-        field: "parent",
+        field: "parent_id",
         path_template: "{database=projects/*}"
       }
       routing_parameters {
-        field: "parent",
+        field: "nest1.nest2.name_id",
         path_template: "{database=projects/*/databases/*}/documents"
       }
       routing_parameters {
-        field: "parent",
+        field: "another_parent_id",
         path_template: "{routing_id=projects/*}/databases/*/documents"
       }
     };
@@ -82,10 +86,18 @@ service TestService {
 // This is a message description.
 // Lorum ipsum dolor sit amet consectetur adipiscing elit.
 message FibonacciRequest {
+  message Inner1{
+    message Inner2{
+      string name_id = 1;
+    }
+    Inner2 nest2 = 1;
+  }
+  Inner1 nest1 = 1;
   // The nth term to retrieve in the Fibonacci sequence.
-  int32 value = 1;
+  int32 value = 2;
   // This is for testing the routing annotation.
-  string name = 2;
+  string name = 3;
   // This is for testing the routing annotation.
-  string parent = 3;
+  string parent_id = 4;
+  string another_parent_id = 5;
 }

--- a/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
@@ -21,6 +21,9 @@ function main() {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
+   */
+  // const nest1 = {}
+  /**
    *  The nth term to retrieve in the Fibonacci sequence.
    */
   // const value = 1234
@@ -31,7 +34,10 @@ function main() {
   /**
    *  This is for testing the routing annotation.
    */
-  // const parent = 'abc123'
+  // const parentId = 'abc123'
+  /**
+   */
+  // const anotherParentId = 'abc123'
 
   // Imports the Routingtest library
   const {TestServiceClient} = require('routingtest').v1;

--- a/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
@@ -21,6 +21,9 @@ function main() {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
+   */
+  // const nest1 = {}
+  /**
    *  The nth term to retrieve in the Fibonacci sequence.
    */
   // const value = 1234
@@ -31,7 +34,10 @@ function main() {
   /**
    *  This is for testing the routing annotation.
    */
-  // const parent = 'abc123'
+  // const parentId = 'abc123'
+  /**
+   */
+  // const anotherParentId = 'abc123'
 
   // Imports the Routingtest library
   const {TestServiceClient} = require('routingtest').v1;

--- a/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
+++ b/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
@@ -21,6 +21,9 @@ function main() {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
+   */
+  // const nest1 = {}
+  /**
    *  The nth term to retrieve in the Fibonacci sequence.
    */
   // const value = 1234
@@ -31,7 +34,10 @@ function main() {
   /**
    *  This is for testing the routing annotation.
    */
-  // const parent = 'abc123'
+  // const parentId = 'abc123'
+  /**
+   */
+  // const anotherParentId = 'abc123'
 
   // Imports the Routingtest library
   const {TestServiceClient} = require('routingtest').v1;

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -279,12 +279,14 @@ export class TestServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
+ * @param {google.routingtest.v1.FibonacciRequest.Inner1} request.nest1
  * @param {number} request.value
  *   The nth term to retrieve in the Fibonacci sequence.
  * @param {string} request.name
  *   This is for testing the routing annotation.
- * @param {string} request.parent
+ * @param {string} request.parentId
  *   This is for testing the routing annotation.
+ * @param {string} request.anotherParentId
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -341,7 +343,7 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){  
+      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
         Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})
       } else
       {}  
@@ -358,12 +360,14 @@ export class TestServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
+ * @param {google.routingtest.v1.FibonacciRequest.Inner1} request.nest1
  * @param {number} request.value
  *   The nth term to retrieve in the Fibonacci sequence.
  * @param {string} request.name
  *   This is for testing the routing annotation.
- * @param {string} request.parent
+ * @param {string} request.parentId
  *   This is for testing the routing annotation.
+ * @param {string} request.anotherParentId
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -420,8 +424,12 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('[^/]+').test(request.name!)){  
+      if(RegExp('[^/]+').test(request.name!)){
         Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})
+      } else
+      {}
+      if(RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
+        Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})
       } else
       {}  
         options.otherArgs.headers[
@@ -437,12 +445,14 @@ export class TestServiceClient {
  *
  * @param {Object} request
  *   The request object that will be sent.
+ * @param {google.routingtest.v1.FibonacciRequest.Inner1} request.nest1
  * @param {number} request.value
  *   The nth term to retrieve in the Fibonacci sequence.
  * @param {string} request.name
  *   This is for testing the routing annotation.
- * @param {string} request.parent
+ * @param {string} request.parentId
  *   This is for testing the routing annotation.
+ * @param {string} request.anotherParentId
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -499,15 +509,15 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.parent!)){  
-        Object.assign(routingParameter, { database: request.parent!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})
+      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
+        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})
       } else
-      if(RegExp('(?<database>projects)/[^/]+').test(request.parent!)){  
-        Object.assign(routingParameter, { database: request.parent!.match(RegExp('(?<database>projects/[^/]+)'))![0]})
+      if(RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
+        Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})
       } else
       {}
-      if(RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.parent!)){  
-        Object.assign(routingParameter, { routing_id: request.parent!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})
+      if(RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
+        Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})
       } else
       {}  
         options.otherArgs.headers[

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -261,9 +261,9 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- if method.dynamicRoutingRequestParams.length > 0 -%}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
-  {%- for sameParamArray in paramArray %}
-      if(RegExp('{{ sameParamArray.messageRegex | safe }}').test(request.{{ sameParamArray.fieldRetrieve }}!)){
-        Object.assign(routingParameter, { {{ sameParamArray.fieldSend }}: request.{{ sameParamArray.fieldRetrieve }}!.match(RegExp('{{ sameParamArray.namedSegment | safe }}'))![0]})
+  {%- for param in paramArray %}
+      if(RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve }}!)){
+        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})
       } else
   {%- endfor %}
       {}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -262,7 +262,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for sameParamArray in paramArray %}
-      if(RegExp('{{ sameParamArray.messageRegex | safe }}').test(request.{{ sameParamArray.fieldRetrieve }}!)){  
+      if(RegExp('{{ sameParamArray.messageRegex | safe }}').test(request.{{ sameParamArray.fieldRetrieve }}!)){
         Object.assign(routingParameter, { {{ sameParamArray.fieldSend }}: request.{{ sameParamArray.fieldRetrieve }}!.match(RegExp('{{ sameParamArray.namedSegment | safe }}'))![0]})
       } else
   {%- endfor %}

--- a/test-fixtures/protos/google/routingtest/v1/routingtest_service.proto
+++ b/test-fixtures/protos/google/routingtest/v1/routingtest_service.proto
@@ -52,6 +52,10 @@ service TestService {
       routing_parameters {
         field: "name"
       }
+      routing_parameters {
+        field: "name"
+        path_template: "{routing_id=**}"
+      }
     };
   };
 
@@ -64,15 +68,15 @@ service TestService {
     // This routing annotation is only for baseline testing purposes.
     option (google.api.routing) = {
       routing_parameters {
-        field: "parent",
+        field: "parent_id",
         path_template: "{database=projects/*}"
       }
       routing_parameters {
-        field: "parent",
+        field: "nest1.nest2.name_id",
         path_template: "{database=projects/*/databases/*}/documents"
       }
       routing_parameters {
-        field: "parent",
+        field: "another_parent_id",
         path_template: "{routing_id=projects/*}/databases/*/documents"
       }
     };
@@ -82,10 +86,18 @@ service TestService {
 // This is a message description.
 // Lorum ipsum dolor sit amet consectetur adipiscing elit.
 message FibonacciRequest {
+  message Inner1{
+    message Inner2{
+      string name_id = 1;
+    }
+    Inner2 nest2 = 1;
+  }
+  Inner1 nest1 = 1;
   // The nth term to retrieve in the Fibonacci sequence.
-  int32 value = 1;
+  int32 value = 2;
   // This is for testing the routing annotation.
-  string name = 2;
+  string name = 3;
   // This is for testing the routing annotation.
-  string parent = 3;
+  string parent_id = 4;
+  string another_parent_id = 5;
 }

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -669,17 +669,14 @@ export interface DynamicRoutingParameters {
 }
 
 // The field to be retrieved needs to be converted into camelCase
-export function convertFieldToCamelCase(
-  field: string
-) {
-  let camelCaseFields: string[] = []
-  let fieldsToRetrieve = field.split(".")
-  fieldsToRetrieve.forEach((field) => {
-    camelCaseFields.push(field.toCamelCase())
-  })
-  return camelCaseFields.join(".")
+export function convertFieldToCamelCase(field: string) {
+  const camelCaseFields: string[] = [];
+  const fieldsToRetrieve = field.split('.');
+  fieldsToRetrieve.forEach(field => {
+    camelCaseFields.push(field.toCamelCase());
+  });
+  return camelCaseFields.join('.');
 }
-
 
 // This parses a single Routing Parameter and returns a MapRoutingParameters interface.
 export function getSingleRoutingHeaderParam(

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -668,6 +668,19 @@ export interface DynamicRoutingParameters {
   namedSegment: string;
 }
 
+// The field to be retrieved needs to be converted into camelCase
+export function convertFieldToCamelCase(
+  field: string
+) {
+  let camelCaseFields: string[] = []
+  let fieldsToRetrieve = field.split(".")
+  fieldsToRetrieve.forEach((field) => {
+    camelCaseFields.push(field.toCamelCase())
+  })
+  return camelCaseFields.join(".")
+}
+
+
 // This parses a single Routing Parameter and returns a MapRoutingParameters interface.
 export function getSingleRoutingHeaderParam(
   rule: protos.google.api.IRoutingParameter
@@ -684,7 +697,7 @@ export function getSingleRoutingHeaderParam(
   } else if (!rule.pathTemplate) {
     // If there is no path template, then capture the full field from the message
     dynamicRoutingRule = {
-      fieldRetrieve: rule.field,
+      fieldRetrieve: convertFieldToCamelCase(rule.field),
       fieldSend: rule.field,
       messageRegex: '[^/]+',
       namedSegment: '[^/]+',
@@ -695,7 +708,7 @@ export function getSingleRoutingHeaderParam(
     return dynamicRoutingRule;
   } else {
     dynamicRoutingRule = {
-      fieldRetrieve: rule.field,
+      fieldRetrieve: convertFieldToCamelCase(rule.field),
       fieldSend: getNamedSegment(rule.pathTemplate)[1],
       messageRegex: convertTemplateToRegex(rule.pathTemplate),
       namedSegment: getNamedSegment(rule.pathTemplate)[3],

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -258,14 +258,8 @@ describe('src/schema/proto.ts', () => {
         convertFieldToCamelCase('name.name2.name3'),
         'name.name2.name3'
       );
-      assert.deepStrictEqual(
-        convertFieldToCamelCase(''),
-        ''
-      );
-      assert.deepStrictEqual(
-        convertFieldToCamelCase('parent_id'),
-        'parentId'
-      );
+      assert.deepStrictEqual(convertFieldToCamelCase(''), '');
+      assert.deepStrictEqual(convertFieldToCamelCase('parent_id'), 'parentId');
       assert.deepStrictEqual(
         convertFieldToCamelCase('app_profile_id'),
         'appProfileId'
@@ -276,7 +270,6 @@ describe('src/schema/proto.ts', () => {
       );
     });
   });
-
 
   describe('should get return an array from a single routing parameters rule', () => {
     it('should return an empty DynamicRoutingParameters interface if the annotation is malformed', () => {

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import * as protos from '../../../protos';
 import {
+  convertFieldToCamelCase,
   DynamicRoutingParameters,
   getDynamicHeaderRequestParams,
   getHeaderRequestParams,
@@ -191,7 +192,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
-            fieldRetrieve: 'app_profile_id',
+            fieldRetrieve: 'appProfileId',
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<profile_id>projects/[^/]+)',
@@ -237,7 +238,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
-            fieldRetrieve: 'app_profile_id',
+            fieldRetrieve: 'appProfileId',
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<profile_id>projects/[^/]+)',
@@ -250,6 +251,32 @@ describe('src/schema/proto.ts', () => {
       );
     });
   });
+
+  describe('should return a string set to camelCase', () => {
+    it('should return this to camelCase', () => {
+      assert.deepStrictEqual(
+        convertFieldToCamelCase('name.name2.name3'),
+        'name.name2.name3'
+      );
+      assert.deepStrictEqual(
+        convertFieldToCamelCase(''),
+        ''
+      );
+      assert.deepStrictEqual(
+        convertFieldToCamelCase('parent_id'),
+        'parentId'
+      );
+      assert.deepStrictEqual(
+        convertFieldToCamelCase('app_profile_id'),
+        'appProfileId'
+      );
+      assert.deepStrictEqual(
+        convertFieldToCamelCase('name.parent_id.another_parent_id'),
+        'name.parentId.anotherParentId'
+      );
+    });
+  });
+
 
   describe('should get return an array from a single routing parameters rule', () => {
     it('should return an empty DynamicRoutingParameters interface if the annotation is malformed', () => {
@@ -298,11 +325,11 @@ describe('src/schema/proto.ts', () => {
     });
     it('works with a basic path template', () => {
       const routingRule: protos.google.api.IRoutingParameter = {
-        field: 'app_profile_id',
+        field: 'app_profile_id.parent_id',
         pathTemplate: '{routing_id=**}',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: 'app_profile_id',
+        fieldRetrieve: 'appProfileId.parentId',
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>(?:/.*)?)',
         namedSegment: '(?<routing_id>.*)',
@@ -318,7 +345,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: '{routing_id=projects/*}/**',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: 'app_profile_id',
+        fieldRetrieve: 'appProfileId',
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
         namedSegment: '(?<routing_id>projects/[^/]+)',

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -209,6 +209,10 @@ describe('src/util.ts', () => {
         'display_video_360_advertiser_link'.toCamelCase(),
         'displayVideo_360AdvertiserLink'
       );
+      assert.deepStrictEqual(
+        'name?_(1)'.toCamelCase(),
+        'name_1'
+      );
     });
 
     it('should convert to PascalCase', () => {

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -209,10 +209,6 @@ describe('src/util.ts', () => {
         'display_video_360_advertiser_link'.toCamelCase(),
         'displayVideo_360AdvertiserLink'
       );
-      assert.deepStrictEqual(
-        'name?_(1)'.toCamelCase(),
-        'name_1'
-      );
     });
 
     it('should convert to PascalCase', () => {


### PR DESCRIPTION
Fix for Issue googleapis/google-cloud-node-core#579 

1) Fixed issue where the routing annotation request field was not being converted into camelCase (thus causing issues as Javascript converts all the fields to camelCase)
2) Added more unit tests to cover above use case + nested field case