### PR TITLE
build: drop Node v10 and set minimum support to v12

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -39,7 +39,7 @@ branchProtectionRules:
     - showcase-test-application (12.x, js)
     - showcase-test-application (12.x, ts)
     - showcase-test-application (14.x, js)
-    - showcase-test-application (12.x, ts)
+    - showcase-test-application (14.x, ts)
 # List of explicit permissions to add (additive only)
 permissionRules:
     # Team slug to add to repository permissions

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -30,16 +30,16 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - "cla/google"
     - build
-    - lib-tests (10.x, dlp)
-    - lib-tests (10.x, kms)
-    - lib-tests (10.x, monitoring)
-    - lib-tests (10.x, showcase)
-    - lib-tests (10.x, texttospeech)
-    - lib-tests (10.x, translate)
-    - showcase-test-application (10.x, js)
-    - showcase-test-application (10.x, ts)
+    - lib-tests (12.x, dlp)
+    - lib-tests (12.x, kms)
+    - lib-tests (12.x, monitoring)
+    - lib-tests (12.x, showcase)
+    - lib-tests (12.x, texttospeech)
+    - lib-tests (12.x, translate)
+    - showcase-test-application (12.x, js)
+    - showcase-test-application (12.x, ts)
     - showcase-test-application (14.x, js)
-    - showcase-test-application (10.x, ts)
+    - showcase-test-application (12.x, ts)
 # List of explicit permissions to add (additive only)
 permissionRules:
     # Team slug to add to repository permissions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         # Test on the oldest and the newest supported version just in case
-        node-version: [10.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         test: [js, ts]
 
     steps:
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
         lib-name: [showcase, kms, translate, monitoring, dlp, texttospeech, showcase-legacy, compute]
     steps:
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "typescript": "~4.6.0"
   },
   "engines": {
-    "node": ">=v10.24.0"
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
Drops Node 10 support, which has been EOL for about 1 year. 🦕

See: [Google Cloud moves Cloud Client Libraries for Node.js support for version 10 to Maintenance](https://cloud.google.com/blog/products/application-development/google-cloud-sdk-moves-nodejs-10-to-maintenance-mode)