### PR TITLE
fix: follow case convention #1149 in generated tests

### DIFF
--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -926,10 +926,10 @@ describe('v1beta1.NamingClient', () => {
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {otherArgs: {headers: {}}};;
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.createABCDESomething = stubSimpleCall(expectedResponse);
+            client.innerApiCalls.createAbcdeSomething = stubSimpleCall(expectedResponse);
             const [response] = await client.createABCDESomething(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createABCDESomething as SinonStub)
+            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -942,7 +942,7 @@ describe('v1beta1.NamingClient', () => {
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {otherArgs: {headers: {}}};;
             const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
-            client.innerApiCalls.createABCDESomething = stubSimpleCallWithCallback(expectedResponse);
+            client.innerApiCalls.createAbcdeSomething = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createABCDESomething(
                     request,
@@ -956,7 +956,7 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createABCDESomething as SinonStub)
+            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
@@ -969,9 +969,9 @@ describe('v1beta1.NamingClient', () => {
             const request = generateSampleMessage(new protos.google.protobuf.Empty());
             const expectedOptions = {otherArgs: {headers: {}}};;
             const expectedError = new Error('expected');
-            client.innerApiCalls.createABCDESomething = stubSimpleCall(undefined, expectedError);
+            client.innerApiCalls.createAbcdeSomething = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createABCDESomething(request), expectedError);
-            assert((client.innerApiCalls.createABCDESomething as SinonStub)
+            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -848,7 +848,7 @@ export class {{ service.name }}Client {
     Transform{
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
-    const defaultCallSettings = this._defaults['{{method.name.toCamelCase()}}'];
+    const defaultCallSettings = this._defaults['{{method.name.toCamelCase(true)}}'];
     const callSettings = defaultCallSettings.merge(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}
@@ -882,7 +882,7 @@ export class {{ service.name }}Client {
     {%- endif %}
     request = request || {};
     {{ util.buildHeaderRequestParam(method) }}
-    const defaultCallSettings = this._defaults['{{method.name.toCamelCase()}}'];
+    const defaultCallSettings = this._defaults['{{method.name.toCamelCase(true)}}'];
     const callSettings = defaultCallSettings.merge(options);
     this.{{ id.get("initialize") }}();
     {%- if method.options and method.options.deprecated %}

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -275,7 +275,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
@@ -285,7 +285,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- else %}
             assert.deepStrictEqual(response, expectedResponse);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -300,7 +300,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCallWithCallback(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.{{ method.name.toCamelCase() }}(
                     request,
@@ -317,7 +317,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
@@ -332,12 +332,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -371,14 +371,14 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(expectedResponse);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
             const [response] = await operation.promise();
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -391,7 +391,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCallWithCallback(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.{{ method.name.toCamelCase() }}(
                     request,
@@ -411,7 +411,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
@@ -424,12 +424,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -442,13 +442,13 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubLongRunningCall(undefined, undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
             await assert.rejects(operation.promise(), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -503,7 +503,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubServerStreamingCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(expectedResponse);
             const stream = client.{{ method.name.toCamelCase() }}(request);
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
@@ -518,7 +518,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions));
         });
 
@@ -531,7 +531,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubServerStreamingCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}(request);
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
@@ -545,7 +545,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions));
         });
 
@@ -585,7 +585,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubBidiStreamingCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubBidiStreamingCall(expectedResponse);
             const stream = client.{{ method.name.toCamelCase() }}();
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
@@ -602,7 +602,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
@@ -616,7 +616,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubBidiStreamingCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}();
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
@@ -632,7 +632,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(null));
             assert.deepStrictEqual(((stream as unknown as PassThrough)
                 ._transform as SinonStub).getCall(0).args[0], request);
@@ -650,7 +650,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             {{ util.initResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubClientStreamingCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
                 stream = client.{{ method.name.toCamelCase() }}(
@@ -669,7 +669,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(null, {} /*, callback defined above */));
             assert.deepStrictEqual((stream!._transform as SinonStub).getCall(0).args[0], request);
         });
@@ -682,7 +682,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubClientStreamingCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
                 stream = client.{{ method.name.toCamelCase() }}(
@@ -700,7 +700,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(null, {} /*, callback defined above */));
         });
     });
@@ -721,13 +721,13 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -743,7 +743,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCallWithCallback(expectedResponse);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.{{ method.name.toCamelCase() }}(
                     request,
@@ -760,7 +760,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
@@ -776,12 +776,12 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method) -}}
             {{ util.initRequestOptions(method) }}
             const expectedError = new Error('expected');
-            client.innerApiCalls.{{ method.name.toCamelCase() }} = stubSimpleCall(undefined, expectedError);
+            client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase() }} as SinonStub)
+            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
                 .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
@@ -816,7 +816,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
-                .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase() }}, request));
+                .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase(true) }}, request));
 {%- if method.headerRequestParams.length > 0 %}
             assert.strictEqual(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
@@ -856,7 +856,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
-                .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase() }}, request));
+                .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase(true) }}, request));
 {%- if method.headerRequestParams.length > 0 %}
             assert.strictEqual(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)


### PR DESCRIPTION
This should fix osconfig tests.