### PR TITLE
fix: proper processing of routing headers

### DIFF
--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -342,14 +342,22 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if ((typeof request.name !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.name!)){
-        Object.assign(routingParameter, { database: request.name!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
+    {
+      const fieldValue = request.name;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)/documents'));
+        if (match) {
+          const parameterValue = match.groups?.['database'] ?? fieldValue;
+          Object.assign(routingParameter, { database: parameterValue });
+        }
+      }
+    }
 
-        options.otherArgs.headers[
-          'x-goog-request-params'
-          ] = gax.routingHeader.fromParams(
-            routingParameter
-          );
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams(
+      routingParameter
+    );
     this.initialize();
     return this.innerApiCalls.fastFibonacci(request, options, callback);
   }
@@ -422,17 +430,33 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if ((typeof request.name !== "undefined") && RegExp('[^/]+').test(request.name!)){
-        Object.assign(routingParameter, { name: request.name!.match(RegExp('[^/]+'))![0]})}
+    {
+      const fieldValue = request.name;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<name>.*)'));
+        if (match) {
+          const parameterValue = match.groups?.['name'] ?? fieldValue;
+          Object.assign(routingParameter, { name: parameterValue });
+        }
+      }
+    }
 
-      if ((typeof request.name !== "undefined") && RegExp('(?<routing_id>(?:/.*)?)').test(request.name!)){
-        Object.assign(routingParameter, { routing_id: request.name!.match(RegExp('(?<routing_id>.*)'))![0]})}
+    {
+      const fieldValue = request.name;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<routing_id>(?:.*)?)'));
+        if (match) {
+          const parameterValue = match.groups?.['routing_id'] ?? fieldValue;
+          Object.assign(routingParameter, { routing_id: parameterValue });
+        }
+      }
+    }
 
-        options.otherArgs.headers[
-          'x-goog-request-params'
-          ] = gax.routingHeader.fromParams(
-            routingParameter
-          );
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams(
+      routingParameter
+    );
     this.initialize();
     return this.innerApiCalls.randomFibonacci(request, options, callback);
   }
@@ -505,20 +529,44 @@ export class TestServiceClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
-      if ((typeof request.parentId !== "undefined") && RegExp('(?<database>projects)/[^/]+').test(request.parentId!)){
-        Object.assign(routingParameter, { database: request.parentId!.match(RegExp('(?<database>projects/[^/]+)'))![0]})}
+    {
+      const fieldValue = request.parentId;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<database>projects/[^/]+)'));
+        if (match) {
+          const parameterValue = match.groups?.['database'] ?? fieldValue;
+          Object.assign(routingParameter, { database: parameterValue });
+        }
+      }
+    }
 
-      if ((typeof request.nest1?.nest2?.nameId !== "undefined") && RegExp('(?<database>projects)/[^/]+/databases/[^/]+/documents').test(request.nest1?.nest2?.nameId!)){
-        Object.assign(routingParameter, { database: request.nest1?.nest2?.nameId!.match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)'))![0]})}
+    {
+      const fieldValue = request.nest1?.nest2?.nameId;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<database>projects/[^/]+/databases/[^/]+)/documents'));
+        if (match) {
+          const parameterValue = match.groups?.['database'] ?? fieldValue;
+          Object.assign(routingParameter, { database: parameterValue });
+        }
+      }
+    }
 
-      if ((typeof request.anotherParentId !== "undefined") && RegExp('(?<routing_id>projects)/[^/]+/databases/[^/]+/documents').test(request.anotherParentId!)){
-        Object.assign(routingParameter, { routing_id: request.anotherParentId!.match(RegExp('(?<routing_id>projects/[^/]+)'))![0]})}
+    {
+      const fieldValue = request.anotherParentId;
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('(?<routing_id>projects/[^/]+)/databases/[^/]+/documents'));
+        if (match) {
+          const parameterValue = match.groups?.['routing_id'] ?? fieldValue;
+          Object.assign(routingParameter, { routing_id: parameterValue });
+        }
+      }
+    }
 
-        options.otherArgs.headers[
-          'x-goog-request-params'
-          ] = gax.routingHeader.fromParams(
-            routingParameter
-          );
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams(
+      routingParameter
+    );
     this.initialize();
     return this.innerApiCalls.slowFibonacci(request, options, callback);
   }

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -341,7 +341,8 @@ export class TestServiceClient {
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    let routingParameter = {};
     {
       const fieldValue = request.name;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -352,7 +353,6 @@ export class TestServiceClient {
         }
       }
     }
-
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams(
@@ -429,7 +429,8 @@ export class TestServiceClient {
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    let routingParameter = {};
     {
       const fieldValue = request.name;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -440,7 +441,6 @@ export class TestServiceClient {
         }
       }
     }
-
     {
       const fieldValue = request.name;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -451,7 +451,6 @@ export class TestServiceClient {
         }
       }
     }
-
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams(
@@ -528,7 +527,8 @@ export class TestServiceClient {
     }
     options = options || {};
     options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};let routingParameter = {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    let routingParameter = {};
     {
       const fieldValue = request.parentId;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -539,7 +539,6 @@ export class TestServiceClient {
         }
       }
     }
-
     {
       const fieldValue = request.nest1?.nest2?.nameId;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -550,7 +549,6 @@ export class TestServiceClient {
         }
       }
     }
-
     {
       const fieldValue = request.anotherParentId;
       if (fieldValue !== undefined && fieldValue !== null) {
@@ -561,7 +559,6 @@ export class TestServiceClient {
         }
       }
     }
-
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams(

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -141,7 +141,11 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.name = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -164,7 +168,11 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.name = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -198,7 +206,11 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.name = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -220,6 +232,8 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            // path template: {database=projects/*/databases/*}/documents
+            request.name = 'projects/value/databases/value/documents';
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.fastFibonacci(request), expectedError);
@@ -234,7 +248,14 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template is empty
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['name'] = 'value';
+            // path template: {routing_id=**}
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['routing_id'] = 'value';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -257,7 +278,14 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template is empty
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['name'] = 'value';
+            // path template: {routing_id=**}
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['routing_id'] = 'value';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -291,7 +319,14 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template is empty
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['name'] = 'value';
+            // path template: {routing_id=**}
+            request.name = 'value';
+            expectedHeaderRequestParamsObj['routing_id'] = 'value';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -313,6 +348,10 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            // path template is empty
+            request.name = 'value';
+            // path template: {routing_id=**}
+            request.name = 'value';
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.randomFibonacci(request), expectedError);
@@ -327,7 +366,19 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*}
+            request.parentId = 'projects/value';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
+            request.nest1 = {};
+            request.nest1.nest2 = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            // path template: {routing_id=projects/*}/databases/*/documents
+            request.anotherParentId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -350,7 +401,19 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*}
+            request.parentId = 'projects/value';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
+            request.nest1 = {};
+            request.nest1.nest2 = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            // path template: {routing_id=projects/*}/databases/*/documents
+            request.anotherParentId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -384,7 +447,19 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParams = "";
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            // path template: {database=projects/*}
+            request.parentId = 'projects/value';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
+            request.nest1 = {};
+            request.nest1.nest2 = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            // path template: {routing_id=projects/*}/databases/*/documents
+            request.anotherParentId = 'projects/value/databases/value/documents';
+            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -406,6 +481,14 @@ describe('v1.TestServiceClient', () => {
         });
             client.initialize();
             const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            // path template: {database=projects/*}
+            request.parentId = 'projects/value';
+            request.nest1 = {};
+            request.nest1.nest2 = {};
+            // path template: {database=projects/*/databases/*}/documents
+            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
+            // path template: {routing_id=projects/*}/databases/*/documents
+            request.anotherParentId = 'projects/value/databases/value/documents';
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.slowFibonacci(request), expectedError);

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -266,15 +266,23 @@ request.{{ oneComment.paramName.toCamelCase() }}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for param in paramArray %}
-      if ((typeof request.{{ param.fieldRetrieve.join('?.') }} !== "undefined") && RegExp('{{ param.messageRegex | safe }}').test(request.{{ param.fieldRetrieve.join('?.') }}!)){
-        Object.assign(routingParameter, { {{ param.fieldSend }}: request.{{ param.fieldRetrieve.join('?.') }}!.match(RegExp('{{ param.namedSegment | safe }}'))![0]})}
+    {
+      const fieldValue = request.{{ param.fieldRetrieve.join('?.') }};
+      if (fieldValue !== undefined && fieldValue !== null) {
+        const match = fieldValue.toString().match(RegExp('{{ param.messageRegex | safe }}'));
+        if (match) {
+          const parameterValue = match.groups?.['{{ param.fieldSend }}'] ?? fieldValue;
+          Object.assign(routingParameter, { {{ param.fieldSend }}: parameterValue });
+        }
+      }
+    }
 {% endfor -%}
 {%- endfor %}
-        options.otherArgs.headers[
-          'x-goog-request-params'
-          ] = gax.routingHeader.fromParams(
-            routingParameter
-          );
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams(
+      routingParameter
+    );
 {%- endif %}
 {%- if method.headerRequestParams.length > 0 %}
     options.otherArgs.headers[

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -261,8 +261,8 @@ request.{{ oneComment.paramName.toCamelCase() }}
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-{#-If dynamic routing annotation exists and is non empty, then send dynamic routing header-#}
-{%- if method.dynamicRoutingRequestParams.length > 0 -%}
+{#- if dynamic routing annotation exists and is non empty, then send dynamic routing header #}
+{%- if method.dynamicRoutingRequestParams.length > 0 %}
     let routingParameter = {};
 {%- for paramArray in method.dynamicRoutingRequestParams %}
   {%- for param in paramArray %}
@@ -276,15 +276,15 @@ request.{{ oneComment.paramName.toCamelCase() }}
         }
       }
     }
-{% endfor -%}
+{%- endfor %}
 {%- endfor %}
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams(
       routingParameter
     );
-{%- endif %}
-{%- if method.headerRequestParams.length > 0 %}
+{%- elif method.headerRequestParams.length > 0 %}
+{#- either dynamic routing parameters are set, or implicit parameters, but not both #}
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = gax.routingHeader.fromParams({
@@ -295,29 +295,13 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endif %}
 {%- endmacro -%}
 
-{%- macro initRequest(method) -%}
+{%- macro initRequestWithHeaderParam(method, skipExpectedVariable='') -%}
+{# initializing request object for generated unit tests -#}
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
-{%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
+{%- if method.headerRequestParams.length > 0 %}
+{#- generated request object for implicit routing headers -#}
 {%- set expectedRequestParamJoiner = joiner("&") -%}
-{%- set expectedRequestParams = "" %}
-{%- for requestParam in method.headerRequestParams %}
-{%- set chain = "request" -%}
-{%- set originalName = "" -%}
-{%- for field in requestParam.slice(0, -1) %}
-            {{ chain }}.{{ field.toCamelCase() }} = {};
-{%- set chain = chain + "." + field.toCamelCase() -%}
-{%- set originalName = originalName + field + "." -%}
-{%- endfor %}
-            {{ chain }}.{{ requestParam.slice(-1)[0].toCamelCase() }} = '';
-{%- endfor %}
-{%- endif %}
-{%- endmacro -%}
-
-{%- macro initRequestWithHeaderParam(method) -%}
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
-{%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-{%- set expectedRequestParamJoiner = joiner("&") -%}
-{%- set expectedRequestParams = "" %}
+{%- set expectedRequestParams = "" -%}
 {%- for requestParam in method.headerRequestParams %}
 {%- set chain = "request" -%}
 {%- set originalName = "" -%}
@@ -330,7 +314,40 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- set expectedRequestParams = expectedRequestParams + expectedRequestParamJoiner() +
                                 originalName + requestParam.slice(-1)[0] + "=" -%}
 {%- endfor %}
+{%- if not skipExpectedVariable %}
             const expectedHeaderRequestParams = "{{ expectedRequestParams | safe }}";
+{%- endif %}
+{%- elif method.dynamicRoutingRequestParams.length > 0 %}
+{#- generated request object for dynamic routing headers -#}
+{%- if not skipExpectedVariable %}
+            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+{%- endif %}
+{%- for paramArray in method.dynamicRoutingRequestParams %}
+{%- for param in paramArray %}
+{%- set chain = "request" -%}
+{%- for field in param.fieldRetrieve.slice(0, -1) %}
+            {{ chain }}.{{ field.toCamelCase() }} = {};
+{%- set chain = chain + "." + field.toCamelCase() -%}
+{%- endfor %}
+            {%- if param.pathTemplate %}
+            // path template: {{ param.pathTemplate }}
+            {#- generate real-looking value for the field that would match the path template -#}
+            {%- set fieldValue = param.pathTemplate.replace(r/{\w+}/, '{name=*}').replace(r/{\w+=/, '').replace('}', '').replace(r/\*+/g, 'value') -%}
+            {%- set parameterValue = param.pathTemplate.replace(r/{\w+}/, '{name=*}').replace(r/.*{\w+=/, '').replace(r/}.*/, '').replace(r/\*+/g, 'value').replace(r/\//g, '%2F') -%}
+            {%- else %}
+            // path template is empty
+            {%- set fieldValue = 'value' -%}
+            {%- set parameterValue = 'value' -%}
+            {%- endif %}
+            {{ chain }}.{{ param.fieldRetrieve.slice(-1)[0].toCamelCase() }} = '{{ fieldValue }}';
+{%- if not skipExpectedVariable %}
+            expectedHeaderRequestParamsObj['{{ param.fieldSend }}'] = '{{ parameterValue }}';
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+{%- if not skipExpectedVariable %}
+            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
+{%- endif %}
 {%- endif %}
 {%- endmacro -%}
 

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -349,7 +349,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequest(method) }}
+            {{ util.initRequestWithHeaderParam(method, skipExpectedVariable='true') }}
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
@@ -555,7 +555,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequest(method) }}
+            {{ util.initRequestWithHeaderParam(method, skipExpectedVariable='true') }}
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.{{ method.name.toCamelCase() }}(request);

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -663,6 +663,8 @@ export function getDynamicHeaderRequestParams(
 
 // This is what each routing annotation is translated into.
 export interface DynamicRoutingParameters {
+  // The original path template, unchanged
+  pathTemplate: string;
   // The name of request field to apply the rules to
   fieldRetrieve: string[];
   // The name of the field to send in the header
@@ -689,6 +691,7 @@ export function getSingleRoutingHeaderParam(
   rule: protos.google.api.IRoutingParameter
 ): DynamicRoutingParameters {
   let dynamicRoutingRule: DynamicRoutingParameters = {
+    pathTemplate: rule.pathTemplate ?? '',
     fieldRetrieve: [],
     fieldSend: '',
     messageRegex: '',
@@ -699,6 +702,7 @@ export function getSingleRoutingHeaderParam(
   } else if (!rule.pathTemplate) {
     // If there is no path template, then capture the full field from the message
     dynamicRoutingRule = {
+      pathTemplate: '',
       fieldRetrieve: convertFieldToCamelCase(rule.field),
       fieldSend: rule.field,
       messageRegex: `(?<${rule.field}>.*)`,
@@ -712,6 +716,7 @@ export function getSingleRoutingHeaderParam(
     }
     const {fieldSend, messageRegex} = processedPathTemplate;
     dynamicRoutingRule = {
+      pathTemplate: rule.pathTemplate,
       fieldRetrieve: convertFieldToCamelCase(rule.field),
       fieldSend,
       messageRegex,

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -221,6 +221,11 @@ export function getResourceNameByPattern(pattern: string): string {
   return name.join('_');
 }
 
+// For the given path template, extract the field name and prepare the regular
+// expression to extract the field value.
+// For example, for "/projects/{project=*}", the field name
+// is "project", and the regex will extract the part of the string that
+// corresponds to the curly brackets.
 export function processPathTemplate(
   pathTemplate: string
 ): {fieldSend: string; messageRegex: string} | null {

--- a/typescript/src/util.ts
+++ b/typescript/src/util.ts
@@ -221,144 +221,35 @@ export function getResourceNameByPattern(pattern: string): string {
   return name.join('_');
 }
 
-export function isStar(pattern: string): boolean {
-  return pattern === '*';
-}
+export function processPathTemplate(
+  pathTemplate: string
+): {fieldSend: string; messageRegex: string} | null {
+  // Find the template part
+  const patternMatch = pathTemplate.match(/{(\w+)[=}]/);
+  if (!patternMatch) {
+    return null;
+  }
+  const fieldSend = patternMatch[1];
 
-export function isDoubleStar(pattern: string): boolean {
-  return pattern === '**';
-}
-
-// This intakes an array of strings and checks if there is at least one and only one named segment.
-// Named segments can be resource names or wildcards.
-export function checkIfArrayContainsOnlyOneNamedSegment(
-  pattern: string[]
-): boolean {
-  let countOfNamedSegments = 0;
-  // Checks that resources are named
-  const regexNamed = new RegExp(/^.+=.+/);
-  const regexWildcard = new RegExp(/^{[a-zA-Z\d-]+}/);
-  pattern.forEach(element => {
-    if (regexNamed.test(element) || regexWildcard.test(element)) {
-      countOfNamedSegments++;
-    }
+  let messageRegex = pathTemplate;
+  messageRegex = messageRegex.replace(/{(\w+)}/, (_match, group) => {
+    return `{${group}=*}`;
   });
-  return countOfNamedSegments === 1;
-}
-
-// This takes in a path template segment and converts it into regex.
-export function convertSegmentToRegex(pattern: string): string {
-  const curlyBraceRegex = new RegExp(/{(.[^}]+)/);
-  const namedResourceRegex = new RegExp(/=/);
-  const getBeforeAfterEqualsSign = new RegExp(/([^=]*)=(.*)/);
-  if (isStar(pattern) || isStar(pattern.replaceAll('}', ''))) {
-    return '[^/]+';
-  }
-  // If segment is a double-wildcard, then it will 'eat' the precending '/'.
-  else if (isDoubleStar(pattern) || isDoubleStar(pattern.replaceAll('}', ''))) {
-    return '(?:/.*)?';
-  }
-  // If segment has a starting curly brace, and is not named, then it is a wildcard.
-  else if (curlyBraceRegex.test(pattern) && !namedResourceRegex.test(pattern)) {
-    // Strip any curly braces
-    const newPattern = pattern.replaceAll('}', '').replaceAll('{', '');
-    return '(?<' + newPattern + '>[^/]+)';
-  }
-  // If segment contains named resource, then the resource could be a wildcard or
-  // a collectionId
-  else if (curlyBraceRegex.test(pattern) && namedResourceRegex.test(pattern)) {
-    // Strip any curly braces
-    const newPattern = pattern.replaceAll('}', '').replaceAll('{', '');
-    const elements = newPattern.match(getBeforeAfterEqualsSign);
-    const name = '(?<' + elements![1] + '>';
-    const resource = elements![2];
-    if (isStar(resource)) {
-      return name + '[^/]+)';
-    } else if (isDoubleStar(resource)) {
-      return name + '(?:/.*)?' + ')';
-    } else {
-      return name + resource + ')';
+  messageRegex = messageRegex.replace(/(\/?)(\*+)/g, (_match, slash, stars) => {
+    if (stars === '*') {
+      return slash + '[^/]+';
     }
-  }
-  // If segment is just a CollectionId, then the regex equivalent is itself.
-  else if (pattern.match(/[a-zA-Z_-]+/)) {
-    return pattern;
-  } else {
-    return '';
-  }
-}
-
-// This takes in a full path template and converts it into regex.
-export function convertTemplateToRegex(pattern: string): string {
-  const splitStrings = pattern.split('/');
-  const regexStrings: string[] = [];
-  while (splitStrings.length > 0) {
-    const item = splitStrings.shift();
-    const itemToRegex = convertSegmentToRegex(item!);
-    // If item is a double-wildcard, then do not include a '/' separator as a double-wildcard may be empty.
-    const doubleWildcardRegex = new RegExp(/\*\*/);
-    if (!doubleWildcardRegex.test(item!)) {
-      regexStrings.push('/');
+    if (slash === '/') {
+      return '(?:/.*)?';
     }
-    regexStrings.push(itemToRegex);
-  }
-  let helperString = regexStrings.join('');
-  // Check if string begins with separator
-  const separatorRegex = new RegExp(/^\//);
-  if (separatorRegex.test(helperString)) {
-    helperString = helperString.substring(1);
-  }
-  return helperString;
-}
-
-// This intakes a path template and returns an array where the first element is the full named
-// segment, the second element is the name of the segment, the third element is the segment itself,
-// and the fourth element is the named capture regex of the named segement.
-// If the path template does not contain exactly one named segment, this function will return an empty array.
-export function getNamedSegment(pattern: string): string[] {
-  // Named segment in path template will always be contained within curly braces, e.g. '{}'
-  const curlyBraceRegex = new RegExp(/[^{}]+(?=})/);
-  // Named segment may just be a collection id
-  const collectionIdRegex = new RegExp(/{.*}/);
-  const namedSegmentWithoutCurlyBraces = pattern.match(curlyBraceRegex);
-  const namedSegmentWithCurlyBraces = pattern.match(collectionIdRegex);
-  if (
-    !namedSegmentWithoutCurlyBraces ||
-    !namedSegmentWithCurlyBraces ||
-    !checkIfArrayContainsOnlyOneNamedSegment(namedSegmentWithCurlyBraces)
-  ) {
-    return [];
-  }
-  const namedSegment = [];
-  // This contains the full named segment.
-  namedSegment.push(namedSegmentWithoutCurlyBraces[0]);
-  // This extracts the name from the named segment.
-  const nameOfSegmentRegex = new RegExp(/^(.*?)=/);
-  const nameOfSegment = namedSegmentWithoutCurlyBraces[0].match(
-    nameOfSegmentRegex
+    return '(?:.*)?';
+  });
+  messageRegex = messageRegex.replace(
+    /{(\w+)=([^}]+)}/,
+    (_match, before, after) => {
+      return `(?<${before}>${after})`;
+    }
   );
-  // // If the segment is just a collection id (e.g., {database}), then the name of the segment is itself, and the segment is a wildcard.
-  if (!nameOfSegmentRegex.test(namedSegmentWithoutCurlyBraces[0])) {
-    namedSegment.push(namedSegmentWithoutCurlyBraces[0]);
-    namedSegment.push('*');
-    namedSegment.push('[^/]+');
-  } else {
-    namedSegment.push(nameOfSegment![1]);
-    // This extracts the segment from the named segement.
-    const extractNameRegex = new RegExp(nameOfSegment![1] + '=(.*)');
-    const segment = namedSegmentWithoutCurlyBraces[0].match(
-      extractNameRegex
-    )![1];
-    namedSegment.push(segment);
-    // This converts the full named segment into regex.
-    // Special case for double wildcard in a named segment as we
-    // do want to capture it for a named segment.
-    let resourceRegex = convertTemplateToRegex(segment);
-    if (isDoubleStar(segment) || isDoubleStar(segment.replaceAll('}', ''))) {
-      resourceRegex = '.*';
-    }
-    const fullRegex = '(?<' + nameOfSegment![1] + '>' + resourceRegex + ')';
-    namedSegment.push(fullRegex);
-  }
-  return namedSegment;
+
+  return {fieldSend, messageRegex};
 }

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -34,24 +34,23 @@ describe('src/schema/proto.ts', () => {
       const httpRule: protos.google.api.IHttpRule = {
         post: '{=abc/*/d/*/ef/}',
       };
-      assert.deepStrictEqual([], getHeaderRequestParams(httpRule));
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), []);
     });
 
     it('works only one parameter', () => {
       const httpRule: protos.google.api.IHttpRule = {
         post: '{param1=abc/*/d/*/ef/}',
       };
-      assert.deepStrictEqual([['param1']], getHeaderRequestParams(httpRule));
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), [['param1']]);
     });
 
     it('works with multiple parameter', () => {
       const httpRule: protos.google.api.IHttpRule = {
         post: '{param1.param2.param3=abc/*/d/*/ef/}',
       };
-      assert.deepStrictEqual(
-        [['param1', 'param2', 'param3']],
-        getHeaderRequestParams(httpRule)
-      );
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), [
+        ['param1', 'param2', 'param3'],
+      ]);
     });
 
     it('works with additional bindings', () => {
@@ -69,14 +68,11 @@ describe('src/schema/proto.ts', () => {
           },
         ],
       };
-      assert.deepStrictEqual(
-        [
-          ['param1', 'param2', 'param3'],
-          ['foo1', 'foo2'],
-          ['bar1', 'bar2', 'bar3'],
-        ],
-        getHeaderRequestParams(httpRule)
-      );
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), [
+        ['param1', 'param2', 'param3'],
+        ['foo1', 'foo2'],
+        ['bar1', 'bar2', 'bar3'],
+      ]);
     });
 
     it('dedups parameters', () => {
@@ -94,13 +90,10 @@ describe('src/schema/proto.ts', () => {
           },
         ],
       };
-      assert.deepStrictEqual(
-        [
-          ['param1', 'param2', 'param3'],
-          ['foo1', 'foo2'],
-        ],
-        getHeaderRequestParams(httpRule)
-      );
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), [
+        ['param1', 'param2', 'param3'],
+        ['foo1', 'foo2'],
+      ]);
     });
 
     it('works with multiple variables', () => {
@@ -112,10 +105,10 @@ describe('src/schema/proto.ts', () => {
           },
         ],
       };
-      assert.deepStrictEqual(
-        [['foo'], ['bar']],
-        getHeaderRequestParams(httpRule)
-      );
+      assert.deepStrictEqual(getHeaderRequestParams(httpRule), [
+        ['foo'],
+        ['bar'],
+      ]);
     });
   });
 
@@ -133,20 +126,19 @@ describe('src/schema/proto.ts', () => {
             fieldRetrieve: [],
             fieldSend: '',
             messageRegex: '',
-            namedSegment: '',
           },
         ],
       ];
       assert.deepStrictEqual(
-        expectedRoutingParameters,
-        getDynamicHeaderRequestParams(routingParameters)
+        getDynamicHeaderRequestParams(routingParameters),
+        expectedRoutingParameters
       );
     });
     it('works with a couple rules with the same parameter', () => {
       const routingParameters: protos.google.api.IRoutingParameter[] = [
         {
           field: 'name',
-          pathTemplate: '{routing_id=projects/*}/**}',
+          pathTemplate: '{routing_id=projects/*}/**',
         },
         {
           field: 'database',
@@ -162,34 +154,31 @@ describe('src/schema/proto.ts', () => {
           {
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+)',
+            messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
           },
           {
             fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>(?:/.*)?)',
-            namedSegment: '(?<routing_id>.*)',
+            messageRegex: '(?<routing_id>(?:.*)?)',
           },
           {
             fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
             messageRegex:
-              '(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
+              '(?<routing_id>projects/[^/]+/databases/[^/]+)/documents/[^/]+(?:/.*)?',
           },
         ],
       ];
       assert.deepStrictEqual(
-        expectedRoutingParameters,
-        getDynamicHeaderRequestParams(routingParameters)
+        getDynamicHeaderRequestParams(routingParameters),
+        expectedRoutingParameters
       );
     });
     it('works with a couple rules with different parameters', () => {
       const routingParameters: protos.google.api.IRoutingParameter[] = [
         {
           field: 'name',
-          pathTemplate: '{routing_id=projects/*}/**}',
+          pathTemplate: '{routing_id=projects/*}/**',
         },
         {
           field: 'app_profile_id',
@@ -201,29 +190,27 @@ describe('src/schema/proto.ts', () => {
           {
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+)',
+            messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
           },
         ],
         [
           {
             fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
-            messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<profile_id>projects/[^/]+)',
+            messageRegex: '(?<profile_id>projects/[^/]+)(?:/.*)?',
           },
         ],
       ];
       assert.deepStrictEqual(
-        expectedRoutingParameters,
-        getDynamicHeaderRequestParams(routingParameters)
+        getDynamicHeaderRequestParams(routingParameters),
+        expectedRoutingParameters
       );
     });
     it('works with a several rules with different parameters', () => {
       const routingParameters: protos.google.api.IRoutingParameter[] = [
         {
           field: 'name',
-          pathTemplate: '{routing_id=projects/*}/**}',
+          pathTemplate: '{routing_id=projects/*}/**',
         },
         {
           field: 'name',
@@ -240,29 +227,47 @@ describe('src/schema/proto.ts', () => {
           {
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
-            messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+)',
+            messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
           },
           {
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex:
-              'test/(?<routing_id>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?',
-            namedSegment: '(?<routing_id>projects/[^/]+/databases/[^/]+)',
+              'test/(?<routing_id>projects/[^/]+/databases/[^/]+)/documents/[^/]+(?:/.*)?',
           },
         ],
         [
           {
             fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
-            messageRegex: '(?<profile_id>projects)/[^/]+(?:/.*)?',
-            namedSegment: '(?<profile_id>projects/[^/]+)',
+            messageRegex: '(?<profile_id>projects/[^/]+)(?:/.*)?',
           },
         ],
       ];
       assert.deepStrictEqual(
-        expectedRoutingParameters,
-        getDynamicHeaderRequestParams(routingParameters)
+        getDynamicHeaderRequestParams(routingParameters),
+        expectedRoutingParameters
+      );
+    });
+    it('regression test: Cloud Run location', () => {
+      const routingParameters: protos.google.api.IRoutingParameter[] = [
+        {
+          field: 'parent',
+          pathTemplate: 'projects/*/locations/{location=*}',
+        },
+      ];
+      const expectedRoutingParameters: DynamicRoutingParameters[][] = [
+        [
+          {
+            fieldRetrieve: ['parent'],
+            fieldSend: 'location',
+            messageRegex: 'projects/[^/]+/locations/(?<location>[^/]+)',
+          },
+        ],
+      ];
+      assert.deepStrictEqual(
+        getDynamicHeaderRequestParams(routingParameters),
+        expectedRoutingParameters
       );
     });
   });
@@ -298,7 +303,6 @@ describe('src/schema/proto.ts', () => {
         fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
-        namedSegment: '',
       };
       assert.deepStrictEqual(
         expectedRoutingParameters,
@@ -311,7 +315,6 @@ describe('src/schema/proto.ts', () => {
         fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
-        namedSegment: '',
       };
       assert.deepStrictEqual(
         expectedRoutingParameters,
@@ -325,8 +328,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters = {
         fieldRetrieve: ['name'],
         fieldSend: 'name',
-        messageRegex: '[^/]+',
-        namedSegment: '[^/]+',
+        messageRegex: '(?<name>.*)',
       };
       assert.deepStrictEqual(
         expectedRoutingParameters,
@@ -341,8 +343,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters = {
         fieldRetrieve: ['appProfileId', 'parentId'],
         fieldSend: 'routing_id',
-        messageRegex: '(?<routing_id>(?:/.*)?)',
-        namedSegment: '(?<routing_id>.*)',
+        messageRegex: '(?<routing_id>(?:.*)?)',
       };
       assert.deepStrictEqual(
         expectedRoutingParameters,
@@ -357,8 +358,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters = {
         fieldRetrieve: ['appProfileId'],
         fieldSend: 'routing_id',
-        messageRegex: '(?<routing_id>projects)/[^/]+(?:/.*)?',
-        namedSegment: '(?<routing_id>projects/[^/]+)',
+        messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
       };
       assert.deepStrictEqual(
         expectedRoutingParameters,

--- a/typescript/test/unit/proto.ts
+++ b/typescript/test/unit/proto.ts
@@ -123,6 +123,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
+            pathTemplate: 'test/database',
             fieldRetrieve: [],
             fieldSend: '',
             messageRegex: '',
@@ -152,16 +153,19 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
+            pathTemplate: '{routing_id=projects/*}/**',
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
           },
           {
+            pathTemplate: '{routing_id=**}',
             fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>(?:.*)?)',
           },
           {
+            pathTemplate: '{routing_id=projects/*/databases/*}/documents/*/**',
             fieldRetrieve: ['database'],
             fieldSend: 'routing_id',
             messageRegex:
@@ -188,6 +192,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
+            pathTemplate: '{routing_id=projects/*}/**',
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
@@ -195,6 +200,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
+            pathTemplate: '{profile_id=projects/*}/**',
             fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects/[^/]+)(?:/.*)?',
@@ -225,11 +231,14 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
+            pathTemplate: '{routing_id=projects/*}/**',
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
           },
           {
+            pathTemplate:
+              'test/{routing_id=projects/*/databases/*}/documents/*/**',
             fieldRetrieve: ['name'],
             fieldSend: 'routing_id',
             messageRegex:
@@ -238,6 +247,7 @@ describe('src/schema/proto.ts', () => {
         ],
         [
           {
+            pathTemplate: '{profile_id=projects/*}/**',
             fieldRetrieve: ['appProfileId'],
             fieldSend: 'profile_id',
             messageRegex: '(?<profile_id>projects/[^/]+)(?:/.*)?',
@@ -259,6 +269,7 @@ describe('src/schema/proto.ts', () => {
       const expectedRoutingParameters: DynamicRoutingParameters[][] = [
         [
           {
+            pathTemplate: 'projects/*/locations/{location=*}',
             fieldRetrieve: ['parent'],
             fieldSend: 'location',
             messageRegex: 'projects/[^/]+/locations/(?<location>[^/]+)',
@@ -300,6 +311,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: 'test/database',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
+        pathTemplate: 'test/database',
         fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
@@ -312,6 +324,7 @@ describe('src/schema/proto.ts', () => {
     it('works with no parameters', () => {
       const routingRule: protos.google.api.IRoutingParameter = {};
       const expectedRoutingParameters: DynamicRoutingParameters = {
+        pathTemplate: '',
         fieldRetrieve: [],
         fieldSend: '',
         messageRegex: '',
@@ -326,6 +339,7 @@ describe('src/schema/proto.ts', () => {
         field: 'name',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
+        pathTemplate: '',
         fieldRetrieve: ['name'],
         fieldSend: 'name',
         messageRegex: '(?<name>.*)',
@@ -341,6 +355,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: '{routing_id=**}',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
+        pathTemplate: '{routing_id=**}',
         fieldRetrieve: ['appProfileId', 'parentId'],
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>(?:.*)?)',
@@ -356,6 +371,7 @@ describe('src/schema/proto.ts', () => {
         pathTemplate: '{routing_id=projects/*}/**',
       };
       const expectedRoutingParameters: DynamicRoutingParameters = {
+        pathTemplate: '{routing_id=projects/*}/**',
         fieldRetrieve: ['appProfileId'],
         fieldSend: 'routing_id',
         messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',

--- a/typescript/test/unit/util.ts
+++ b/typescript/test/unit/util.ts
@@ -20,10 +20,7 @@ import {
   seconds,
   milliseconds,
   isDigit,
-  checkIfArrayContainsOnlyOneNamedSegment,
-  convertSegmentToRegex,
-  convertTemplateToRegex,
-  getNamedSegment,
+  processPathTemplate,
 } from '../../src/util';
 import * as protos from '../../../protos';
 
@@ -455,167 +452,63 @@ describe('src/util.ts', () => {
     });
   });
 
-  describe('Array check', () => {
-    it('should get return true if an array of strings contains exactly one named segment', () => {
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment(['database=projects', 'foo']),
-        true
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment([
-          'database',
-          '123',
-          'pho123=yummy234',
-        ]),
-        true
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment(['=projects', 'foo']),
-        false
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment(['projects', 'foo=']),
-        false
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment(['projects', 'foo=*']),
-        true
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment([
-          'database=projects',
-          'foo=bar',
-          'cat',
-        ]),
-        false
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment([
-          'database=projects',
-          'foo=*',
-          'cat',
-        ]),
-        false
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment([
-          'database=projects',
-          'foo=**',
-          'cat',
-        ]),
-        false
-      );
-      assert.deepStrictEqual(
-        checkIfArrayContainsOnlyOneNamedSegment(['{database}', 'cat']),
-        true
-      );
-    });
-  });
-  describe('Strings to regex', () => {
-    it('should get convert a path template segment into regex', () => {
-      assert.deepStrictEqual(convertSegmentToRegex('{foo}'), '(?<foo>[^/]+)');
-      assert.deepStrictEqual(convertSegmentToRegex('{foo=*}'), '(?<foo>[^/]+)');
-      assert.deepStrictEqual(
-        convertSegmentToRegex('{foo=**}'),
-        '(?<foo>(?:/.*)?)'
-      );
-      assert.deepStrictEqual(convertSegmentToRegex('{foo=bar}'), '(?<foo>bar)');
-      assert.deepStrictEqual(convertSegmentToRegex('{foo=bar'), '(?<foo>bar)');
-      assert.deepStrictEqual(convertSegmentToRegex('*'), '[^/]+');
-      assert.deepStrictEqual(convertSegmentToRegex('*}'), '[^/]+');
-      assert.deepStrictEqual(convertSegmentToRegex('**'), '(?:/.*)?');
-      assert.deepStrictEqual(convertSegmentToRegex('foo'), 'foo');
-    });
-  });
-
   describe('Path template to regex', () => {
     it('should get convert a full path template into regex', () => {
-      assert.deepStrictEqual(convertTemplateToRegex('{foo}'), '(?<foo>[^/]+)');
+      assert.deepStrictEqual(processPathTemplate('{foo}'), {
+        fieldSend: 'foo',
+        messageRegex: '(?<foo>[^/]+)',
+      });
+      assert.deepStrictEqual(processPathTemplate('{foo=*}'), {
+        fieldSend: 'foo',
+        messageRegex: '(?<foo>[^/]+)',
+      });
+      assert.deepStrictEqual(processPathTemplate('{foo=**}'), {
+        fieldSend: 'foo',
+        messageRegex: '(?<foo>(?:.*)?)',
+      });
+      assert.deepStrictEqual(processPathTemplate('{foo=bar}'), {
+        fieldSend: 'foo',
+        messageRegex: '(?<foo>bar)',
+      });
+      assert.deepStrictEqual(processPathTemplate('*'), null);
+      assert.deepStrictEqual(processPathTemplate('*}'), null);
+      assert.deepStrictEqual(processPathTemplate('**'), null);
       assert.deepStrictEqual(
-        convertTemplateToRegex('{foo=*}'),
-        '(?<foo>[^/]+)'
-      );
-      assert.deepStrictEqual(
-        convertTemplateToRegex('{foo=**}'),
-        '(?<foo>(?:/.*)?)'
-      );
-      assert.deepStrictEqual(
-        convertTemplateToRegex('{foo=bar}'),
-        '(?<foo>bar)'
-      );
-      assert.deepStrictEqual(convertTemplateToRegex('{foo=bar'), '(?<foo>bar)');
-      assert.deepStrictEqual(convertTemplateToRegex('*'), '[^/]+');
-      assert.deepStrictEqual(convertTemplateToRegex('*}'), '[^/]+');
-      assert.deepStrictEqual(convertTemplateToRegex('**'), '(?:/.*)?');
-      assert.deepStrictEqual(
-        convertTemplateToRegex(
+        processPathTemplate(
           'test/{database=projects/*/databases/*}/documents/*/**'
         ),
-        'test/(?<database>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?'
+        {
+          fieldSend: 'database',
+          messageRegex:
+            'test/(?<database>projects/[^/]+/databases/[^/]+)/documents/[^/]+(?:/.*)?',
+        }
       );
       assert.deepStrictEqual(
-        convertTemplateToRegex(
-          '{database=projects/*/databases/*}/documents/*/**'
-        ),
-        '(?<database>projects)/[^/]+/databases/[^/]+/documents/[^/]+(?:/.*)?'
+        processPathTemplate('{database=projects/*/databases/*}/documents/*/**'),
+        {
+          fieldSend: 'database',
+          messageRegex:
+            '(?<database>projects/[^/]+/databases/[^/]+)/documents/[^/]+(?:/.*)?',
+        }
       );
       assert.deepStrictEqual(
-        convertTemplateToRegex(
-          '{new_name_match=projects/*/instances/*/tables/*}'
-        ),
-        '(?<new_name_match>projects)/[^/]+/instances/[^/]+/tables/[^/]+'
+        processPathTemplate('{new_name_match=projects/*/instances/*/tables/*}'),
+        {
+          fieldSend: 'new_name_match',
+          messageRegex:
+            '(?<new_name_match>projects/[^/]+/instances/[^/]+/tables/[^/]+)',
+        }
       );
       assert.deepStrictEqual(
-        convertTemplateToRegex('{routing_id=projects/*}/**'),
-        '(?<routing_id>projects)/[^/]+(?:/.*)?'
+        processPathTemplate('{routing_id=projects/*}/**'),
+        {
+          fieldSend: 'routing_id',
+          messageRegex: '(?<routing_id>projects/[^/]+)(?:/.*)?',
+        }
       );
-      assert.deepStrictEqual(
-        convertTemplateToRegex('profiles/{routing_id=*}'),
-        'profiles/(?<routing_id>[^/]+)'
-      );
-    });
-  });
-
-  describe('Path template matching', () => {
-    it('should get the named segment information from a full path template', () => {
-      assert.deepStrictEqual(
-        getNamedSegment('{database=projects/*/databases/*}/documents/*/**'),
-        [
-          'database=projects/*/databases/*',
-          'database',
-          'projects/*/databases/*',
-          '(?<database>projects/[^/]+/databases/[^/]+)',
-        ]
-      );
-      assert.deepStrictEqual(
-        getNamedSegment('test/{table=projects/*/databases/*}/documents/*/**'),
-        [
-          'table=projects/*/databases/*',
-          'table',
-          'projects/*/databases/*',
-          '(?<table>projects/[^/]+/databases/[^/]+)',
-        ]
-      );
-      assert.deepStrictEqual(getNamedSegment('{routing_id=**}'), [
-        'routing_id=**',
-        'routing_id',
-        '**',
-        '(?<routing_id>.*)',
-      ]);
-      assert.deepStrictEqual(getNamedSegment('{database}'), [
-        'database',
-        'database',
-        '*',
-        '[^/]+',
-      ]);
-      it('should return an empty array if the path template does not contain exactly one named segment', () => {
-        assert.deepStrictEqual(getNamedSegment('test/database'), []);
-        assert.deepStrictEqual(
-          getNamedSegment(
-            'test/{database=projects/*/databases/*}/documents/*/**/{hello=world}'
-          ),
-          []
-        );
+      assert.deepStrictEqual(processPathTemplate('profiles/{routing_id=*}'), {
+        fieldSend: 'routing_id',
+        messageRegex: 'profiles/(?<routing_id>[^/]+)',
       });
     });
   });


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#569.

A huge refactor of the routing header processing logic to fix the Cloud Run use case. Tested locally, the generated Cloud Run client works (successfully providing the `location` routing header).
