### PR TITLE
feat: allow passing gax instance

### DIFF
--- a/baselines/asset/package.json
+++ b/baselines/asset/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -88,7 +88,7 @@ export class AssetServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './asset_service_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +88,15 @@ export class AssetServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new AssetServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AssetServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +111,13 @@ export class AssetServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -200,7 +211,7 @@ export class AssetServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -409,7 +420,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -494,7 +505,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -568,7 +579,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -641,7 +652,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -720,7 +731,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'feed.name': request.feed!.name || '',
     });
     this.initialize();
@@ -794,7 +805,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -892,7 +903,7 @@ export class AssetServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -911,9 +922,9 @@ export class AssetServiceClient {
  * region_tag:cloudasset_v1_generated_AssetService_ExportAssets_async
  */
   async checkExportAssetsProgress(name: string): Promise<LROperation<protos.google.cloud.asset.v1.ExportAssetsResponse, protos.google.cloud.asset.v1.ExportAssetsRequest>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportAssets, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.exportAssets, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.asset.v1.ExportAssetsResponse, protos.google.cloud.asset.v1.ExportAssetsRequest>;
   }
   // --------------------

--- a/baselines/bigquery-storage/package.json
+++ b/baselines/bigquery-storage/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -89,7 +89,7 @@ export class BigQueryStorageClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GoogleError} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 import {PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './big_query_storage_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -91,8 +89,15 @@ export class BigQueryStorageClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new BigQueryStorageClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof BigQueryStorageClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -107,8 +112,13 @@ export class BigQueryStorageClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -166,7 +176,7 @@ export class BigQueryStorageClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      readRows: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest')
+      readRows: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest')
     };
 
     // Put together the default options sent with requests.
@@ -180,7 +190,7 @@ export class BigQueryStorageClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -220,7 +230,7 @@ export class BigQueryStorageClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -402,7 +412,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'table_reference.project_id': request.tableReference!.projectId || '',
       'table_reference.dataset_id': request.tableReference!.datasetId || '',
     });
@@ -481,7 +491,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'session.name': request.session!.name || '',
     });
     this.initialize();
@@ -565,7 +575,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'stream.name': request.stream!.name || '',
     });
     this.initialize();
@@ -656,7 +666,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'original_stream.name': request.originalStream!.name || '',
     });
     this.initialize();
@@ -700,7 +710,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'read_position.stream.name': request.readPosition!.stream!.name || '',
     });
     this.initialize();

--- a/baselines/compute/package.json
+++ b/baselines/compute/package.json
@@ -38,7 +38,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './addresses_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -91,8 +89,15 @@ export class AddressesClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new AddressesClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AddressesClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -113,8 +118,13 @@ export class AddressesClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -175,7 +185,7 @@ export class AddressesClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -372,7 +382,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
       'address': request.address || '',
@@ -467,7 +477,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
     });
@@ -534,7 +544,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
     });
     const defaultCallSettings = this._defaults['aggregatedList'];
@@ -636,7 +646,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
     });
@@ -692,7 +702,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
     });
@@ -757,7 +767,7 @@ export class AddressesClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
     });

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -89,7 +89,7 @@ export class AddressesClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './region_operations_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -87,8 +86,15 @@ export class RegionOperationsClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new RegionOperationsClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof RegionOperationsClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -109,8 +115,13 @@ export class RegionOperationsClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -161,7 +172,7 @@ export class RegionOperationsClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -347,7 +358,7 @@ export class RegionOperationsClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
       'operation': request.operation || '',
@@ -428,7 +439,7 @@ export class RegionOperationsClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'project': request.project || '',
       'region': request.region || '',
       'operation': request.operation || '',

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -86,7 +86,7 @@ export class RegionOperationsClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/deprecatedtest/package.json
+++ b/baselines/deprecatedtest/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './deprecated_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +88,15 @@ export class DeprecatedServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new DeprecatedServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DeprecatedServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +111,13 @@ export class DeprecatedServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -160,7 +171,7 @@ export class DeprecatedServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -88,7 +88,7 @@ export class DeprecatedServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/disable-packing-test/package.json
+++ b/baselines/disable-packing-test/package.json
@@ -40,7 +40,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -17,11 +17,9 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
-
-import {Transform} from 'stream';
-import {PassThrough} from 'stream';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -30,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './echo_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -95,8 +92,15 @@ export class EchoClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new EchoClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -111,8 +115,13 @@ export class EchoClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -199,9 +208,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
@@ -240,7 +249,7 @@ export class EchoClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -280,7 +289,7 @@ export class EchoClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -695,9 +704,9 @@ export class EchoClient {
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
  */
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -92,7 +92,7 @@ export class EchoClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -87,7 +87,7 @@ export class IdentityClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './identity_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +87,15 @@ export class IdentityClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new IdentityClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +110,13 @@ export class IdentityClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -201,7 +211,7 @@ export class IdentityClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -446,7 +456,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -520,7 +530,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'user.name': request.user!.name || '',
     });
     this.initialize();
@@ -591,7 +601,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -17,11 +17,9 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
-
-import {Transform} from 'stream';
-import {PassThrough} from 'stream';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -30,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './messaging_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -94,8 +91,15 @@ export class MessagingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new MessagingClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -110,8 +114,13 @@ export class MessagingClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -200,9 +209,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      connect: new this._gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
@@ -241,7 +250,7 @@ export class MessagingClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -281,7 +290,7 @@ export class MessagingClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -495,7 +504,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -569,7 +578,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'room.name': request.room!.name || '',
     });
     this.initialize();
@@ -640,7 +649,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -716,7 +725,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -787,7 +796,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -861,7 +870,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'blurb.name': request.blurb!.name || '',
     });
     this.initialize();
@@ -932,7 +941,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -969,7 +978,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1129,7 +1138,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1148,9 +1157,9 @@ export class MessagingClient {
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
  */
   async checkSearchBlurbsProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
  /**
@@ -1393,7 +1402,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1436,7 +1445,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
@@ -1488,7 +1497,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -91,7 +91,7 @@ export class MessagingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './testing_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class TestingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new TestingClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -106,8 +111,13 @@ export class TestingClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -204,7 +214,7 @@ export class TestingClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -451,7 +461,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -522,7 +532,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -595,7 +605,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -671,7 +681,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -749,7 +759,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -982,7 +992,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1021,7 +1031,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTests'];
@@ -1069,7 +1079,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTests'];

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -88,7 +88,7 @@ export class TestingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/dlp/package.json
+++ b/baselines/dlp/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './dlp_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -97,8 +95,15 @@ export class DlpServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new DlpServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof DlpServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -113,8 +118,13 @@ export class DlpServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -220,7 +230,7 @@ export class DlpServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -423,7 +433,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -514,7 +524,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -618,7 +628,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -724,7 +734,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -806,7 +816,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'location_id': request.locationId || '',
     });
     this.initialize();
@@ -890,7 +900,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -969,7 +979,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1043,7 +1053,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1117,7 +1127,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1202,7 +1212,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -1282,7 +1292,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1357,7 +1367,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1432,7 +1442,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1515,7 +1525,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -1593,7 +1603,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1666,7 +1676,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1739,7 +1749,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1812,7 +1822,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1901,7 +1911,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -1975,7 +1985,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2050,7 +2060,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2125,7 +2135,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2209,7 +2219,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2292,7 +2302,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2367,7 +2377,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2442,7 +2452,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -2544,7 +2554,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2604,7 +2614,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2673,7 +2683,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2782,7 +2792,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2842,7 +2852,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -2911,7 +2921,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3045,7 +3055,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3131,7 +3141,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3226,7 +3236,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3363,7 +3373,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3451,7 +3461,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3548,7 +3558,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3658,7 +3668,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3719,7 +3729,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });
@@ -3789,7 +3799,7 @@ export class DlpServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
       'location_id': request.locationId || '',
     });

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -95,7 +95,7 @@ export class DlpServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/kms/package.json
+++ b/baselines/kms/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -97,7 +97,7 @@ export class KeyManagementServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './key_management_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -99,8 +97,15 @@ export class KeyManagementServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new KeyManagementServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof KeyManagementServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -115,8 +120,13 @@ export class KeyManagementServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -137,7 +147,7 @@ export class KeyManagementServiceClient {
     if (servicePath === staticMembers.servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
 
     // Determine the client header string.
@@ -186,7 +196,7 @@ export class KeyManagementServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -368,7 +378,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -440,7 +450,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -511,7 +521,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -586,7 +596,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -657,7 +667,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -734,7 +744,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -821,7 +831,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -899,7 +909,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1002,7 +1012,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1081,7 +1091,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1154,7 +1164,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'crypto_key.name': request.cryptoKey!.name || '',
     });
     this.initialize();
@@ -1233,7 +1243,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'crypto_key_version.name': request.cryptoKeyVersion!.name || '',
     });
     this.initialize();
@@ -1329,7 +1339,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1408,7 +1418,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1485,7 +1495,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1562,7 +1572,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1637,7 +1647,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1719,7 +1729,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1796,7 +1806,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1887,7 +1897,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1936,7 +1946,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listKeyRings'];
@@ -1994,7 +2004,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listKeyRings'];
@@ -2092,7 +2102,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -2143,7 +2153,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeys'];
@@ -2203,7 +2213,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeys'];
@@ -2302,7 +2312,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -2354,7 +2364,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeyVersions'];
@@ -2415,7 +2425,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeyVersions'];
@@ -2511,7 +2521,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -2560,7 +2570,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listImportJobs'];
@@ -2618,7 +2628,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listImportJobs'];

--- a/baselines/logging/package.json
+++ b/baselines/logging/package.json
@@ -39,7 +39,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './config_service_v2_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +87,15 @@ export class ConfigServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new ConfigServiceV2Client({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ConfigServiceV2Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +110,13 @@ export class ConfigServiceV2Client {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -247,7 +257,7 @@ export class ConfigServiceV2Client {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -439,7 +449,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -541,7 +551,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -619,7 +629,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'sink_name': request.sinkName || '',
     });
     this.initialize();
@@ -715,7 +725,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -828,7 +838,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'sink_name': request.sinkName || '',
     });
     this.initialize();
@@ -908,7 +918,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'sink_name': request.sinkName || '',
     });
     this.initialize();
@@ -986,7 +996,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1069,7 +1079,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1158,7 +1168,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1236,7 +1246,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1325,7 +1335,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1433,7 +1443,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1528,7 +1538,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1581,7 +1591,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBuckets'];
@@ -1643,7 +1653,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBuckets'];
@@ -1739,7 +1749,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1788,7 +1798,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listSinks'];
@@ -1846,7 +1856,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listSinks'];
@@ -1942,7 +1952,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1991,7 +2001,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listExclusions'];
@@ -2049,7 +2059,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listExclusions'];

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -87,7 +87,7 @@ export class ConfigServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -87,7 +87,7 @@ export class LoggingServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './logging_service_v2_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +87,15 @@ export class LoggingServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new LoggingServiceV2Client({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof LoggingServiceV2Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +110,13 @@ export class LoggingServiceV2Client {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -260,7 +270,7 @@ export class LoggingServiceV2Client {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -460,7 +470,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'log_name': request.logName || '',
     });
     this.initialize();
@@ -1102,7 +1112,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1151,7 +1161,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listLogs'];
@@ -1209,7 +1219,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listLogs'];

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -87,7 +87,7 @@ export class MetricsServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './metrics_service_v2_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +87,15 @@ export class MetricsServiceV2Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new MetricsServiceV2Client({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricsServiceV2Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -105,8 +110,13 @@ export class MetricsServiceV2Client {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -240,7 +250,7 @@ export class MetricsServiceV2Client {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -427,7 +437,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'metric_name': request.metricName || '',
     });
     this.initialize();
@@ -505,7 +515,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -584,7 +594,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'metric_name': request.metricName || '',
     });
     this.initialize();
@@ -657,7 +667,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'metric_name': request.metricName || '',
     });
     this.initialize();
@@ -745,7 +755,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -791,7 +801,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listLogMetrics'];
@@ -846,7 +856,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listLogMetrics'];

--- a/baselines/monitoring/package.json
+++ b/baselines/monitoring/package.json
@@ -42,7 +42,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './alert_policy_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -97,8 +95,15 @@ export class AlertPolicyServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new AlertPolicyServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof AlertPolicyServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -113,8 +118,13 @@ export class AlertPolicyServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -254,7 +264,7 @@ export class AlertPolicyServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -439,7 +449,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -521,7 +531,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -596,7 +606,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -695,7 +705,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'alert_policy.name': request.alertPolicy!.name || '',
     });
     this.initialize();
@@ -799,7 +809,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -861,7 +871,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listAlertPolicies'];
@@ -932,7 +942,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listAlertPolicies'];

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -95,7 +95,7 @@ export class AlertPolicyServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './group_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -100,8 +98,15 @@ export class GroupServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new GroupServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof GroupServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -116,8 +121,13 @@ export class GroupServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -259,7 +269,7 @@ export class GroupServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -443,7 +453,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -520,7 +530,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -595,7 +605,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'group.name': request.group!.name || '',
     });
     this.initialize();
@@ -671,7 +681,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -770,7 +780,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -827,7 +837,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listGroups'];
@@ -893,7 +903,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listGroups'];
@@ -995,7 +1005,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1050,7 +1060,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listGroupMembers'];
@@ -1114,7 +1124,7 @@ export class GroupServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listGroupMembers'];

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -98,7 +98,7 @@ export class GroupServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './metric_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class MetricServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new MetricServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MetricServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -106,8 +111,13 @@ export class MetricServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -269,7 +279,7 @@ export class MetricServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -456,7 +466,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -530,7 +540,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -607,7 +617,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -682,7 +692,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -765,7 +775,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -857,7 +867,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -907,7 +917,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listMonitoredResourceDescriptors'];
@@ -966,7 +976,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listMonitoredResourceDescriptors'];
@@ -1064,7 +1074,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1115,7 +1125,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listMetricDescriptors'];
@@ -1175,7 +1185,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listMetricDescriptors'];
@@ -1291,7 +1301,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1360,7 +1370,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listTimeSeries'];
@@ -1438,7 +1448,7 @@ export class MetricServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listTimeSeries'];

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -88,7 +88,7 @@ export class MetricServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -88,7 +88,7 @@ export class NotificationChannelServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './notification_channel_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class NotificationChannelServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new NotificationChannelServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NotificationChannelServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -106,8 +111,13 @@ export class NotificationChannelServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -249,7 +259,7 @@ export class NotificationChannelServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -434,7 +444,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -510,7 +520,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -591,7 +601,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -668,7 +678,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'notification_channel.name': request.notificationChannel!.name || '',
     });
     this.initialize();
@@ -745,7 +755,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -817,7 +827,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -920,7 +930,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1001,7 +1011,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1095,7 +1105,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1146,7 +1156,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannelDescriptors'];
@@ -1206,7 +1216,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannelDescriptors'];
@@ -1315,7 +1325,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1377,7 +1387,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannels'];
@@ -1448,7 +1458,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannels'];

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './service_monitoring_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -92,8 +90,15 @@ export class ServiceMonitoringServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new ServiceMonitoringServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof ServiceMonitoringServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -108,8 +113,13 @@ export class ServiceMonitoringServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -251,7 +261,7 @@ export class ServiceMonitoringServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -440,7 +450,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -512,7 +522,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -586,7 +596,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'service.name': request.service!.name || '',
     });
     this.initialize();
@@ -658,7 +668,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -738,7 +748,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -816,7 +826,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -890,7 +900,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'service_level_objective.name': request.serviceLevelObjective!.name || '',
     });
     this.initialize();
@@ -963,7 +973,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1064,7 +1074,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1123,7 +1133,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listServices'];
@@ -1191,7 +1201,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listServices'];
@@ -1288,7 +1298,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1338,7 +1348,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listServiceLevelObjectives'];
@@ -1397,7 +1407,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listServiceLevelObjectives'];

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -90,7 +90,7 @@ export class ServiceMonitoringServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './uptime_check_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -96,8 +94,15 @@ export class UptimeCheckServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new UptimeCheckServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof UptimeCheckServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -112,8 +117,13 @@ export class UptimeCheckServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -255,7 +265,7 @@ export class UptimeCheckServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -439,7 +449,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -513,7 +523,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -602,7 +612,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'uptime_check_config.name': request.uptimeCheckConfig!.name || '',
     });
     this.initialize();
@@ -676,7 +686,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -764,7 +774,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -809,7 +819,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listUptimeCheckConfigs'];
@@ -863,7 +873,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listUptimeCheckConfigs'];

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -94,7 +94,7 @@ export class UptimeCheckServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/naming/package.json
+++ b/baselines/naming/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -88,7 +88,7 @@ export class NamingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './naming_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class NamingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new NamingClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof NamingClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath1;
@@ -106,8 +111,13 @@ export class NamingClient {
       opts['scopes'] = staticMembers.scopes1;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -206,7 +216,7 @@ export class NamingClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -1096,9 +1106,9 @@ export class NamingClient {
  * region_tag:localhost_v1beta1_generated_Naming_LongRunning_async
  */
   async checkLongRunningProgress1(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.longRunning, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.longRunning, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>;
   }
  /**

--- a/baselines/redis/package.json
+++ b/baselines/redis/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './cloud_redis_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -104,8 +102,15 @@ export class CloudRedisClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new CloudRedisClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudRedisClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -120,8 +125,13 @@ export class CloudRedisClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -260,7 +270,7 @@ export class CloudRedisClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -444,7 +454,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -542,7 +552,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -561,9 +571,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_CreateInstance_async
  */
   async checkCreateInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.createInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -647,7 +657,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'instance.name': request.instance!.name || '',
     });
     this.initialize();
@@ -666,9 +676,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_UpdateInstance_async
  */
   async checkUpdateInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.updateInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.updateInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -749,7 +759,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -768,9 +778,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_ImportInstance_async
  */
   async checkImportInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.importInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.importInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -849,7 +859,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -868,9 +878,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_ExportInstance_async
  */
   async checkExportInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.exportInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.exportInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -946,7 +956,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -965,9 +975,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_FailoverInstance_async
  */
   async checkFailoverInstanceProgress(name: string): Promise<LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.failoverInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.failoverInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.redis.v1beta1.Instance, protos.google.protobuf.Any>;
   }
 /**
@@ -1040,7 +1050,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1059,9 +1069,9 @@ export class CloudRedisClient {
  * region_tag:redis_v1beta1_generated_CloudRedis_DeleteInstance_async
  */
   async checkDeleteInstanceProgress(name: string): Promise<LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteInstance, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.deleteInstance, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Any>;
   }
  /**
@@ -1154,7 +1164,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1202,7 +1212,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listInstances'];
@@ -1259,7 +1269,7 @@ export class CloudRedisClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listInstances'];

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -102,7 +102,7 @@ export class CloudRedisClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/routingtest/package.json
+++ b/baselines/routingtest/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './test_service_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -88,8 +87,15 @@ export class TestServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new TestServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -104,8 +110,13 @@ export class TestServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -159,7 +170,7 @@ export class TestServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -356,7 +367,7 @@ export class TestServiceClient {
     }
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams(
+    ] = this._gaxModule.routingHeader.fromParams(
       routingParameter
     );
     this.initialize();
@@ -454,7 +465,7 @@ export class TestServiceClient {
     }
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams(
+    ] = this._gaxModule.routingHeader.fromParams(
       routingParameter
     );
     this.initialize();
@@ -562,7 +573,7 @@ export class TestServiceClient {
     }
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams(
+    ] = this._gaxModule.routingHeader.fromParams(
       routingParameter
     );
     this.initialize();

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -87,7 +87,7 @@ export class TestServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/showcase-legacy/package.json
+++ b/baselines/showcase-legacy/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -86,7 +86,7 @@ export class EchoClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -16,7 +16,7 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import type * as gax from 'google-gax';
+import * as gax from 'google-gax';
 import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
@@ -86,15 +86,8 @@ export class EchoClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
-   *     need to avoid loading the default gRPC version and want to use the fallback
-   *     HTTP implementation. Load only fallback version and pass it to the constructor:
-   *     ```
-   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
-   *     const client = new EchoClient({fallback: 'rest'}, gax);
-   *     ```
    */
-  constructor(opts?: ClientOptions, gaxInstance?: typeof gax) {
+  constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -108,13 +101,8 @@ export class EchoClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
-    // Load google-gax module synchronously if needed
-    if (!gaxInstance) {
-      gaxInstance = require('google-gax') as typeof gax;
-    }
-
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = gaxInstance;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -16,11 +16,9 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError} from 'google-gax';
-
-import {Transform} from 'stream';
-import {PassThrough} from 'stream';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import * as path from 'path';
 /**
@@ -29,7 +27,6 @@ import * as path from 'path';
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './echo_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -89,8 +86,15 @@ export class EchoClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new EchoClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -104,8 +108,13 @@ export class EchoClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = gax;
+    this._gaxModule = gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -158,9 +167,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
     };
 
     let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();
@@ -198,7 +207,7 @@ export class EchoClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -236,7 +245,7 @@ export class EchoClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -651,9 +660,9 @@ export class EchoClient {
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
  */
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -94,7 +94,7 @@ export class EchoClient {
    *     const client = new EchoClient({fallback: 'rest'}, gax);
    *     ```
    */
-  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;

--- a/baselines/showcase/package.json
+++ b/baselines/showcase/package.json
@@ -40,7 +40,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -94,7 +94,7 @@ export class EchoClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -17,11 +17,9 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
-
-import {Transform} from 'stream';
-import {PassThrough} from 'stream';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -30,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './echo_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -97,8 +94,15 @@ export class EchoClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new EchoClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof EchoClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -113,8 +117,13 @@ export class EchoClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -135,9 +144,9 @@ export class EchoClient {
     if (servicePath === staticMembers.servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
   
 
     // Determine the client header string.
@@ -205,9 +214,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
@@ -249,7 +258,7 @@ export class EchoClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -289,7 +298,7 @@ export class EchoClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -704,9 +713,9 @@ export class EchoClient {
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
  */
   async checkWaitProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.wait, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.WaitResponse, protos.google.showcase.v1beta1.WaitMetadata>;
   }
  /**

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -146,7 +146,10 @@ export class EchoClient {
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(
+      this._gaxGrpc,
+      opts
+    );
   
 
     // Determine the client header string.

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -90,7 +90,7 @@ export class IdentityClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -142,7 +142,10 @@ export class IdentityClient {
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(
+      this._gaxGrpc,
+      opts
+    );
   
 
     // Determine the client header string.

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './identity_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -92,8 +90,15 @@ export class IdentityClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new IdentityClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof IdentityClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -108,8 +113,13 @@ export class IdentityClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -130,9 +140,9 @@ export class IdentityClient {
     if (servicePath === staticMembers.servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
   
 
     // Determine the client header string.
@@ -228,7 +238,7 @@ export class IdentityClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -473,7 +483,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -547,7 +557,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'user.name': request.user!.name || '',
     });
     this.initialize();
@@ -618,7 +628,7 @@ export class IdentityClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -145,7 +145,10 @@ export class MessagingClient {
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(
+      this._gaxGrpc,
+      opts
+    );
   
 
     // Determine the client header string.

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -93,7 +93,7 @@ export class MessagingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -17,11 +17,9 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, GoogleError, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
-
-import {Transform} from 'stream';
-import {PassThrough} from 'stream';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -30,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './messaging_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -96,8 +93,15 @@ export class MessagingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new MessagingClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof MessagingClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -112,8 +116,13 @@ export class MessagingClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,9 +143,9 @@ export class MessagingClient {
     if (servicePath === staticMembers.servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
   
 
     // Determine the client header string.
@@ -206,9 +215,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(gax.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      connect: new this._gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
@@ -250,7 +259,7 @@ export class MessagingClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -290,7 +299,7 @@ export class MessagingClient {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -504,7 +513,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -578,7 +587,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'room.name': request.room!.name || '',
     });
     this.initialize();
@@ -649,7 +658,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -725,7 +734,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -796,7 +805,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -870,7 +879,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'blurb.name': request.blurb!.name || '',
     });
     this.initialize();
@@ -941,7 +950,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -978,7 +987,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1138,7 +1147,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1157,9 +1166,9 @@ export class MessagingClient {
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
  */
   async checkSearchBlurbsProgress(name: string): Promise<LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.searchBlurbs, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.showcase.v1beta1.SearchBlurbsResponse, protos.google.showcase.v1beta1.SearchBlurbsMetadata>;
   }
  /**
@@ -1402,7 +1411,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1445,7 +1454,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
@@ -1497,7 +1506,7 @@ export class MessagingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, PaginationCallback, GaxCall, IamClient, IamProtos, LocationsClient, LocationProtos} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './testing_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -93,8 +91,15 @@ export class TestingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new TestingClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TestingClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -109,8 +114,13 @@ export class TestingClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -131,9 +141,9 @@ export class TestingClient {
     if (servicePath === staticMembers.servicePath) {
       this.auth.defaultScopes = staticMembers.scopes;
     }
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
   
 
     // Determine the client header string.
@@ -231,7 +241,7 @@ export class TestingClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -478,7 +488,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -549,7 +559,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -622,7 +632,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -698,7 +708,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -776,7 +786,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1009,7 +1019,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1048,7 +1058,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTests'];
@@ -1096,7 +1106,7 @@ export class TestingClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTests'];

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -143,7 +143,10 @@ export class TestingClient {
     }
     this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   
-    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(
+      this._gaxGrpc,
+      opts
+    );
   
 
     // Determine the client header string.

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -91,7 +91,7 @@ export class TestingClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/tasks/package.json
+++ b/baselines/tasks/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './cloud_tasks_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class CloudTasksClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new CloudTasksClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof CloudTasksClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -106,8 +111,13 @@ export class CloudTasksClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -183,7 +193,7 @@ export class CloudTasksClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -365,7 +375,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -456,7 +466,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -551,7 +561,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'queue.name': request.queue!.name || '',
     });
     this.initialize();
@@ -635,7 +645,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -712,7 +722,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -790,7 +800,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -874,7 +884,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -957,7 +967,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'resource': request.resource || '',
     });
     this.initialize();
@@ -1044,7 +1054,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'resource': request.resource || '',
     });
     this.initialize();
@@ -1127,7 +1137,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'resource': request.resource || '',
     });
     this.initialize();
@@ -1212,7 +1222,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1337,7 +1347,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1413,7 +1423,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1521,7 +1531,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1630,7 +1640,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1695,7 +1705,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listQueues'];
@@ -1769,7 +1779,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listQueues'];
@@ -1892,7 +1902,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1960,7 +1970,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTasks'];
@@ -2037,7 +2047,7 @@ export class CloudTasksClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listTasks'];

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -88,7 +88,7 @@ export class CloudTasksClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/texttospeech/package.json
+++ b/baselines/texttospeech/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './text_to_speech_client_config.json';
-
 const version = require('../../../package.json').version;
 
 /**
@@ -87,8 +86,15 @@ export class TextToSpeechClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new TextToSpeechClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TextToSpeechClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -103,8 +109,13 @@ export class TextToSpeechClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -158,7 +169,7 @@ export class TextToSpeechClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -86,7 +86,7 @@ export class TextToSpeechClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/translate/package.json
+++ b/baselines/translate/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -88,7 +88,7 @@ export class TranslationServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -17,9 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
-
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -29,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './translation_service_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -90,8 +88,15 @@ export class TranslationServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new TranslationServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof TranslationServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -106,8 +111,13 @@ export class TranslationServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -222,7 +232,7 @@ export class TranslationServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -465,7 +475,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -570,7 +580,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -672,7 +682,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -744,7 +754,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -874,7 +884,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -893,9 +903,9 @@ export class TranslationServiceClient {
  * region_tag:translate_v3beta1_generated_TranslationService_BatchTranslateText_async
  */
   async checkBatchTranslateTextProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.batchTranslateText, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.batchTranslateText, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.BatchTranslateResponse, protos.google.cloud.translation.v3beta1.BatchTranslateMetadata>;
   }
 /**
@@ -968,7 +978,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -987,9 +997,9 @@ export class TranslationServiceClient {
  * region_tag:translate_v3beta1_generated_TranslationService_CreateGlossary_async
  */
   async checkCreateGlossaryProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.createGlossary, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.createGlossary, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.Glossary, protos.google.cloud.translation.v3beta1.CreateGlossaryMetadata>;
   }
 /**
@@ -1061,7 +1071,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'name': request.name || '',
     });
     this.initialize();
@@ -1080,9 +1090,9 @@ export class TranslationServiceClient {
  * region_tag:translate_v3beta1_generated_TranslationService_DeleteGlossary_async
  */
   async checkDeleteGlossaryProgress(name: string): Promise<LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.deleteGlossary, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.deleteGlossary, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.translation.v3beta1.DeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.DeleteGlossaryMetadata>;
   }
  /**
@@ -1168,7 +1178,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     this.initialize();
@@ -1215,7 +1225,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listGlossaries'];
@@ -1271,7 +1281,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers = options.otherArgs.headers || {};
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
       'parent': request.parent || '',
     });
     const defaultCallSettings = this._defaults['listGlossaries'];

--- a/baselines/videointelligence/package.json
+++ b/baselines/videointelligence/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -87,7 +87,7 @@ export class VideoIntelligenceServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 /* global window */
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation} from 'google-gax';
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation} from 'google-gax';
 
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -28,7 +28,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -88,8 +87,15 @@ export class VideoIntelligenceServiceClient {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new VideoIntelligenceServiceClient({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof VideoIntelligenceServiceClient;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
@@ -104,8 +110,13 @@ export class VideoIntelligenceServiceClient {
       opts['scopes'] = staticMembers.scopes;
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = opts.fallback ? gaxInstance.fallback : gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -184,7 +195,7 @@ export class VideoIntelligenceServiceClient {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -413,9 +424,9 @@ export class VideoIntelligenceServiceClient {
  * region_tag:videointelligence_v1_generated_VideoIntelligenceService_AnnotateVideo_async
  */
   async checkAnnotateVideoProgress(name: string): Promise<LROperation<protos.google.cloud.videointelligence.v1.AnnotateVideoResponse, protos.google.cloud.videointelligence.v1.AnnotateVideoProgress>>{
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.annotateVideo, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.annotateVideo, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos.google.cloud.videointelligence.v1.AnnotateVideoResponse, protos.google.cloud.videointelligence.v1.AnnotateVideoProgress>;
   }
 

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -280,14 +280,14 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endfor %}
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams(
+    ] = this._gaxModule.routingHeader.fromParams(
       routingParameter
     );
 {%- elif method.headerRequestParams.length > 0 %}
 {#- either dynamic routing parameters are set, or implicit parameters, but not both #}
     options.otherArgs.headers[
       'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
+    ] = this._gaxModule.routingHeader.fromParams({
 {%- for requestParam in method.headerRequestParams %}
       '{{ requestParam.toSnakeCaseString(".") }}': request.{{ requestParam.toCamelCaseString("!.") }} || '',
 {%- endfor %}

--- a/templates/typescript_gapic/package.json
+++ b/templates/typescript_gapic/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.2.2"
+    "google-gax": "^3.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -136,7 +136,7 @@ export class {{ service.name }}Client {
    *     const client = new {{ service.name }}Client({fallback: 'rest'}, gax);
    *     ```
    */
-  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax{% if not api.legacyProtoLoad %} | typeof gax.fallback{% endif %}) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -128,7 +128,7 @@ export class {{ service.name }}Client {
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
 {%- endif %}
-   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
    *     ```

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -26,20 +26,20 @@ limitations under the License.
 {% import "../../_operations.njk" as operations -%}
 {% import "../../_namer.njk" as namer -%}
 {{- namer.initialize(id, service) -}}
-import * as gax from 'google-gax';
-import {Callback, CallOptions, Descriptors, ClientOptions
+import type * as gax from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions
 {%- if service.longRunning.length > 0 or service.LongRunningOperationsMixin > 0%}, GrpcClientOptions{%- endif -%}
 {%- if service.longRunning.length > 0 or service.diregapicLRO.length > 0 %}, LROperation{%- endif -%}
 {%- if service.paging.length > 0 %}, PaginationCallback, GaxCall{%- endif -%}
-{%- if service.streaming.length > 0 %}, GoogleError{%- endif -%}
 {%- if service.IAMPolicyMixin > 0 %}, IamClient, IamProtos{%- endif -%}
 {%- if service.LocationMixin > 0 %}, LocationsClient, LocationProtos{%- endif -%}
 } from 'google-gax';
-{% if service.paging.length > 0 %}
-import {Transform} from 'stream';
-{%- endif %}
-{%- if service.streaming.length > 0 %}
-import {PassThrough} from 'stream';
+{% if service.paging.length > 0 or service.streaming.length > 0 -%}
+{% set importStreamJoiner = joiner(', ') -%}
+import {
+{%- if service.paging.length > 0 -%}{{- importStreamJoiner() -}}Transform{%- endif -%}
+{%- if service.streaming.length > 0 -%}{{- importStreamJoiner() -}}PassThrough{%- endif -%}
+} from 'stream';
 {%- endif %}
 import * as protos from '../../protos/protos';
 {%- if api.legacyProtoLoad %}
@@ -53,9 +53,6 @@ import jsonProtos = require('../../protos/protos.json');
  * This file defines retry strategy and timeouts for all API methods in this library.
  */
 import * as gapicConfig from './{{ service.name.toSnakeCase() }}_client_config.json';
-{% if service.longRunning.length > 0 -%}
-import {operationsProtos} from 'google-gax';
-{%- endif %}
 const version = require('../../../package.json').version;
 
 /**
@@ -131,8 +128,15 @@ export class {{ service.name }}Client {
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
 {%- endif %}
+   * @param {gax} gaxInstance: loaded instance of `google-gax`. Useful if you
+   *     need to avoid loading the default gRPC version and want to use the fallback
+   *     HTTP implementation. Load only fallback version and pass it to the constructor:
+   *     ```
+   *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
+   *     const client = new {{ service.name }}Client({fallback: 'rest'}, gax);
+   *     ```
    */
-  constructor(opts?: ClientOptions) {
+  constructor(opts?: ClientOptions, gaxInstance?: typeof gax | typeof gax.fallback) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
@@ -159,8 +163,13 @@ export class {{ service.name }}Client {
       opts['scopes'] = staticMembers.{{ id.get("scopes") }};
     }
 
+    // Load google-gax module synchronously if needed
+    if (!gaxInstance) {
+      gaxInstance = require('google-gax') as typeof gax;
+    }
+
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = {% if not api.legacyProtoLoad %}opts.fallback ? gax.fallback : {% endif %}gax;
+    this._gaxModule = {% if not api.legacyProtoLoad %}opts.fallback ? gaxInstance.fallback : {% endif %}gaxInstance;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -185,11 +194,11 @@ export class {{ service.name }}Client {
       this.auth.defaultScopes = staticMembers.{{ id.get("scopes") }};
     }
   {%- if service.IAMPolicyMixin > 0 %}
-    this.iamClient = new IamClient(this._gaxGrpc, opts);
+    this.iamClient = new this._gaxModule.IamClient(this._gaxGrpc, opts);
   {% endif %}
 
   {%- if service.LocationMixin > 0 %}
-    this.locationsClient = new LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
   {% endif %}
 
     // Determine the client header string.
@@ -263,7 +272,7 @@ export class {{ service.name }}Client {
 {%- set streamingJoiner = joiner() %}
 {%- for method in service.streaming %}
       {{- streamingJoiner() }}
-      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(gax.StreamType.{{ method.streaming }}, opts.fallback === 'rest')
+      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, opts.fallback === 'rest')
 {%- endfor %}
     };
 {%- endif %}
@@ -354,7 +363,7 @@ export class {{ service.name }}Client {
     this.innerApiCalls = {};
 
     // Add a warn function to the client constructor so it can be easily tested.
-    this.warn = gax.warn;
+    this.warn = this._gaxModule.warn;
   }
 
   /**
@@ -408,7 +417,7 @@ export class {{ service.name }}Client {
             if (methodName in this.descriptors.stream) {
               const stream = new PassThrough();
               setImmediate(() => {
-                stream.emit('error', new GoogleError('The client has already been closed.'));
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
               });
               return stream;
             }
@@ -768,9 +777,9 @@ export class {{ service.name }}Client {
     {%- if method.options and method.options.deprecated %}
     this.warn('DEP${{service.name}}-${{decodeMethodName}}','{{decodeMethodName}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}
-    const request = new operationsProtos.google.longrunning.GetOperationRequest({name});
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
     const [operation] = await this.operationsClient.getOperation(request);
-    const decodeOperation = new gax.Operation(operation, this.descriptors.longrunning.{{ method.name.toCamelCase() }}, this._gaxModule.createDefaultBackoffSettings());
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.{{ method.name.toCamelCase() }}, this._gaxModule.createDefaultBackoffSettings());
     return decodeOperation as LROperation<protos{{ method.longRunningResponseType }}, protos{{ method.longRunningMetadataType }}>;
   }
 {%- endfor %}

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -26,7 +26,7 @@ limitations under the License.
 {% import "../../_operations.njk" as operations -%}
 {% import "../../_namer.njk" as namer -%}
 {{- namer.initialize(id, service) -}}
-import type * as gax from 'google-gax';
+import {% if not api.legacyProtoLoad %}type {% endif %}* as gax from 'google-gax';
 import type {Callback, CallOptions, Descriptors, ClientOptions
 {%- if service.longRunning.length > 0 or service.LongRunningOperationsMixin > 0%}, GrpcClientOptions{%- endif -%}
 {%- if service.longRunning.length > 0 or service.diregapicLRO.length > 0 %}, LROperation{%- endif -%}
@@ -127,7 +127,6 @@ export class {{ service.name }}Client {
    *     Pass "rest" to use HTTP/1.1 REST API instead of gRPC.
    *     For more information, please check the
    *     {@link https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#http11-rest-api-mode documentation}.
-{%- endif %}
    * @param {gax} [gaxInstance]: loaded instance of `google-gax`. Useful if you
    *     need to avoid loading the default gRPC version and want to use the fallback
    *     HTTP implementation. Load only fallback version and pass it to the constructor:
@@ -135,8 +134,9 @@ export class {{ service.name }}Client {
    *     const gax = require('google-gax/build/src/fallback'); // avoids loading google-gax with gRPC
    *     const client = new {{ service.name }}Client({fallback: 'rest'}, gax);
    *     ```
+{%- endif %}
    */
-  constructor(opts?: ClientOptions, gaxInstance?: typeof gax{% if not api.legacyProtoLoad %} | typeof gax.fallback{% endif %}) {
+  constructor(opts?: ClientOptions{% if not api.legacyProtoLoad %}, gaxInstance?: typeof gax | typeof gax.fallback{% endif %}) {
     // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof {{ service.name }}Client;
     const servicePath = opts?.servicePath || opts?.apiEndpoint || staticMembers.{{ id.get("servicePath") }};
@@ -162,14 +162,16 @@ export class {{ service.name }}Client {
     if (servicePath !== staticMembers.{{ id.get("servicePath") }} && !('scopes' in opts)) {
       opts['scopes'] = staticMembers.{{ id.get("scopes") }};
     }
+    {%- if not api.legacyProtoLoad %}
 
     // Load google-gax module synchronously if needed
     if (!gaxInstance) {
       gaxInstance = require('google-gax') as typeof gax;
     }
+    {%- endif %}
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = {% if not api.legacyProtoLoad %}opts.fallback ? gaxInstance.fallback : {% endif %}gaxInstance;
+    this._gaxModule = {% if not api.legacyProtoLoad %}opts.fallback ? gaxInstance.fallback : gaxInstance{% else %}gax{% endif %};
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -200,7 +200,10 @@ export class {{ service.name }}Client {
   {% endif %}
 
   {%- if service.LocationMixin > 0 %}
-    this.locationsClient = new this._gaxModule.LocationsClient(this._gaxGrpc, opts);
+    this.locationsClient = new this._gaxModule.LocationsClient(
+      this._gaxGrpc,
+      opts
+    );
   {% endif %}
 
     // Determine the client header string.


### PR DESCRIPTION
Client constructors will accept `gaxInstance` and will not load `google-gax` unless needed.

Test failures are expected before https://github.com/googleapis/gax-nodejs/pull/1326 is merged and released. I will restart tests after the gax release.