### PR TITLE
fix: add check for undefined routing header parameters

### DIFF
--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -343,7 +343,7 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
+      if((typeof request.name !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
         Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
 
         options.otherArgs.headers[
@@ -423,10 +423,10 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('[^/]+').test(request.name!)){
+      if((typeof request.name !== "undefined") && RegExp('[^/]+').test(request.name!)){
         Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})}
 
-      if(RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
+      if((typeof request.name !== "undefined") && RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
         Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})}
 
         options.otherArgs.headers[
@@ -506,13 +506,13 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if(RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
+      if((typeof request.parentId !== "undefined") && RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
         Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})}
 
-      if(RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
+      if((typeof request.nest1.nest2.nameId !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
         Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
 
-      if(RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
+      if((typeof request.anotherParentId !== "undefined") && RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
         Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})}
 
         options.otherArgs.headers[

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -262,7 +262,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for param in paramArray %}
-      if(RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve }}!)){
+      if((typeof request.{{ param.fieldRetrieve }} !== "undefined") && RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve }}!)){
         Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})}
 {% endfor -%}
 {%- endfor %}


### PR DESCRIPTION
This adds a check for dynamic routing annotations based on fields that may be undefined.

TODO: Add integration test to generator to test dynamic routing header with gapic-showcase.