### PR TITLE
fix: remove empty else

### DIFF
--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -506,11 +506,11 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
-        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
-
       if(RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
         Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})}
+
+      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
+        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
 
       if(RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
         Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})}

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -344,9 +344,8 @@ export class TestServiceClient {
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
       if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
-        Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})
-      } else
-      {}  
+        Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
+
         options.otherArgs.headers[
           'x-goog-request-params'
           ] = gax.routingHeader.fromParams(
@@ -425,13 +424,11 @@ export class TestServiceClient {
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
       if(RegExp('[^/]+').test(request.name!)){
-        Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})
-      } else
-      {}
+        Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})}
+
       if(RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
-        Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})
-      } else
-      {}  
+        Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})}
+
         options.otherArgs.headers[
           'x-goog-request-params'
           ] = gax.routingHeader.fromParams(
@@ -510,16 +507,14 @@ export class TestServiceClient {
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
       if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
-        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})
-      } else
+        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
+
       if(RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
-        Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})
-      } else
-      {}
+        Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})}
+
       if(RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
-        Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})
-      } else
-      {}  
+        Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})}
+
         options.otherArgs.headers[
           'x-goog-request-params'
           ] = gax.routingHeader.fromParams(

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -263,11 +263,9 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for param in paramArray %}
       if(RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve }}!)){
-        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})
-      } else
-  {%- endfor %}
-      {}
-{%- endfor %}  
+        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})}
+{% endfor -%}
+{%- endfor %}
         options.otherArgs.headers[
           'x-goog-request-params'
           ] = gax.routingHeader.fromParams(

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -642,16 +642,15 @@ export function getDynamicHeaderRequestParams(
       params[countOfParameters].push(getSingleRoutingHeaderParam(rule));
     }
     // If the 'fieldSend' is the same as the previous rule, then add it to the same array. Otherwise, start a new array.
-    // Add newer items to front of array due to "last one wins" rule.
     else if (
       getSingleRoutingHeaderParam(rule).fieldSend ===
       getSingleRoutingHeaderParam(rules[index - 1]).fieldSend
     ) {
-      params[countOfParameters].unshift(getSingleRoutingHeaderParam(rule));
+      params[countOfParameters].push(getSingleRoutingHeaderParam(rule));
     } else {
       countOfParameters++;
       params[countOfParameters] = [];
-      params[countOfParameters].unshift(getSingleRoutingHeaderParam(rule));
+      params[countOfParameters].push(getSingleRoutingHeaderParam(rule));
     }
   });
   return params;

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -145,11 +145,10 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
-            fieldRetrieve: 'database',
+            fieldRetrieve: 'name',
             fieldSend: 'routing_id',
-            messageRegex:
-              '(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
+            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
+            namedSegment: '(?<routing_id>projects/[^/]+)',
           },
           {
             fieldRetrieve: 'database',
@@ -158,10 +157,11 @@ describe('src/schema/proto.ts', () => {
             namedSegment: '(?<routing_id>.*)',
           },
           {
-            fieldRetrieve: 'name',
+            fieldRetrieve: 'database',
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+)',
+            messageRegex:
+              '(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
+            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
           },
         ],
       ];
@@ -225,15 +225,15 @@ describe('src/schema/proto.ts', () => {
           {
             fieldRetrieve: 'name',
             fieldSend: 'routing_id',
-            messageRegex:
-              'test/(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
+            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
+            namedSegment: '(?<routing_id>projects/[^/]+)',
           },
           {
             fieldRetrieve: 'name',
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+)',
+            messageRegex:
+              'test/(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
+            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
           },
         ],
         [


### PR DESCRIPTION
Removes empty `else{}` statement for multiple dynamic routing annotations