### PR TITLE
fix: unit tests for LRO and Location need async iteration stub

### DIFF
--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -145,6 +145,8 @@ function stubPageStreamingCall<ResponseType>(responses?: ResponseType[], error?:
     }
     return sinon.stub().returns(mockStream);
 }
+{%- endif %}
+{%- if (service.paging.length > 0 or service.LongRunningOperationsMixin > 0 or service.LocationMixin > 0) %}
 
 function stubAsyncIterationCall<ResponseType>(responses?: ResponseType[], error?: Error) {
     let counter = 0;


### PR DESCRIPTION
LRO and Location mixins have List methods and use the stub for async iteration in the generated unit tests. If an API does not have any list methods at all, this stub is not generated, which cases a failure:

```
test/gapic_completion_v4beta1.ts:453:78 - error TS2304: Cannot find name 'stubAsyncIterationCall'.

453             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(expectedResponse);
                                                                                 ~~~~~~~~~~~~~~~~~~~~~~
```

I'm not adding a new baseline test here since just having a baseline test (without compiling the result) won't catch this, and adding a baseline to run it in CI will expand our already huge CI run even more.