### PR TITLE
fix: pass fallback to createApiCall for browser

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -252,7 +252,8 @@ export class AssetServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -912,7 +913,7 @@ export class AssetServiceClient {
   async checkExportAssetsProgress(name: string): Promise<LROperation<protos.google.cloud.asset.v1.ExportAssetsResponse, protos.google.cloud.asset.v1.ExportAssetsRequest>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportAssets, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportAssets, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.asset.v1.ExportAssetsResponse, protos.google.cloud.asset.v1.ExportAssetsRequest>;
   }
   // --------------------

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -239,7 +239,8 @@ export class BigQueryStorageClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -228,7 +227,8 @@ export class AddressesClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -542,7 +542,7 @@ export class AddressesClient {
     this.initialize();
     return this.descriptors.page.aggregatedList.asyncIterate(
       this.innerApiCalls['aggregatedList'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<[string, protos.google.cloud.compute.v1.IAddressesScopedList]>;
   }
@@ -700,7 +700,7 @@ export class AddressesClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.list.createStream(
-      this.innerApiCalls.list as gax.GaxCall,
+      this.innerApiCalls.list as GaxCall,
       request,
       callSettings
     );
@@ -766,7 +766,7 @@ export class AddressesClient {
     this.initialize();
     return this.descriptors.page.list.asyncIterate(
       this.innerApiCalls['list'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.compute.v1.IAddress>;
   }

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -212,7 +212,8 @@ export class RegionOperationsClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -212,7 +212,8 @@ export class DeprecatedServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -302,7 +301,8 @@ export class EchoClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -697,7 +697,7 @@ export class EchoClient {
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**
@@ -811,7 +811,7 @@ export class EchoClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
-      this.innerApiCalls.pagedExpand as gax.GaxCall,
+      this.innerApiCalls.pagedExpand as GaxCall,
       request,
       callSettings
     );
@@ -855,7 +855,7 @@ export class EchoClient {
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -254,7 +253,8 @@ export class IdentityClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -710,7 +710,7 @@ export class IdentityClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listUsers.createStream(
-      this.innerApiCalls.listUsers as gax.GaxCall,
+      this.innerApiCalls.listUsers as GaxCall,
       request,
       callSettings
     );
@@ -755,7 +755,7 @@ export class IdentityClient {
     this.initialize();
     return this.descriptors.page.listUsers.asyncIterate(
       this.innerApiCalls['listUsers'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IUser>;
   }

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -303,7 +302,8 @@ export class MessagingClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1150,7 +1150,7 @@ export class MessagingClient {
   async checkSearchBlurbsProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
  /**
@@ -1265,7 +1265,7 @@ export class MessagingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listRooms.createStream(
-      this.innerApiCalls.listRooms as gax.GaxCall,
+      this.innerApiCalls.listRooms as GaxCall,
       request,
       callSettings
     );
@@ -1310,7 +1310,7 @@ export class MessagingClient {
     this.initialize();
     return this.descriptors.page.listRooms.asyncIterate(
       this.innerApiCalls['listRooms'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
@@ -1443,7 +1443,7 @@ export class MessagingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.createStream(
-      this.innerApiCalls.listBlurbs as gax.GaxCall,
+      this.innerApiCalls.listBlurbs as GaxCall,
       request,
       callSettings
     );
@@ -1496,7 +1496,7 @@ export class MessagingClient {
     this.initialize();
     return this.descriptors.page.listBlurbs.asyncIterate(
       this.innerApiCalls['listBlurbs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IBlurb>;
   }

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -257,7 +256,8 @@ export class TestingClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -862,7 +862,7 @@ export class TestingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listSessions.createStream(
-      this.innerApiCalls.listSessions as gax.GaxCall,
+      this.innerApiCalls.listSessions as GaxCall,
       request,
       callSettings
     );
@@ -904,7 +904,7 @@ export class TestingClient {
     this.initialize();
     return this.descriptors.page.listSessions.asyncIterate(
       this.innerApiCalls['listSessions'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
@@ -1028,7 +1028,7 @@ export class TestingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listTests.createStream(
-      this.innerApiCalls.listTests as gax.GaxCall,
+      this.innerApiCalls.listTests as GaxCall,
       request,
       callSettings
     );
@@ -1077,7 +1077,7 @@ export class TestingClient {
     this.initialize();
     return this.descriptors.page.listTests.asyncIterate(
       this.innerApiCalls['listTests'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ITest>;
   }

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -273,7 +272,8 @@ export class DlpServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -2612,7 +2612,7 @@ export class DlpServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listInspectTemplates.createStream(
-      this.innerApiCalls.listInspectTemplates as gax.GaxCall,
+      this.innerApiCalls.listInspectTemplates as GaxCall,
       request,
       callSettings
     );
@@ -2682,7 +2682,7 @@ export class DlpServiceClient {
     this.initialize();
     return this.descriptors.page.listInspectTemplates.asyncIterate(
       this.innerApiCalls['listInspectTemplates'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IInspectTemplate>;
   }
@@ -2850,7 +2850,7 @@ export class DlpServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listDeidentifyTemplates.createStream(
-      this.innerApiCalls.listDeidentifyTemplates as gax.GaxCall,
+      this.innerApiCalls.listDeidentifyTemplates as GaxCall,
       request,
       callSettings
     );
@@ -2920,7 +2920,7 @@ export class DlpServiceClient {
     this.initialize();
     return this.descriptors.page.listDeidentifyTemplates.asyncIterate(
       this.innerApiCalls['listDeidentifyTemplates'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDeidentifyTemplate>;
   }
@@ -3139,7 +3139,7 @@ export class DlpServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listJobTriggers.createStream(
-      this.innerApiCalls.listJobTriggers as gax.GaxCall,
+      this.innerApiCalls.listJobTriggers as GaxCall,
       request,
       callSettings
     );
@@ -3235,7 +3235,7 @@ export class DlpServiceClient {
     this.initialize();
     return this.descriptors.page.listJobTriggers.asyncIterate(
       this.innerApiCalls['listJobTriggers'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IJobTrigger>;
   }
@@ -3459,7 +3459,7 @@ export class DlpServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listDlpJobs.createStream(
-      this.innerApiCalls.listDlpJobs as gax.GaxCall,
+      this.innerApiCalls.listDlpJobs as GaxCall,
       request,
       callSettings
     );
@@ -3557,7 +3557,7 @@ export class DlpServiceClient {
     this.initialize();
     return this.descriptors.page.listDlpJobs.asyncIterate(
       this.innerApiCalls['listDlpJobs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IDlpJob>;
   }
@@ -3727,7 +3727,7 @@ export class DlpServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listStoredInfoTypes.createStream(
-      this.innerApiCalls.listStoredInfoTypes as gax.GaxCall,
+      this.innerApiCalls.listStoredInfoTypes as GaxCall,
       request,
       callSettings
     );
@@ -3798,7 +3798,7 @@ export class DlpServiceClient {
     this.initialize();
     return this.descriptors.page.listStoredInfoTypes.asyncIterate(
       this.innerApiCalls['listStoredInfoTypes'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.privacy.dlp.v2.IStoredInfoType>;
   }

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -239,7 +238,8 @@ export class KeyManagementServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1943,7 +1943,7 @@ export class KeyManagementServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listKeyRings.createStream(
-      this.innerApiCalls.listKeyRings as gax.GaxCall,
+      this.innerApiCalls.listKeyRings as GaxCall,
       request,
       callSettings
     );
@@ -2002,7 +2002,7 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.descriptors.page.listKeyRings.asyncIterate(
       this.innerApiCalls['listKeyRings'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>;
   }
@@ -2150,7 +2150,7 @@ export class KeyManagementServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeys.createStream(
-      this.innerApiCalls.listCryptoKeys as gax.GaxCall,
+      this.innerApiCalls.listCryptoKeys as GaxCall,
       request,
       callSettings
     );
@@ -2211,7 +2211,7 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.descriptors.page.listCryptoKeys.asyncIterate(
       this.innerApiCalls['listCryptoKeys'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>;
   }
@@ -2361,7 +2361,7 @@ export class KeyManagementServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listCryptoKeyVersions.createStream(
-      this.innerApiCalls.listCryptoKeyVersions as gax.GaxCall,
+      this.innerApiCalls.listCryptoKeyVersions as GaxCall,
       request,
       callSettings
     );
@@ -2423,7 +2423,7 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.descriptors.page.listCryptoKeyVersions.asyncIterate(
       this.innerApiCalls['listCryptoKeyVersions'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>;
   }
@@ -2567,7 +2567,7 @@ export class KeyManagementServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listImportJobs.createStream(
-      this.innerApiCalls.listImportJobs as gax.GaxCall,
+      this.innerApiCalls.listImportJobs as GaxCall,
       request,
       callSettings
     );
@@ -2626,7 +2626,7 @@ export class KeyManagementServiceClient {
     this.initialize();
     return this.descriptors.page.listImportJobs.asyncIterate(
       this.innerApiCalls['listImportJobs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.kms.v1.IImportJob>;
   }

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -300,7 +299,8 @@ export class ConfigServiceV2Client {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1588,7 +1588,7 @@ export class ConfigServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listBuckets.createStream(
-      this.innerApiCalls.listBuckets as gax.GaxCall,
+      this.innerApiCalls.listBuckets as GaxCall,
       request,
       callSettings
     );
@@ -1651,7 +1651,7 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.descriptors.page.listBuckets.asyncIterate(
       this.innerApiCalls['listBuckets'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
   }
@@ -1795,7 +1795,7 @@ export class ConfigServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listSinks.createStream(
-      this.innerApiCalls.listSinks as gax.GaxCall,
+      this.innerApiCalls.listSinks as GaxCall,
       request,
       callSettings
     );
@@ -1854,7 +1854,7 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.descriptors.page.listSinks.asyncIterate(
       this.innerApiCalls['listSinks'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
@@ -1998,7 +1998,7 @@ export class ConfigServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listExclusions.createStream(
-      this.innerApiCalls.listExclusions as gax.GaxCall,
+      this.innerApiCalls.listExclusions as GaxCall,
       request,
       callSettings
     );
@@ -2057,7 +2057,7 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.descriptors.page.listExclusions.asyncIterate(
       this.innerApiCalls['listExclusions'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogExclusion>;
   }

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -314,7 +313,8 @@ export class LoggingServiceV2Client {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -773,7 +773,7 @@ export class LoggingServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listLogEntries.createStream(
-      this.innerApiCalls.listLogEntries as gax.GaxCall,
+      this.innerApiCalls.listLogEntries as GaxCall,
       request,
       callSettings
     );
@@ -846,7 +846,7 @@ export class LoggingServiceV2Client {
     this.initialize();
     return this.descriptors.page.listLogEntries.asyncIterate(
       this.innerApiCalls['listLogEntries'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogEntry>;
   }
@@ -966,7 +966,7 @@ export class LoggingServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.createStream(
-      this.innerApiCalls.listMonitoredResourceDescriptors as gax.GaxCall,
+      this.innerApiCalls.listMonitoredResourceDescriptors as GaxCall,
       request,
       callSettings
     );
@@ -1013,7 +1013,7 @@ export class LoggingServiceV2Client {
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.asyncIterate(
       this.innerApiCalls['listMonitoredResourceDescriptors'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
@@ -1158,7 +1158,7 @@ export class LoggingServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listLogs.createStream(
-      this.innerApiCalls.listLogs as gax.GaxCall,
+      this.innerApiCalls.listLogs as GaxCall,
       request,
       callSettings
     );
@@ -1217,7 +1217,7 @@ export class LoggingServiceV2Client {
     this.initialize();
     return this.descriptors.page.listLogs.asyncIterate(
       this.innerApiCalls['listLogs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<string>;
   }

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -293,7 +292,8 @@ export class MetricsServiceV2Client {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -798,7 +798,7 @@ export class MetricsServiceV2Client {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listLogMetrics.createStream(
-      this.innerApiCalls.listLogMetrics as gax.GaxCall,
+      this.innerApiCalls.listLogMetrics as GaxCall,
       request,
       callSettings
     );
@@ -854,7 +854,7 @@ export class MetricsServiceV2Client {
     this.initialize();
     return this.descriptors.page.listLogMetrics.asyncIterate(
       this.innerApiCalls['listLogMetrics'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogMetric>;
   }

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -307,7 +306,8 @@ export class AlertPolicyServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -868,7 +868,7 @@ export class AlertPolicyServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listAlertPolicies.createStream(
-      this.innerApiCalls.listAlertPolicies as gax.GaxCall,
+      this.innerApiCalls.listAlertPolicies as GaxCall,
       request,
       callSettings
     );
@@ -940,7 +940,7 @@ export class AlertPolicyServiceClient {
     this.initialize();
     return this.descriptors.page.listAlertPolicies.asyncIterate(
       this.innerApiCalls['listAlertPolicies'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IAlertPolicy>;
   }

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -312,7 +311,8 @@ export class GroupServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -834,7 +834,7 @@ export class GroupServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listGroups.createStream(
-      this.innerApiCalls.listGroups as gax.GaxCall,
+      this.innerApiCalls.listGroups as GaxCall,
       request,
       callSettings
     );
@@ -901,7 +901,7 @@ export class GroupServiceClient {
     this.initialize();
     return this.descriptors.page.listGroups.asyncIterate(
       this.innerApiCalls['listGroups'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IGroup>;
   }
@@ -1057,7 +1057,7 @@ export class GroupServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listGroupMembers.createStream(
-      this.innerApiCalls.listGroupMembers as gax.GaxCall,
+      this.innerApiCalls.listGroupMembers as GaxCall,
       request,
       callSettings
     );
@@ -1122,7 +1122,7 @@ export class GroupServiceClient {
     this.initialize();
     return this.descriptors.page.listGroupMembers.asyncIterate(
       this.innerApiCalls['listGroupMembers'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResource>;
   }

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -322,7 +321,8 @@ export class MetricServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -914,7 +914,7 @@ export class MetricServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.createStream(
-      this.innerApiCalls.listMonitoredResourceDescriptors as gax.GaxCall,
+      this.innerApiCalls.listMonitoredResourceDescriptors as GaxCall,
       request,
       callSettings
     );
@@ -974,7 +974,7 @@ export class MetricServiceClient {
     this.initialize();
     return this.descriptors.page.listMonitoredResourceDescriptors.asyncIterate(
       this.innerApiCalls['listMonitoredResourceDescriptors'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.api.IMonitoredResourceDescriptor>;
   }
@@ -1122,7 +1122,7 @@ export class MetricServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listMetricDescriptors.createStream(
-      this.innerApiCalls.listMetricDescriptors as gax.GaxCall,
+      this.innerApiCalls.listMetricDescriptors as GaxCall,
       request,
       callSettings
     );
@@ -1183,7 +1183,7 @@ export class MetricServiceClient {
     this.initialize();
     return this.descriptors.page.listMetricDescriptors.asyncIterate(
       this.innerApiCalls['listMetricDescriptors'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.api.IMetricDescriptor>;
   }
@@ -1367,7 +1367,7 @@ export class MetricServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listTimeSeries.createStream(
-      this.innerApiCalls.listTimeSeries as gax.GaxCall,
+      this.innerApiCalls.listTimeSeries as GaxCall,
       request,
       callSettings
     );
@@ -1446,7 +1446,7 @@ export class MetricServiceClient {
     this.initialize();
     return this.descriptors.page.listTimeSeries.asyncIterate(
       this.innerApiCalls['listTimeSeries'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.ITimeSeries>;
   }

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -302,7 +301,8 @@ export class NotificationChannelServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1153,7 +1153,7 @@ export class NotificationChannelServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannelDescriptors.createStream(
-      this.innerApiCalls.listNotificationChannelDescriptors as gax.GaxCall,
+      this.innerApiCalls.listNotificationChannelDescriptors as GaxCall,
       request,
       callSettings
     );
@@ -1214,7 +1214,7 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.descriptors.page.listNotificationChannelDescriptors.asyncIterate(
       this.innerApiCalls['listNotificationChannelDescriptors'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannelDescriptor>;
   }
@@ -1384,7 +1384,7 @@ export class NotificationChannelServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listNotificationChannels.createStream(
-      this.innerApiCalls.listNotificationChannels as gax.GaxCall,
+      this.innerApiCalls.listNotificationChannels as GaxCall,
       request,
       callSettings
     );
@@ -1456,7 +1456,7 @@ export class NotificationChannelServiceClient {
     this.initialize();
     return this.descriptors.page.listNotificationChannels.asyncIterate(
       this.innerApiCalls['listNotificationChannels'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.INotificationChannel>;
   }

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -304,7 +303,8 @@ export class ServiceMonitoringServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1130,7 +1130,7 @@ export class ServiceMonitoringServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listServices.createStream(
-      this.innerApiCalls.listServices as gax.GaxCall,
+      this.innerApiCalls.listServices as GaxCall,
       request,
       callSettings
     );
@@ -1199,7 +1199,7 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.descriptors.page.listServices.asyncIterate(
       this.innerApiCalls['listServices'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IService>;
   }
@@ -1345,7 +1345,7 @@ export class ServiceMonitoringServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listServiceLevelObjectives.createStream(
-      this.innerApiCalls.listServiceLevelObjectives as gax.GaxCall,
+      this.innerApiCalls.listServiceLevelObjectives as GaxCall,
       request,
       callSettings
     );
@@ -1405,7 +1405,7 @@ export class ServiceMonitoringServiceClient {
     this.initialize();
     return this.descriptors.page.listServiceLevelObjectives.asyncIterate(
       this.innerApiCalls['listServiceLevelObjectives'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IServiceLevelObjective>;
   }

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -308,7 +307,8 @@ export class UptimeCheckServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -816,7 +816,7 @@ export class UptimeCheckServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckConfigs.createStream(
-      this.innerApiCalls.listUptimeCheckConfigs as gax.GaxCall,
+      this.innerApiCalls.listUptimeCheckConfigs as GaxCall,
       request,
       callSettings
     );
@@ -871,7 +871,7 @@ export class UptimeCheckServiceClient {
     this.initialize();
     return this.descriptors.page.listUptimeCheckConfigs.asyncIterate(
       this.innerApiCalls['listUptimeCheckConfigs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckConfig>;
   }
@@ -995,7 +995,7 @@ export class UptimeCheckServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listUptimeCheckIps.createStream(
-      this.innerApiCalls.listUptimeCheckIps as gax.GaxCall,
+      this.innerApiCalls.listUptimeCheckIps as GaxCall,
       request,
       callSettings
     );
@@ -1044,7 +1044,7 @@ export class UptimeCheckServiceClient {
     this.initialize();
     return this.descriptors.page.listUptimeCheckIps.asyncIterate(
       this.innerApiCalls['listUptimeCheckIps'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.monitoring.v3.IUptimeCheckIp>;
   }

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -260,7 +259,8 @@ export class NamingClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1098,7 +1098,7 @@ export class NamingClient {
   async checkLongRunningProgress1(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.longRunning, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.longRunning, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>;
   }
  /**
@@ -1206,7 +1206,7 @@ export class NamingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize1();
     return this.descriptors.page.paginatedMethod.createStream(
-      this.innerApiCalls.paginatedMethod as gax.GaxCall,
+      this.innerApiCalls.paginatedMethod as GaxCall,
       request,
       callSettings
     );
@@ -1247,7 +1247,7 @@ export class NamingClient {
     this.initialize1();
     return this.descriptors.page.paginatedMethod.asyncIterate(
       this.innerApiCalls['paginatedMethod'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.protobuf.IEmpty>;
   }

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -314,7 +313,8 @@ export class CloudRedisClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -563,7 +563,7 @@ export class CloudRedisClient {
   async checkCreateInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -668,7 +668,7 @@ export class CloudRedisClient {
   async checkUpdateInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.updateInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.updateInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -770,7 +770,7 @@ export class CloudRedisClient {
   async checkImportInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.importInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.importInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -870,7 +870,7 @@ export class CloudRedisClient {
   async checkExportInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -967,7 +967,7 @@ export class CloudRedisClient {
   async checkFailoverInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.failoverInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.failoverInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -1061,7 +1061,7 @@ export class CloudRedisClient {
   async checkDeleteInstanceProgress(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteInstance, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>;
   }
  /**
@@ -1209,7 +1209,7 @@ export class CloudRedisClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listInstances.createStream(
-      this.innerApiCalls.listInstances as gax.GaxCall,
+      this.innerApiCalls.listInstances as GaxCall,
       request,
       callSettings
     );
@@ -1267,7 +1267,7 @@ export class CloudRedisClient {
     this.initialize();
     return this.descriptors.page.listInstances.asyncIterate(
       this.innerApiCalls['listInstances'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.redis.v1beta1.IInstance>;
   }

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -210,7 +210,8 @@ export class TestServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -20,7 +20,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import * as path from 'path';
@@ -258,7 +257,8 @@ export class EchoClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -653,7 +653,7 @@ export class EchoClient {
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**
@@ -767,7 +767,7 @@ export class EchoClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
-      this.innerApiCalls.pagedExpand as gax.GaxCall,
+      this.innerApiCalls.pagedExpand as GaxCall,
       request,
       callSettings
     );
@@ -811,7 +811,7 @@ export class EchoClient {
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -224,7 +223,7 @@ export class EchoClient {
       lroOptions.httpRules = [{selector: 'google.cloud.location.Locations.ListLocations',get: '/v1beta1/{name=projects/*}/locations',},{selector: 'google.cloud.location.Locations.GetLocation',get: '/v1beta1/{name=projects/*/locations/*}',},{selector: 'google.iam.v1.IAMPolicy.SetIamPolicy',post: '/v1beta1/{resource=users/*}:setIamPolicy',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=sequences/*}:setIamPolicy',body: '*',}],
       },{selector: 'google.iam.v1.IAMPolicy.GetIamPolicy',get: '/v1beta1/{resource=users/*}:getIamPolicy',additional_bindings: [{get: '/v1beta1/{resource=rooms/*}:getIamPolicy',},{get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy',},{get: '/v1beta1/{resource=sequences/*}:getIamPolicy',}],
       },{selector: 'google.iam.v1.IAMPolicy.TestIamPermissions',post: '/v1beta1/{resource=users/*}:testIamPermissions',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=sequences/*}:testIamPermissions',body: '*',}],
-      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=/operations/*}:cancel',}];
+      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=operations/**}:cancel',}];
     }
     this.operationsClient = this._gaxModule.lro(lroOptions).operationsClient(opts);
     const waitResponse = protoFilesRoot.lookup(
@@ -311,7 +310,8 @@ export class EchoClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -706,7 +706,7 @@ export class EchoClient {
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**
@@ -820,7 +820,7 @@ export class EchoClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.pagedExpand.createStream(
-      this.innerApiCalls.pagedExpand as gax.GaxCall,
+      this.innerApiCalls.pagedExpand as GaxCall,
       request,
       callSettings
     );
@@ -864,7 +864,7 @@ export class EchoClient {
     this.initialize();
     return this.descriptors.page.pagedExpand.asyncIterate(
       this.innerApiCalls['pagedExpand'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IEchoResponse>;
   }

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -211,7 +210,7 @@ export class IdentityClient {
       lroOptions.httpRules = [{selector: 'google.cloud.location.Locations.ListLocations',get: '/v1beta1/{name=projects/*}/locations',},{selector: 'google.cloud.location.Locations.GetLocation',get: '/v1beta1/{name=projects/*/locations/*}',},{selector: 'google.iam.v1.IAMPolicy.SetIamPolicy',post: '/v1beta1/{resource=users/*}:setIamPolicy',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=sequences/*}:setIamPolicy',body: '*',}],
       },{selector: 'google.iam.v1.IAMPolicy.GetIamPolicy',get: '/v1beta1/{resource=users/*}:getIamPolicy',additional_bindings: [{get: '/v1beta1/{resource=rooms/*}:getIamPolicy',},{get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy',},{get: '/v1beta1/{resource=sequences/*}:getIamPolicy',}],
       },{selector: 'google.iam.v1.IAMPolicy.TestIamPermissions',post: '/v1beta1/{resource=users/*}:testIamPermissions',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=sequences/*}:testIamPermissions',body: '*',}],
-      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=/operations/*}:cancel',}];
+      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=operations/**}:cancel',}];
     }
     this.operationsClient = this._gaxModule.lro(lroOptions).operationsClient(opts);
 
@@ -281,7 +280,8 @@ export class IdentityClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -737,7 +737,7 @@ export class IdentityClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listUsers.createStream(
-      this.innerApiCalls.listUsers as gax.GaxCall,
+      this.innerApiCalls.listUsers as GaxCall,
       request,
       callSettings
     );
@@ -782,7 +782,7 @@ export class IdentityClient {
     this.initialize();
     return this.descriptors.page.listUsers.asyncIterate(
       this.innerApiCalls['listUsers'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IUser>;
   }

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -225,7 +224,7 @@ export class MessagingClient {
       lroOptions.httpRules = [{selector: 'google.cloud.location.Locations.ListLocations',get: '/v1beta1/{name=projects/*}/locations',},{selector: 'google.cloud.location.Locations.GetLocation',get: '/v1beta1/{name=projects/*/locations/*}',},{selector: 'google.iam.v1.IAMPolicy.SetIamPolicy',post: '/v1beta1/{resource=users/*}:setIamPolicy',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=sequences/*}:setIamPolicy',body: '*',}],
       },{selector: 'google.iam.v1.IAMPolicy.GetIamPolicy',get: '/v1beta1/{resource=users/*}:getIamPolicy',additional_bindings: [{get: '/v1beta1/{resource=rooms/*}:getIamPolicy',},{get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy',},{get: '/v1beta1/{resource=sequences/*}:getIamPolicy',}],
       },{selector: 'google.iam.v1.IAMPolicy.TestIamPermissions',post: '/v1beta1/{resource=users/*}:testIamPermissions',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=sequences/*}:testIamPermissions',body: '*',}],
-      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=/operations/*}:cancel',}];
+      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=operations/**}:cancel',}];
     }
     this.operationsClient = this._gaxModule.lro(lroOptions).operationsClient(opts);
     const searchBlurbsResponse = protoFilesRoot.lookup(
@@ -312,7 +311,8 @@ export class MessagingClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1159,7 +1159,7 @@ export class MessagingClient {
   async checkSearchBlurbsProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
  /**
@@ -1274,7 +1274,7 @@ export class MessagingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listRooms.createStream(
-      this.innerApiCalls.listRooms as gax.GaxCall,
+      this.innerApiCalls.listRooms as GaxCall,
       request,
       callSettings
     );
@@ -1319,7 +1319,7 @@ export class MessagingClient {
     this.initialize();
     return this.descriptors.page.listRooms.asyncIterate(
       this.innerApiCalls['listRooms'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IRoom>;
   }
@@ -1452,7 +1452,7 @@ export class MessagingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listBlurbs.createStream(
-      this.innerApiCalls.listBlurbs as gax.GaxCall,
+      this.innerApiCalls.listBlurbs as GaxCall,
       request,
       callSettings
     );
@@ -1505,7 +1505,7 @@ export class MessagingClient {
     this.initialize();
     return this.descriptors.page.listBlurbs.asyncIterate(
       this.innerApiCalls['listBlurbs'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.IBlurb>;
   }

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -214,7 +213,7 @@ export class TestingClient {
       lroOptions.httpRules = [{selector: 'google.cloud.location.Locations.ListLocations',get: '/v1beta1/{name=projects/*}/locations',},{selector: 'google.cloud.location.Locations.GetLocation',get: '/v1beta1/{name=projects/*/locations/*}',},{selector: 'google.iam.v1.IAMPolicy.SetIamPolicy',post: '/v1beta1/{resource=users/*}:setIamPolicy',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy',body: '*',},{post: '/v1beta1/{resource=sequences/*}:setIamPolicy',body: '*',}],
       },{selector: 'google.iam.v1.IAMPolicy.GetIamPolicy',get: '/v1beta1/{resource=users/*}:getIamPolicy',additional_bindings: [{get: '/v1beta1/{resource=rooms/*}:getIamPolicy',},{get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy',},{get: '/v1beta1/{resource=sequences/*}:getIamPolicy',}],
       },{selector: 'google.iam.v1.IAMPolicy.TestIamPermissions',post: '/v1beta1/{resource=users/*}:testIamPermissions',body: '*',additional_bindings: [{post: '/v1beta1/{resource=rooms/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions',body: '*',},{post: '/v1beta1/{resource=sequences/*}:testIamPermissions',body: '*',}],
-      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=/operations/*}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=/operations/*}:cancel',}];
+      },{selector: 'google.longrunning.Operations.ListOperations',get: '/v1beta1/operations',},{selector: 'google.longrunning.Operations.GetOperation',get: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.DeleteOperation',delete: '/v1beta1/{name=operations/**}',},{selector: 'google.longrunning.Operations.CancelOperation',post: '/v1beta1/{name=operations/**}:cancel',}];
     }
     this.operationsClient = this._gaxModule.lro(lroOptions).operationsClient(opts);
 
@@ -284,7 +283,8 @@ export class TestingClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -889,7 +889,7 @@ export class TestingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listSessions.createStream(
-      this.innerApiCalls.listSessions as gax.GaxCall,
+      this.innerApiCalls.listSessions as GaxCall,
       request,
       callSettings
     );
@@ -931,7 +931,7 @@ export class TestingClient {
     this.initialize();
     return this.descriptors.page.listSessions.asyncIterate(
       this.innerApiCalls['listSessions'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ISession>;
   }
@@ -1055,7 +1055,7 @@ export class TestingClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listTests.createStream(
-      this.innerApiCalls.listTests as gax.GaxCall,
+      this.innerApiCalls.listTests as GaxCall,
       request,
       callSettings
     );
@@ -1104,7 +1104,7 @@ export class TestingClient {
     this.initialize();
     return this.descriptors.page.listTests.asyncIterate(
       this.innerApiCalls['listTests'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.showcase.v1beta1.ITest>;
   }

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -236,7 +235,8 @@ export class CloudTasksClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -1702,7 +1702,7 @@ export class CloudTasksClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listQueues.createStream(
-      this.innerApiCalls.listQueues as gax.GaxCall,
+      this.innerApiCalls.listQueues as GaxCall,
       request,
       callSettings
     );
@@ -1777,7 +1777,7 @@ export class CloudTasksClient {
     this.initialize();
     return this.descriptors.page.listQueues.asyncIterate(
       this.innerApiCalls['listQueues'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.tasks.v2.IQueue>;
   }
@@ -1967,7 +1967,7 @@ export class CloudTasksClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listTasks.createStream(
-      this.innerApiCalls.listTasks as gax.GaxCall,
+      this.innerApiCalls.listTasks as GaxCall,
       request,
       callSettings
     );
@@ -2045,7 +2045,7 @@ export class CloudTasksClient {
     this.initialize();
     return this.descriptors.page.listTasks.asyncIterate(
       this.innerApiCalls['listTasks'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.tasks.v2.ITask>;
   }

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -209,7 +209,8 @@ export class TextToSpeechClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -21,7 +21,6 @@ import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -276,7 +275,8 @@ export class TranslationServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -895,7 +895,7 @@ export class TranslationServiceClient {
   async checkBatchTranslateTextProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.batchTranslateText, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.batchTranslateText, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>;
   }
 /**
@@ -989,7 +989,7 @@ export class TranslationServiceClient {
   async checkCreateGlossaryProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createGlossary, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createGlossary, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>;
   }
 /**
@@ -1082,7 +1082,7 @@ export class TranslationServiceClient {
   async checkDeleteGlossaryProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteGlossary, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteGlossary, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>;
   }
  /**
@@ -1222,7 +1222,7 @@ export class TranslationServiceClient {
     const callSettings = defaultCallSettings.merge(options);
     this.initialize();
     return this.descriptors.page.listGlossaries.createStream(
-      this.innerApiCalls.listGlossaries as gax.GaxCall,
+      this.innerApiCalls.listGlossaries as GaxCall,
       request,
       callSettings
     );
@@ -1279,7 +1279,7 @@ export class TranslationServiceClient {
     this.initialize();
     return this.descriptors.page.listGlossaries.asyncIterate(
       this.innerApiCalls['listGlossaries'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     ) as AsyncIterable<protos.google.cloud.translation.v3beta1.IGlossary>;
   }

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -236,7 +236,8 @@ export class VideoIntelligenceServiceClient {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -414,7 +415,7 @@ export class VideoIntelligenceServiceClient {
   async checkAnnotateVideoProgress(name: string): Promise<LROperation<protos.google.cloud.videointelligence.v1.AnnotateVideoResponse, protos.google.cloud.videointelligence.v1.AnnotateVideoProgress>>{
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.annotateVideo, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.annotateVideo, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.videointelligence.v1.AnnotateVideoResponse, protos.google.cloud.videointelligence.v1.AnnotateVideoProgress>;
   }
 

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -37,7 +37,6 @@ import {Callback, CallOptions, Descriptors, ClientOptions
 } from 'google-gax';
 {% if service.paging.length > 0 %}
 import {Transform} from 'stream';
-import {RequestType} from 'google-gax/build/src/apitypes';
 {%- endif %}
 {%- if service.streaming.length > 0 %}
 import {PassThrough} from 'stream';
@@ -440,7 +439,8 @@ export class {{ service.name }}Client {
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
         this._defaults[methodName],
-        descriptor
+        descriptor,
+        this._opts.fallback
       );
 
       this.innerApiCalls[methodName] = apiCall;
@@ -770,7 +770,7 @@ export class {{ service.name }}Client {
     {%- endif %}
     const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.{{ method.name.toCamelCase() }}, gax.createDefaultBackoffSettings());
+    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.{{ method.name.toCamelCase() }}, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos{{ method.longRunningResponseType }}, protos{{ method.longRunningMetadataType }}>;
   }
 {%- endfor %}
@@ -855,7 +855,7 @@ export class {{ service.name }}Client {
     this.warn('DEP${{service.name}}-${{method.name}}','{{method.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
     return this.descriptors.page.{{ method.name.toCamelCase() }}.createStream(
-      this.innerApiCalls.{{ method.name.toCamelCase(true) }} as gax.GaxCall,
+      this.innerApiCalls.{{ method.name.toCamelCase(true) }} as GaxCall,
       request,
       callSettings
     );
@@ -890,7 +890,7 @@ export class {{ service.name }}Client {
     {%- endif %}
     return this.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate(
       this.innerApiCalls['{{ method.name.toCamelCase(true) }}'] as GaxCall,
-      request as unknown as RequestType,
+      request as {},
       callSettings
     {%- if method.pagingMapResponseType %}
     ) as AsyncIterable<[string, {{ util.toInterface(method.pagingMapResponseType) }}]>;

--- a/test-fixtures/protos/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/test-fixtures/protos/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -33,6 +33,7 @@ documentation:
   summary: |-
     Showcase represents both a model API and an integration testing surface for
     client library generator consumption.
+
 backend:
   rules:
   - selector: 'google.cloud.location.Locations.*'
@@ -77,9 +78,8 @@ http:
   - selector: google.longrunning.Operations.ListOperations
     get: '/v1beta1/operations'
   - selector: google.longrunning.Operations.GetOperation
-    get: '/v1beta1/{name=/operations/*}'
+    get: '/v1beta1/{name=operations/**}'
   - selector: google.longrunning.Operations.DeleteOperation
-    delete: '/v1beta1/{name=/operations/*}'
+    delete: '/v1beta1/{name=operations/**}'
   - selector: google.longrunning.Operations.CancelOperation
-    post: '/v1beta1/{name=/operations/*}:cancel'
-    
+    post: '/v1beta1/{name=operations/**}:cancel'


### PR DESCRIPTION
This is one more step in fixing the problems that prevent the client libraries from working in `webpack`.