### PR TITLE
fix: use optional chaining for routing parameters

### DIFF
--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -343,7 +343,7 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if((typeof request.name !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
+      if ((typeof request.name !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
         Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
 
         options.otherArgs.headers[
@@ -423,10 +423,10 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if((typeof request.name !== "undefined") && RegExp('[^/]+').test(request.name!)){
+      if ((typeof request.name !== "undefined") && RegExp('[^/]+').test(request.name!)){
         Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})}
 
-      if((typeof request.name !== "undefined") && RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
+      if ((typeof request.name !== "undefined") && RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
         Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})}
 
         options.otherArgs.headers[
@@ -506,13 +506,13 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if((typeof request.parentId !== "undefined") && RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
+      if ((typeof request.parentId !== "undefined") && RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
         Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})}
 
-      if((typeof request.nest1.nest2.nameId !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1.nest2.nameId!)){
-        Object.assign(routingParameter, { database: request.nest1.nest2.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
+      if ((typeof request.nest1?.nest2?.nameId !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1?.nest2?.nameId!)){
+        Object.assign(routingParameter, { database: request.nest1?.nest2?.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
 
-      if((typeof request.anotherParentId !== "undefined") && RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
+      if ((typeof request.anotherParentId !== "undefined") && RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
         Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})}
 
         options.otherArgs.headers[

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -266,8 +266,8 @@ request.{{ oneComment.paramName.toCamelCase() }}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for param in paramArray %}
-      if((typeof request.{{ param.fieldRetrieve }} !== "undefined") && RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve }}!)){
-        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})}
+      if ((typeof request.{{ param.fieldRetrieve.join('?.') }} !== "undefined") && RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve.join('?.') }}!)){
+        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve.join('?.') }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})}
 {% endfor -%}
 {%- endfor %}
         options.otherArgs.headers[

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -664,7 +664,7 @@ export function getDynamicHeaderRequestParams(
 // messageRegex is the regex of the path template that the message field should match.
 // namedSegment is the regex capture of the named value of the field.
 export interface DynamicRoutingParameters {
-  fieldRetrieve: string;
+  fieldRetrieve: string[];
   fieldSend: string;
   messageRegex: string;
   namedSegment: string;
@@ -673,11 +673,14 @@ export interface DynamicRoutingParameters {
 // The field to be retrieved needs to be converted into camelCase
 export function convertFieldToCamelCase(field: string) {
   const camelCaseFields: string[] = [];
+  if (field === '') {
+    return camelCaseFields;
+  }
   const fieldsToRetrieve = field.split('.');
   fieldsToRetrieve.forEach(field => {
     camelCaseFields.push(field.toCamelCase());
   });
-  return camelCaseFields.join('.');
+  return camelCaseFields;
 }
 
 // This parses a single Routing Parameter and returns a MapRoutingParameters interface.
@@ -685,7 +688,7 @@ export function getSingleRoutingHeaderParam(
   rule: protos.google.api.IRoutingParameter
 ): DynamicRoutingParameters {
   let dynamicRoutingRule: DynamicRoutingParameters = {
-    fieldRetrieve: '',
+    fieldRetrieve: [],
     fieldSend: '',
     messageRegex: '',
     namedSegment: '',

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -130,7 +130,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
-            fieldRetrieve: '',
+            fieldRetrieve: [],
             fieldSend: '',
             messageRegex: '',
             namedSegment: '',
@@ -160,19 +160,19 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
-            fieldRetrieve: 'name',
+            fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<routing_id>projects/[^/]+)',
           },
           {
-            fieldRetrieve: 'database',
+            fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>(?:/.*)?)',
             namedSegment: '(?<routing_id>.*)',
           },
           {
-            fieldRetrieve: 'database',
+            fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
             messageRegex:
               '(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
@@ -199,7 +199,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
-            fieldRetrieve: 'name',
+            fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<routing_id>projects/[^/]+)',
@@ -207,7 +207,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
-            fieldRetrieve: 'appProfileId',
+            fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<profile_id>projects/[^/]+)',
@@ -238,13 +238,13 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
-            fieldRetrieve: 'name',
+            fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<routing_id>projects/[^/]+)',
           },
           {
-            fieldRetrieve: 'name',
+            fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex:
               'test/(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
@@ -253,7 +253,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
-            fieldRetrieve: 'appProfileId',
+            fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
             namedSegment: '(?<profile_id>projects/[^/]+)',
@@ -269,19 +269,21 @@ describe('src/schema/proto.ts', () => {
 
   describe('should return a string set to camelCase', () => {
     it('should return this to camelCase', () => {
-      assert.deepStrictEqual(
-        convertFieldToCamelCase('name.name2.name3'),
-        'name.name2.name3'
-      );
-      assert.deepStrictEqual(convertFieldToCamelCase(''), '');
-      assert.deepStrictEqual(convertFieldToCamelCase('parent_id'), 'parentId');
-      assert.deepStrictEqual(
-        convertFieldToCamelCase('app_profile_id'),
-        'appProfileId'
-      );
+      assert.deepStrictEqual(convertFieldToCamelCase('name.name2.name3'), [
+        'name',
+        'name2',
+        'name3',
+      ]);
+      assert.deepStrictEqual(convertFieldToCamelCase(''), []);
+      assert.deepStrictEqual(convertFieldToCamelCase('parent_id'), [
+        'parentId',
+      ]);
+      assert.deepStrictEqual(convertFieldToCamelCase('app_profile_id'), [
+        'appProfileId',
+      ]);
       assert.deepStrictEqual(
         convertFieldToCamelCase('name.parent_id.another_parent_id'),
-        'name.parentId.anotherParentId'
+        ['name', 'parentId', 'anotherParentId']
       );
     });
   });
@@ -293,7 +295,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: 'test/database',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: '',
+        fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
         namedSegment: '',
@@ -306,7 +308,7 @@ describe('src/schema/proto.ts', () => {
     it('works with no parameters', () => {
       const routingRule: protos.google.api.IRoutingParameter = {};
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: '',
+        fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
         namedSegment: '',
@@ -321,7 +323,7 @@ describe('src/schema/proto.ts', () => {
         field: 'name',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: 'name',
+        fieldRetrieve: ['name'],
         fieldSend: 'name',
         messageRegex: '[^/]+',
         namedSegment: '[^/]+',
@@ -337,7 +339,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: '{routing_id=**}',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: 'appProfileId.parentId',
+        fieldRetrieve: ['appProfileId', 'parentId'],
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>(?:/.*)?)',
         namedSegment: '(?<routing_id>.*)',
@@ -353,7 +355,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: '{routing_id=projects/*}/**',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
-        fieldRetrieve: 'appProfileId',
+        fieldRetrieve: ['appProfileId'],
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
         namedSegment: '(?<routing_id>projects/[^/]+)',


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#572. The generated code for routing headers should use optional chaining (`?.`) instead of just dots for nested field names. Currently, it breaks compilation for Cloud Run v2 client library.

The change includes a small refactor: it's not correct to concatenate a dot-separated name in the generator code because, by design, the generator has no knowledge of the target language. All language specific stuff must be limited to the templates. So now the generator will only keep the list of camelCased field names, that will be joined (with `?.`) in the template.