### PR TITLE
fix: lint of assigned value not being used

### DIFF
--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -553,7 +553,8 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
         });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1135,7 +1135,8 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
         });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
+            const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.connect();
             const promise = new Promise((resolve, reject) => {

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -546,7 +546,8 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
         });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -553,7 +553,8 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
         });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1135,7 +1135,8 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
         });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
+            const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.connect();
             const promise = new Promise((resolve, reject) => {

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -583,7 +583,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
+            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase() }} = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}();


### PR DESCRIPTION
issue:https://github.com/googleapis/google-cloud-node-core/issues/578

lint complains that: "'expectedHeaderRequestParams' is assigned a value but never used" in bidi stream unit test
https://github.com/googleapis/gapic-generator-typescript/commit/1149cb16463531694c580034cc05b9f659a0a058