### PR TITLE
fix: use _gaxModule when accessing gax for bundling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        lib-name: [showcase, kms, translate, monitoring, dlp, texttospeech, showcase-legacy, compute]
+        lib-name: [showcase, kms, translate, monitoring, dlp, texttospeech, showcase-legacy, compute, logging]
     steps:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/baselines/asset/package.json
+++ b/baselines/asset/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/bigquery-storage/package.json
+++ b/baselines/bigquery-storage/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/compute/package.json
+++ b/baselines/compute/package.json
@@ -38,7 +38,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/deprecatedtest/package.json
+++ b/baselines/deprecatedtest/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/disable-packing-test/package.json
+++ b/baselines/disable-packing-test/package.json
@@ -40,7 +40,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/dlp/package.json
+++ b/baselines/dlp/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/kms/package.json
+++ b/baselines/kms/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/logging/package.json
+++ b/baselines/logging/package.json
@@ -39,7 +39,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/logging/protos/google/logging/type/http_request.proto.baseline
+++ b/baselines/logging/protos/google/logging/type/http_request.proto.baseline
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.logging.type;
+
+import "google/protobuf/duration.proto";
+
+option csharp_namespace = "Google.Cloud.Logging.Type";
+option go_package = "google.golang.org/genproto/googleapis/logging/type;ltype";
+option java_multiple_files = true;
+option java_outer_classname = "HttpRequestProto";
+option java_package = "com.google.logging.type";
+option php_namespace = "Google\\Cloud\\Logging\\Type";
+option ruby_package = "Google::Cloud::Logging::Type";
+
+// A common proto for logging HTTP requests. Only contains semantics
+// defined by the HTTP specification. Product-specific logging
+// information MUST be defined in a separate message.
+message HttpRequest {
+  // The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
+  string request_method = 1;
+
+  // The scheme (http, https), the host name, the path and the query
+  // portion of the URL that was requested.
+  // Example: `"http://example.com/some/info?color=red"`.
+  string request_url = 2;
+
+  // The size of the HTTP request message in bytes, including the request
+  // headers and the request body.
+  int64 request_size = 3;
+
+  // The response code indicating the status of response.
+  // Examples: 200, 404.
+  int32 status = 4;
+
+  // The size of the HTTP response message sent back to the client, in bytes,
+  // including the response headers and the response body.
+  int64 response_size = 5;
+
+  // The user agent sent by the client. Example:
+  // `"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET
+  // CLR 1.0.3705)"`.
+  string user_agent = 6;
+
+  // The IP address (IPv4 or IPv6) of the client that issued the HTTP
+  // request. This field can include port information. Examples:
+  // `"192.168.1.1"`, `"10.0.0.1:80"`, `"FE80::0202:B3FF:FE1E:8329"`.
+  string remote_ip = 7;
+
+  // The IP address (IPv4 or IPv6) of the origin server that the request was
+  // sent to. This field can include port information. Examples:
+  // `"192.168.1.1"`, `"10.0.0.1:80"`, `"FE80::0202:B3FF:FE1E:8329"`.
+  string server_ip = 13;
+
+  // The referer URL of the request, as defined in
+  // [HTTP/1.1 Header Field
+  // Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
+  string referer = 8;
+
+  // The request processing latency on the server, from the time the request was
+  // received until the response was sent.
+  google.protobuf.Duration latency = 14;
+
+  // Whether or not a cache lookup was attempted.
+  bool cache_lookup = 11;
+
+  // Whether or not an entity was served from cache
+  // (with or without validation).
+  bool cache_hit = 9;
+
+  // Whether or not the response was validated with the origin server before
+  // being served from cache. This field is only meaningful if `cache_hit` is
+  // True.
+  bool cache_validated_with_origin_server = 10;
+
+  // The number of HTTP response bytes inserted into cache. Set only when a
+  // cache fill was attempted.
+  int64 cache_fill_bytes = 12;
+
+  // Protocol used for the request. Examples: "HTTP/1.1", "HTTP/2", "websocket"
+  string protocol = 15;
+}

--- a/baselines/logging/protos/google/logging/type/log_severity.proto.baseline
+++ b/baselines/logging/protos/google/logging/type/log_severity.proto.baseline
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.logging.type;
+
+option csharp_namespace = "Google.Cloud.Logging.Type";
+option go_package = "google.golang.org/genproto/googleapis/logging/type;ltype";
+option java_multiple_files = true;
+option java_outer_classname = "LogSeverityProto";
+option java_package = "com.google.logging.type";
+option objc_class_prefix = "GLOG";
+option php_namespace = "Google\\Cloud\\Logging\\Type";
+option ruby_package = "Google::Cloud::Logging::Type";
+
+// The severity of the event described in a log entry, expressed as one of the
+// standard severity levels listed below.  For your reference, the levels are
+// assigned the listed numeric values. The effect of using numeric values other
+// than those listed is undefined.
+//
+// You can filter for log entries by severity.  For example, the following
+// filter expression will match log entries with severities `INFO`, `NOTICE`,
+// and `WARNING`:
+//
+//     severity > DEBUG AND severity <= WARNING
+//
+// If you are writing log entries, you should map other severity encodings to
+// one of these standard levels. For example, you might map all of Java's FINE,
+// FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
+// original severity level in the log entry payload if you wish.
+enum LogSeverity {
+  // (0) The log entry has no assigned severity level.
+  DEFAULT = 0;
+
+  // (100) Debug or trace information.
+  DEBUG = 100;
+
+  // (200) Routine information, such as ongoing status or performance.
+  INFO = 200;
+
+  // (300) Normal but significant events, such as start up, shut down, or
+  // a configuration change.
+  NOTICE = 300;
+
+  // (400) Warning events might cause problems.
+  WARNING = 400;
+
+  // (500) Error events are likely to cause problems.
+  ERROR = 500;
+
+  // (600) Critical events cause more severe problems or outages.
+  CRITICAL = 600;
+
+  // (700) A person must take an action immediately.
+  ALERT = 700;
+
+  // (800) One or more systems are unusable.
+  EMERGENCY = 800;
+}

--- a/baselines/logging/protos/google/logging/v2/log_entry.proto.baseline
+++ b/baselines/logging/protos/google/logging/v2/log_entry.proto.baseline
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -25,8 +24,6 @@ import "google/logging/type/log_severity.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/rpc/status.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -35,10 +32,9 @@ option java_multiple_files = true;
 option java_outer_classname = "LogEntryProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // An individual entry in a log.
-//
-//
 message LogEntry {
   option (google.api.resource) = {
     type: "logging.googleapis.com/Log"
@@ -62,12 +58,13 @@ message LogEntry {
   //
   // `[LOG_ID]` must be URL-encoded within `log_name`. Example:
   // `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+  //
   // `[LOG_ID]` must be less than 512 characters long and can only include the
   // following characters: upper and lower case alphanumeric characters,
   // forward-slash, underscore, hyphen, and period.
   //
   // For backward compatibility, if `log_name` begins with a forward-slash, such
-  // as `/projects/...`, then the log entry is ingested as usual but the
+  // as `/projects/...`, then the log entry is ingested as usual, but the
   // forward-slash is removed. Listing the log entry will not show the leading
   // slash and filtering for a log name with a leading slash will never return
   // any results.
@@ -106,11 +103,11 @@ message LogEntry {
   // current time. Timestamps have nanosecond accuracy, but trailing zeros in
   // the fractional seconds might be omitted when the timestamp is displayed.
   //
-  // Incoming log entries should have timestamps that are no more than the [logs
-  // retention period](/logging/quotas) in the past, and no more than 24 hours
-  // in the future. Log entries outside those time boundaries will not be
-  // available when calling `entries.list`, but those log entries can still be
-  // [exported with LogSinks](/logging/docs/api/tasks/exporting-logs).
+  // Incoming log entries must have timestamps that don't exceed the
+  // [logs retention
+  // period](https://cloud.google.com/logging/quotas#logs_retention_periods) in
+  // the past, and that don't exceed 24 hours in the future. Log entries outside
+  // those time boundaries aren't ingested by Logging.
   google.protobuf.Timestamp timestamp = 9 [(google.api.field_behavior) = OPTIONAL];
 
   // Output only. The time the log entry was received by Logging.
@@ -126,7 +123,7 @@ message LogEntry {
   // de-duplication in the export of logs.
   //
   // If the `insert_id` is omitted when writing a log entry, the Logging API
-  //  assigns its own unique identifier in this field.
+  // assigns its own unique identifier in this field.
   //
   // In queries, the `insert_id` is also used to order log entries that have
   // the same `log_name` and `timestamp` values.
@@ -136,8 +133,20 @@ message LogEntry {
   // applicable.
   google.logging.type.HttpRequest http_request = 7 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. A set of user-defined (key, value) data that provides additional
-  // information about the log entry.
+  // Optional. A map of key, value pairs that provides additional information about the
+  // log entry. The labels can be user-defined or system-defined.
+  //
+  // User-defined labels are arbitrary key, value pairs that you can use to
+  // classify logs.
+  //
+  // System-defined labels are defined by GCP services for platform logs.
+  // They have two components - a service namespace component and the
+  // attribute name. For example: `compute.googleapis.com/resource_name`.
+  //
+  // Cloud Logging truncates label keys that exceed 512 B and label
+  // values that exceed 64 KB upon their associated log entry being
+  // written. The truncation is indicated by an ellipsis at the
+  // end of the character string.
   map<string, string> labels = 11 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. Information about an operation associated with the log entry, if
@@ -168,6 +177,10 @@ message LogEntry {
 
   // Optional. Source code location information associated with the log entry, if any.
   LogEntrySourceLocation source_location = 23 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Information indicating this LogEntry is part of a sequence of multiple log
+  // entries split from a single LogEntry.
+  LogSplit split = 35 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Additional information about a potentially long-running operation with which
@@ -207,4 +220,22 @@ message LogEntrySourceLocation {
   // `qual.if.ied.Class.method` (Java), `dir/package.func` (Go), `function`
   // (Python).
   string function = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Additional information used to correlate multiple log entries. Used when a
+// single LogEntry would exceed the Google Cloud Logging size limit and is
+// split across multiple log entries.
+message LogSplit {
+  // A globally unique identifier for all log entries in a sequence of split log
+  // entries. All log entries with the same |LogSplit.uid| are assumed to be
+  // part of the same sequence of split log entries.
+  string uid = 1;
+
+  // The index of this LogEntry in the sequence of split log entries. Log
+  // entries are given |index| values 0, 1, ..., n-1 for a sequence of n log
+  // entries.
+  int32 index = 2;
+
+  // The total number of log entries that the original LogEntry was split into.
+  int32 total_splits = 3;
 }

--- a/baselines/logging/protos/google/logging/v2/logging.proto.baseline
+++ b/baselines/logging/protos/google/logging/v2/logging.proto.baseline
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,23 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/monitored_resource.proto";
 import "google/api/resource.proto";
 import "google/logging/v2/log_entry.proto";
-import "google/logging/v2/logging_config.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -36,6 +33,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // Service for ingesting and querying logs.
 service LoggingServiceV2 {
@@ -47,10 +45,10 @@ service LoggingServiceV2 {
       "https://www.googleapis.com/auth/logging.read,"
       "https://www.googleapis.com/auth/logging.write";
 
-  // Deletes all the log entries in a log. The log reappears if it receives new
-  // entries. Log entries written shortly before the delete operation might not
-  // be deleted. Entries received after the delete operation with a timestamp
-  // before the operation will be deleted.
+  // Deletes all the log entries in a log for the _Default Log Bucket. The log
+  // reappears if it receives new entries. Log entries written shortly before
+  // the delete operation might not be deleted. Entries received after the
+  // delete operation with a timestamp before the operation will be deleted.
   rpc DeleteLog(DeleteLogRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v2/{log_name=projects/*/logs/*}"
@@ -87,7 +85,8 @@ service LoggingServiceV2 {
 
   // Lists log entries.  Use this method to retrieve log entries that originated
   // from a project/folder/organization/billing account.  For ways to export log
-  // entries, see [Exporting Logs](/logging/docs/export).
+  // entries, see [Exporting
+  // Logs](https://cloud.google.com/logging/docs/export).
   rpc ListLogEntries(ListLogEntriesRequest) returns (ListLogEntriesResponse) {
     option (google.api.http) = {
       post: "/v2/entries:list"
@@ -123,20 +122,30 @@ service LoggingServiceV2 {
     };
     option (google.api.method_signature) = "parent";
   }
+
+  // Streaming read of log entries as they are ingested. Until the stream is
+  // terminated, it will continue reading logs.
+  rpc TailLogEntries(stream TailLogEntriesRequest) returns (stream TailLogEntriesResponse) {
+    option (google.api.http) = {
+      post: "/v2/entries:tail"
+      body: "*"
+    };
+  }
 }
 
 // The parameters to DeleteLog.
 message DeleteLogRequest {
   // Required. The resource name of the log to delete:
   //
-  //     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-  //     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-  //     "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  // * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+  // * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+  // * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+  // * `folders/[FOLDER_ID]/logs/[LOG_ID]`
   //
   // `[LOG_ID]` must be URL-encoded. For example,
   // `"projects/my-project-id/logs/syslog"`,
-  // `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+  // `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
+  //
   // For more information about log names, see
   // [LogEntry][google.logging.v2.LogEntry].
   string log_name = 1 [
@@ -152,15 +161,15 @@ message WriteLogEntriesRequest {
   // Optional. A default log resource name that is assigned to all log entries
   // in `entries` that do not specify a value for `log_name`:
   //
-  //     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-  //     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-  //     "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  // * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+  // * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+  // * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+  // * `folders/[FOLDER_ID]/logs/[LOG_ID]`
   //
   // `[LOG_ID]` must be URL-encoded. For example:
   //
   //     "projects/my-project-id/logs/syslog"
-  //     "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+  //     "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
   //
   // The permission `logging.logEntries.create` is needed on each project,
   // organization, billing account, or folder that is receiving new log
@@ -203,15 +212,16 @@ message WriteLogEntriesRequest {
   // the entries later in the list. See the `entries.list` method.
   //
   // Log entries with timestamps that are more than the
-  // [logs retention period](/logging/quota-policy) in the past or more than
-  // 24 hours in the future will not be available when calling `entries.list`.
-  // However, those log entries can still be
-  // [exported with LogSinks](/logging/docs/api/tasks/exporting-logs).
+  // [logs retention period](https://cloud.google.com/logging/quotas) in
+  // the past or more than 24 hours in the future will not be available when
+  // calling `entries.list`. However, those log entries can still be [exported
+  // with
+  // LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
   //
   // To improve throughput and to avoid exceeding the
-  // [quota limit](/logging/quota-policy) for calls to `entries.write`,
-  // you should try to include several log entries in this list,
-  // rather than calling this method for each individual log entry.
+  // [quota limit](https://cloud.google.com/logging/quotas) for calls to
+  // `entries.write`, you should try to include several log entries in this
+  // list, rather than calling this method for each individual log entry.
   repeated LogEntry entries = 4 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Whether valid entries should be written even if some other
@@ -228,7 +238,9 @@ message WriteLogEntriesRequest {
 }
 
 // Result returned from WriteLogEntries.
-message WriteLogEntriesResponse {}
+message WriteLogEntriesResponse {
+
+}
 
 // Error details for WriteLogEntries with partial success.
 message WriteLogEntriesPartialErrors {
@@ -246,11 +258,17 @@ message ListLogEntriesRequest {
   // Required. Names of one or more parent resources from which to
   // retrieve log entries:
   //
-  //     "projects/[PROJECT_ID]"
-  //     "organizations/[ORGANIZATION_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]"
-  //     "folders/[FOLDER_ID]"
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
   //
+  // May alternatively be one or more views:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
   //
   // Projects listed in the `project_ids` field are added to this list.
   repeated string resource_names = 8 [
@@ -261,12 +279,12 @@ message ListLogEntriesRequest {
   ];
 
   // Optional. A filter that chooses which log entries to return.  See [Advanced
-  // Logs Queries](/logging/docs/view/advanced-queries).  Only log entries that
-  // match the filter are returned.  An empty filter matches all log entries in
-  // the resources listed in `resource_names`. Referencing a parent resource
-  // that is not listed in `resource_names` will cause the filter to return no
-  // results.
-  // The maximum length of the filter is 20000 characters.
+  // Logs Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+  // Only log entries that match the filter are returned.  An empty filter
+  // matches all log entries in the resources listed in `resource_names`.
+  // Referencing a parent resource that is not listed in `resource_names` will
+  // cause the filter to return no results. The maximum length of the filter is
+  // 20000 characters.
   string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. How the results should be sorted.  Presently, the only permitted
@@ -277,9 +295,10 @@ message ListLogEntriesRequest {
   // timestamps are returned in order of their `insert_id` values.
   string order_by = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. The maximum number of results to return from this request.
-  // Non-positive values are ignored.  The presence of `next_page_token` in the
-  // response indicates that more results might be available.
+  // Optional. The maximum number of results to return from this request. Default is 50.
+  // If the value is negative or exceeds 1000, the request is rejected. The
+  // presence of `next_page_token` in the response indicates that more results
+  // might be available.
   int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. If present, then retrieve the next batch of results from the
@@ -338,10 +357,10 @@ message ListMonitoredResourceDescriptorsResponse {
 message ListLogsRequest {
   // Required. The resource name that owns the logs:
   //
-  //     "projects/[PROJECT_ID]"
-  //     "organizations/[ORGANIZATION_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]"
-  //     "folders/[FOLDER_ID]"
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -359,6 +378,26 @@ message ListLogsRequest {
   // `nextPageToken` from the previous response.  The values of other method
   // parameters should be identical to those in the previous call.
   string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The resource name that owns the logs:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //
+  // To support legacy queries, it could also be:
+  //
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
+  repeated string resource_names = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.resource_reference) = {
+      child_type: "logging.googleapis.com/Log"
+    }
+  ];
 }
 
 // Result returned from ListLogs.
@@ -372,4 +411,77 @@ message ListLogsResponse {
   // `nextPageToken` is included.  To get the next set of results, call this
   // method again using the value of `nextPageToken` as `pageToken`.
   string next_page_token = 2;
+}
+
+// The parameters to `TailLogEntries`.
+message TailLogEntriesRequest {
+  // Required. Name of a parent resource from which to retrieve log entries:
+  //
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
+  //
+  // May alternatively be one or more views:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  repeated string resource_names = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. A filter that chooses which log entries to return.  See [Advanced
+  // Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
+  // Only log entries that match the filter are returned.  An empty filter
+  // matches all log entries in the resources listed in `resource_names`.
+  // Referencing a parent resource that is not in `resource_names` will cause
+  // the filter to return no results. The maximum length of the filter is 20000
+  // characters.
+  string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The amount of time to buffer log entries at the server before
+  // being returned to prevent out of order results due to late arriving log
+  // entries. Valid values are between 0-60000 milliseconds. Defaults to 2000
+  // milliseconds.
+  google.protobuf.Duration buffer_window = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Result returned from `TailLogEntries`.
+message TailLogEntriesResponse {
+  // Information about entries that were omitted from the session.
+  message SuppressionInfo {
+    // An indicator of why entries were omitted.
+    enum Reason {
+      // Unexpected default.
+      REASON_UNSPECIFIED = 0;
+
+      // Indicates suppression occurred due to relevant entries being
+      // received in excess of rate limits. For quotas and limits, see
+      // [Logging API quotas and
+      // limits](https://cloud.google.com/logging/quotas#api-limits).
+      RATE_LIMIT = 1;
+
+      // Indicates suppression occurred due to the client not consuming
+      // responses quickly enough.
+      NOT_CONSUMED = 2;
+    }
+
+    // The reason that entries were omitted from the session.
+    Reason reason = 1;
+
+    // A lower bound on the count of entries omitted due to `reason`.
+    int32 suppressed_count = 2;
+  }
+
+  // A list of log entries. Each response in the stream will order entries with
+  // increasing values of `LogEntry.timestamp`. Ordering is not guaranteed
+  // between separate responses.
+  repeated LogEntry entries = 1;
+
+  // If entries that otherwise would have been included in the session were not
+  // sent back to the client, counts of relevant entries omitted from the
+  // session with the reason that they were not included. There will be at most
+  // one of each reason per response. The counts represent the number of
+  // suppressed entries since the last streamed response.
+  repeated SuppressionInfo suppression_info = 2;
 }

--- a/baselines/logging/protos/google/logging/v2/logging_config.proto.baseline
+++ b/baselines/logging/protos/google/logging/v2/logging_config.proto.baseline
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,20 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
+import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -33,6 +32,19 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingConfigProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/OrganizationLocation"
+  pattern: "organizations/{organization}/locations/{location}"
+};
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/FolderLocation"
+  pattern: "folders/{folder}/locations/{location}"
+};
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/BillingAccountLocation"
+  pattern: "billingAccounts/{billing_account}/locations/{location}"
+};
 
 // Service for configuring sinks used to route log entries.
 service ConfigServiceV2 {
@@ -43,7 +55,7 @@ service ConfigServiceV2 {
       "https://www.googleapis.com/auth/logging.admin,"
       "https://www.googleapis.com/auth/logging.read";
 
-  // Lists buckets (Beta).
+  // Lists log buckets.
   rpc ListBuckets(ListBucketsRequest) returns (ListBucketsResponse) {
     option (google.api.http) = {
       get: "/v2/{parent=*/*/locations/*}/buckets"
@@ -63,7 +75,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent";
   }
 
-  // Gets a bucket (Beta).
+  // Gets a log bucket.
   rpc GetBucket(GetBucketRequest) returns (LogBucket) {
     option (google.api.http) = {
       get: "/v2/{name=*/*/locations/*/buckets/*}"
@@ -82,17 +94,41 @@ service ConfigServiceV2 {
     };
   }
 
-  // Updates a bucket. This method replaces the following fields in the
+  // Creates a log bucket that can be used to store log entries. After a bucket
+  // has been created, the bucket's location cannot be changed.
+  rpc CreateBucket(CreateBucketRequest) returns (LogBucket) {
+    option (google.api.http) = {
+      post: "/v2/{parent=*/*/locations/*}/buckets"
+      body: "bucket"
+      additional_bindings {
+        post: "/v2/{parent=projects/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=organizations/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=folders/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=billingAccounts/*/locations/*}/buckets"
+        body: "bucket"
+      }
+    };
+  }
+
+  // Updates a log bucket. This method replaces the following fields in the
   // existing bucket with values from the new bucket: `retention_period`
   //
   // If the retention period is decreased and the bucket is locked,
-  // FAILED_PRECONDITION will be returned.
+  // `FAILED_PRECONDITION` will be returned.
   //
-  // If the bucket has a LifecycleState of DELETE_REQUESTED, FAILED_PRECONDITION
-  // will be returned.
+  // If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then
+  // `FAILED_PRECONDITION` will be returned.
   //
-  // A buckets region may not be modified after it is created.
-  // This method is in Beta.
+  // After a bucket has been created, the bucket's location cannot be changed.
   rpc UpdateBucket(UpdateBucketRequest) returns (LogBucket) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*/locations/*/buckets/*}"
@@ -112,6 +148,168 @@ service ConfigServiceV2 {
       additional_bindings {
         patch: "/v2/{name=billingAccounts/*/locations/*/buckets/*}"
         body: "bucket"
+      }
+    };
+  }
+
+  // Deletes a log bucket.
+  //
+  // Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
+  // After 7 days, the bucket will be purged and all log entries in the bucket
+  // will be permanently deleted.
+  rpc DeleteBucket(DeleteBucketRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v2/{name=*/*/locations/*/buckets/*}"
+      additional_bindings {
+        delete: "/v2/{name=projects/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=organizations/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=folders/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=billingAccounts/*/locations/*/buckets/*}"
+      }
+    };
+  }
+
+  // Undeletes a log bucket. A bucket that has been deleted can be undeleted
+  // within the grace period of 7 days.
+  rpc UndeleteBucket(UndeleteBucketRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v2/{name=*/*/locations/*/buckets/*}:undelete"
+      body: "*"
+      additional_bindings {
+        post: "/v2/{name=projects/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=organizations/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=folders/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=billingAccounts/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+    };
+  }
+
+  // Lists views on a log bucket.
+  rpc ListViews(ListViewsRequest) returns (ListViewsResponse) {
+    option (google.api.http) = {
+      get: "/v2/{parent=*/*/locations/*/buckets/*}/views"
+      additional_bindings {
+        get: "/v2/{parent=projects/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=organizations/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=folders/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=billingAccounts/*/locations/*/buckets/*}/views"
+      }
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Gets a view on a log bucket..
+  rpc GetView(GetViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      get: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      additional_bindings {
+        get: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*/buckets/*/views/*}"
+      }
+    };
+  }
+
+  // Creates a view over log entries in a log bucket. A bucket may contain a
+  // maximum of 30 views.
+  rpc CreateView(CreateViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      post: "/v2/{parent=*/*/locations/*/buckets/*}/views"
+      body: "view"
+      additional_bindings {
+        post: "/v2/{parent=projects/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=organizations/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=folders/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=billingAccounts/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+    };
+  }
+
+  // Updates a view on a log bucket. This method replaces the following fields
+  // in the existing view with values from the new view: `filter`.
+  // If an `UNAVAILABLE` error is returned, this indicates that system is not in
+  // a state where it can update the view. If this occurs, please try again in a
+  // few minutes.
+  rpc UpdateView(UpdateViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      patch: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      body: "view"
+      additional_bindings {
+        patch: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=billingAccounts/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+    };
+  }
+
+  // Deletes a view on a log bucket.
+  // If an `UNAVAILABLE` error is returned, this indicates that system is not in
+  // a state where it can delete the view. If this occurs, please try again in a
+  // few minutes.
+  rpc DeleteView(DeleteViewRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      additional_bindings {
+        delete: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=billingAccounts/*/locations/*/buckets/*/views/*}"
       }
     };
   }
@@ -251,7 +449,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "sink_name";
   }
 
-  // Lists all the exclusions in a parent resource.
+  // Lists all the exclusions on the _Default sink in a parent resource.
   rpc ListExclusions(ListExclusionsRequest) returns (ListExclusionsResponse) {
     option (google.api.http) = {
       get: "/v2/{parent=*/*}/exclusions"
@@ -271,7 +469,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent";
   }
 
-  // Gets the description of an exclusion.
+  // Gets the description of an exclusion in the _Default sink.
   rpc GetExclusion(GetExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       get: "/v2/{name=*/*/exclusions/*}"
@@ -291,9 +489,9 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name";
   }
 
-  // Creates a new exclusion in a specified parent resource.
-  // Only log entries belonging to that resource can be excluded.
-  // You can have up to 10 exclusions in a resource.
+  // Creates a new exclusion in the _Default sink in a specified parent
+  // resource. Only log entries belonging to that resource can be excluded. You
+  // can have up to 10 exclusions in a resource.
   rpc CreateExclusion(CreateExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       post: "/v2/{parent=*/*}/exclusions"
@@ -318,7 +516,8 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent,exclusion";
   }
 
-  // Changes one or more properties of an existing exclusion.
+  // Changes one or more properties of an existing exclusion in the _Default
+  // sink.
   rpc UpdateExclusion(UpdateExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*/exclusions/*}"
@@ -343,7 +542,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name,exclusion,update_mask";
   }
 
-  // Deletes an exclusion.
+  // Deletes an exclusion in the _Default sink.
   rpc DeleteExclusion(DeleteExclusionRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v2/{name=*/*/exclusions/*}"
@@ -363,28 +562,39 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name";
   }
 
-  // Gets the Logs Router CMEK settings for the given resource.
+  // Gets the Logging CMEK settings for the given resource.
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  // Note: CMEK for the Log Router can be configured for Google Cloud projects,
+  // folders, organizations and billing accounts. Once configured for an
+  // organization, it applies to all projects and folders in the Google Cloud
+  // organization.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   rpc GetCmekSettings(GetCmekSettingsRequest) returns (CmekSettings) {
     option (google.api.http) = {
       get: "/v2/{name=*/*}/cmekSettings"
       additional_bindings {
+        get: "/v2/{name=projects/*}/cmekSettings"
+      }
+      additional_bindings {
         get: "/v2/{name=organizations/*}/cmekSettings"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*}/cmekSettings"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*}/cmekSettings"
       }
     };
   }
 
-  // Updates the Logs Router CMEK settings for the given resource.
+  // Updates the Log Router CMEK settings for the given resource.
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  // Note: CMEK for the Log Router can currently only be configured for Google
+  // Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
   //
   // [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings]
   // will fail if 1) `kms_key_name` is invalid, or 2) the associated service
@@ -392,8 +602,9 @@ service ConfigServiceV2 {
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
   // 3) access to the key is disabled.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   rpc UpdateCmekSettings(UpdateCmekSettingsRequest) returns (CmekSettings) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*}/cmekSettings"
@@ -404,9 +615,82 @@ service ConfigServiceV2 {
       }
     };
   }
+
+  // Gets the Log Router settings for the given resource.
+  //
+  // Note: Settings for the Log Router can be get for Google Cloud projects,
+  // folders, organizations and billing accounts. Currently it can only be
+  // configured for organizations. Once configured for an organization, it
+  // applies to all projects and folders in the Google Cloud organization.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  rpc GetSettings(GetSettingsRequest) returns (Settings) {
+    option (google.api.http) = {
+      get: "/v2/{name=*/*}/settings"
+      additional_bindings {
+        get: "/v2/{name=projects/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=organizations/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*}/settings"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Updates the Log Router settings for the given resource.
+  //
+  // Note: Settings for the Log Router can currently only be configured for
+  // Google Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
+  //
+  // [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings]
+  // will fail if 1) `kms_key_name` is invalid, or 2) the associated service
+  // account does not have the required
+  // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
+  // 3) access to the key is disabled. 4) `location_id` is not supported by
+  // Logging. 5) `location_id` violate OrgPolicy.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  rpc UpdateSettings(UpdateSettingsRequest) returns (Settings) {
+    option (google.api.http) = {
+      patch: "/v2/{name=*/*}/settings"
+      body: "settings"
+      additional_bindings {
+        patch: "/v2/{name=organizations/*}/settings"
+        body: "settings"
+      }
+      additional_bindings {
+        patch: "/v2/{name=folders/*}/settings"
+        body: "settings"
+      }
+    };
+    option (google.api.method_signature) = "settings,update_mask";
+  }
+
+  // Copies a set of log entries from a log bucket to a Cloud Storage bucket.
+  rpc CopyLogEntries(CopyLogEntriesRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v2/entries:copy"
+      body: "*"
+    };
+    option (google.longrunning.operation_info) = {
+      response_type: "CopyLogEntriesResponse"
+      metadata_type: "CopyLogEntriesMetadata"
+    };
+  }
 }
 
-// Describes a repository of logs (Beta).
+// Describes a repository in which log entries are stored.
 message LogBucket {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogBucket"
@@ -416,17 +700,20 @@ message LogBucket {
     pattern: "billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}"
   };
 
-  // The resource name of the bucket.
-  // For example:
-  // "projects/my-project-id/locations/my-location/buckets/my-bucket-id The
-  // supported locations are:
-  //   "global"
-  //   "us-central1"
+  // Output only. The resource name of the bucket.
   //
-  // For the location of `global` it is unspecified where logs are actually
-  // stored.
-  // Once a bucket has been created, the location can not be changed.
-  string name = 1;
+  // For example:
+  //
+  //   `projects/my-project/locations/global/buckets/my-bucket`
+  //
+  // For a list of supported locations, see [Supported
+  // Regions](https://cloud.google.com/logging/docs/region-support)
+  //
+  // For the location of `global` it is unspecified where log entries are
+  // actually stored.
+  //
+  // After a bucket has been created, the location cannot be changed.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Describes this bucket.
   string description = 3;
@@ -439,20 +726,85 @@ message LogBucket {
   google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Logs will be retained by default for this amount of time, after which they
-  // will automatically be deleted. The minimum retention period is 1 day.
-  // If this value is set to zero at bucket creation time, the default time of
-  // 30 days will be used.
+  // will automatically be deleted. The minimum retention period is 1 day. If
+  // this value is set to zero at bucket creation time, the default time of 30
+  // days will be used.
   int32 retention_days = 11;
+
+  // Whether the bucket is locked.
+  //
+  // The retention period on a locked bucket cannot be changed. Locked buckets
+  // may only be deleted if they are empty.
+  bool locked = 9;
 
   // Output only. The bucket lifecycle state.
   LifecycleState lifecycle_state = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Log entry field paths that are denied access in this bucket.
+  //
+  // The following fields and their children are eligible: `textPayload`,
+  // `jsonPayload`, `protoPayload`, `httpRequest`, `labels`, `sourceLocation`.
+  //
+  // Restricting a repeated field will restrict all values. Adding a parent will
+  // block all child fields. (e.g. `foo.bar` will block `foo.bar.baz`)
+  repeated string restricted_fields = 15;
+
+  // The CMEK settings of the log bucket. If present, new log entries written to
+  // this log bucket are encrypted using the CMEK key provided in this
+  // configuration. If a log bucket has CMEK settings, the CMEK settings cannot
+  // be disabled later by updating the log bucket. Changing the KMS key is
+  // allowed.
+  CmekSettings cmek_settings = 19;
+}
+
+// Describes a view over log entries in a bucket.
+message LogView {
+  option (google.api.resource) = {
+    type: "logging.googleapis.com/LogView"
+    pattern: "projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}"
+  };
+
+  // The resource name of the view.
+  //
+  // For example:
+  //
+  //   `projects/my-project/locations/global/buckets/my-bucket/views/my-view`
+  string name = 1;
+
+  // Describes this view.
+  string description = 3;
+
+  // Output only. The creation timestamp of the view.
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The last update timestamp of the view.
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Filter that restricts which log entries in a bucket are visible in this
+  // view.
+  //
+  // Filters are restricted to be a logical AND of ==/!= of any of the
+  // following:
+  //
+  //   - originating project/folder/organization/billing account.
+  //   - resource type
+  //   - log id
+  //
+  // For example:
+  //
+  //   SOURCE("projects/myproject") AND resource.type = "gce_instance"
+  //                                AND LOG_ID("stdout")
+  string filter = 7;
 }
 
 // Describes a sink used to export log entries to one of the following
-// destinations in any project: a Cloud Storage bucket, a BigQuery dataset, or a
-// Cloud Pub/Sub topic. A logs filter controls which log entries are exported.
-// The sink must be created within a project, organization, billing account, or
-// folder.
+// destinations in any project: a Cloud Storage bucket, a BigQuery dataset, a
+// Pub/Sub topic or a Cloud Logging log bucket. A logs filter controls which log
+// entries are exported. The sink must be created within a project,
+// organization, billing account, or folder.
 message LogSink {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogSink"
@@ -462,9 +814,7 @@ message LogSink {
     pattern: "billingAccounts/{billing_account}/sinks/{sink}"
   };
 
-  // Available log entry formats. Log entries can be written to
-  // Logging in either format and can be exported in either format.
-  // Version 2 is the preferred format.
+  // Deprecated. This is unused.
   enum VersionFormat {
     // An unspecified format version that will default to V2.
     VERSION_FORMAT_UNSPECIFIED = 0;
@@ -476,9 +826,10 @@ message LogSink {
     V1 = 2;
   }
 
-  // Required. The client-assigned sink identifier, unique within the project. Example:
-  // `"my-syslog-errors-to-pubsub"`. Sink identifiers are limited to 100
-  // characters and can include only the following characters: upper and
+  // Required. The client-assigned sink identifier, unique within the project.
+  //
+  // For example: `"my-syslog-errors-to-pubsub"`. Sink identifiers are limited
+  // to 100 characters and can include only the following characters: upper and
   // lower-case alphanumeric characters, underscores, hyphens, and periods.
   // First character has to be alphanumeric.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
@@ -489,10 +840,11 @@ message LogSink {
   //     "bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]"
   //     "pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]"
   //
-  // The sink's `writer_identity`, set when the sink is created, must
-  // have permission to write to the destination or else the log
-  // entries are not exported. For more information, see
-  // [Exporting Logs with Sinks](/logging/docs/api/tasks/exporting-logs).
+  // The sink's `writer_identity`, set when the sink is created, must have
+  // permission to write to the destination or else the log entries are not
+  // exported. For more information, see
+  // [Exporting Logs with
+  // Sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
   string destination = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -500,52 +852,70 @@ message LogSink {
     }
   ];
 
-  // Optional. An [advanced logs filter](/logging/docs/view/advanced-queries). The only
-  // exported log entries are those that are in the resource owning the sink and
-  // that match the filter. For example:
+  // Optional. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced-queries). The
+  // only exported log entries are those that are in the resource owning the
+  // sink and that match the filter.
   //
-  //     logName="projects/[PROJECT_ID]/logs/[LOG_ID]" AND severity>=ERROR
+  // For example:
+  //
+  //   `logName="projects/[PROJECT_ID]/logs/[LOG_ID]" AND severity>=ERROR`
   string filter = 5 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. A description of this sink.
+  //
   // The maximum length of the description is 8000 characters.
   string description = 18 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. If set to True, then this sink is disabled and it does not
-  // export any log entries.
+  // Optional. If set to true, then this sink is disabled and it does not export any log
+  // entries.
   bool disabled = 19 [(google.api.field_behavior) = OPTIONAL];
 
-  // Deprecated. The log entry format to use for this sink's exported log
-  // entries. The v2 format is used by default and cannot be changed.
+  // Optional. Log entries that match any of these exclusion filters will not be exported.
+  //
+  // If a log entry is matched by both `filter` and one of `exclusion_filters`
+  // it will not be exported.
+  repeated LogExclusion exclusions = 16 [(google.api.field_behavior) = OPTIONAL];
+
+  // Deprecated. This field is unused.
   VersionFormat output_version_format = 6 [deprecated = true];
 
-  // Output only. An IAM identity–a service account or group&mdash;under which Logging
-  // writes the exported log entries to the sink's destination. This field is
-  // set by [sinks.create][google.logging.v2.ConfigServiceV2.CreateSink] and
+  // Output only. An IAM identity&mdash;a service account or group&mdash;under which Cloud
+  // Logging writes the exported log entries to the sink's destination. This
+  // field is set by
+  // [sinks.create][google.logging.v2.ConfigServiceV2.CreateSink] and
   // [sinks.update][google.logging.v2.ConfigServiceV2.UpdateSink] based on the
   // value of `unique_writer_identity` in those methods.
   //
   // Until you grant this identity write-access to the destination, log entry
-  // exports from this sink will fail. For more information,
-  // see [Granting Access for a
-  // Resource](/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource).
+  // exports from this sink will fail. For more information, see [Granting
+  // Access for a
+  // Resource](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource).
   // Consult the destination service's documentation to determine the
   // appropriate IAM roles to assign to the identity.
+  //
+  // Sinks that have a destination that is a log bucket in the same project as
+  // the sink do not have a writer_identity and no additional permissions are
+  // required.
   string writer_identity = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Optional. This field applies only to sinks owned by organizations and
-  // folders. If the field is false, the default, only the logs owned by the
-  // sink's parent resource are available for export. If the field is true, then
-  // logs from all the projects, folders, and billing accounts contained in the
+  // Optional. This field applies only to sinks owned by organizations and folders. If the
+  // field is false, the default, only the logs owned by the sink's parent
+  // resource are available for export. If the field is true, then log entries
+  // from all the projects, folders, and billing accounts contained in the
   // sink's parent resource are also available for export. Whether a particular
   // log entry from the children is exported depends on the sink's filter
-  // expression. For example, if this field is true, then the filter
-  // `resource.type=gce_instance` would export all Compute Engine VM instance
-  // log entries from all projects in the sink's parent. To only export entries
-  // from certain child projects, filter on the project part of the log name:
+  // expression.
   //
-  //     logName:("projects/test-project1/" OR "projects/test-project2/") AND
-  //     resource.type=gce_instance
+  // For example, if this field is true, then the filter
+  // `resource.type=gce_instance` would export all Compute Engine VM instance
+  // log entries from all projects in the sink's parent.
+  //
+  // To only export entries from certain child projects, filter on the project
+  // part of the log name:
+  //
+  //   logName:("projects/test-project1/" OR "projects/test-project2/") AND
+  //   resource.type=gce_instance
   bool include_children = 9 [(google.api.field_behavior) = OPTIONAL];
 
   // Destination dependent options.
@@ -568,16 +938,18 @@ message LogSink {
 // Options that change functionality of a sink exporting data to BigQuery.
 message BigQueryOptions {
   // Optional. Whether to use [BigQuery's partition
-  // tables](/bigquery/docs/partitioned-tables). By default, Logging
-  // creates dated tables based on the log entries' timestamps, e.g.
-  // syslog_20170523. With partitioned tables the date suffix is no longer
-  // present and [special query
-  // syntax](/bigquery/docs/querying-partitioned-tables) has to be used instead.
-  // In both cases, tables are sharded based on UTC timezone.
+  // tables](https://cloud.google.com/bigquery/docs/partitioned-tables). By
+  // default, Cloud Logging creates dated tables based on the log entries'
+  // timestamps, e.g. syslog_20170523. With partitioned tables the date suffix
+  // is no longer present and [special query
+  // syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+  // has to be used instead. In both cases, tables are sharded based on UTC
+  // timezone.
   bool use_partitioned_tables = 1 [(google.api.field_behavior) = OPTIONAL];
 
-  // Output only. True if new timestamp column based partitioning is in use,
-  // false if legacy ingestion-time partitioning is in use.
+  // Output only. True if new timestamp column based partitioning is in use, false if legacy
+  // ingestion-time partitioning is in use.
+  //
   // All new sinks will have this field set true and will use timestamp column
   // based partitioning. If use_partitioned_tables is false, this value has no
   // meaning and will be false. Legacy sinks using partitioned tables will have
@@ -585,20 +957,7 @@ message BigQueryOptions {
   bool uses_timestamp_column_partitioning = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// LogBucket lifecycle states (Beta).
-enum LifecycleState {
-  // Unspecified state.  This is only used/useful for distinguishing
-  // unset values.
-  LIFECYCLE_STATE_UNSPECIFIED = 0;
-
-  // The normal and active state.
-  ACTIVE = 1;
-
-  // The bucket has been marked for deletion by the user.
-  DELETE_REQUESTED = 2;
-}
-
-// The parameters to `ListBuckets` (Beta).
+// The parameters to `ListBuckets`.
 message ListBucketsRequest {
   // Required. The parent resource whose buckets are to be listed:
   //
@@ -614,21 +973,22 @@ message ListBucketsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       child_type: "logging.googleapis.com/LogBucket"
-    }];
+    }
+  ];
 
-  // Optional. If present, then retrieve the next batch of results from the
-  // preceding call to this method. `pageToken` must be the value of
-  // `nextPageToken` from the previous response. The values of other method
-  // parameters should be identical to those in the previous call.
+  // Optional. If present, then retrieve the next batch of results from the preceding call
+  // to this method. `pageToken` must be the value of `nextPageToken` from the
+  // previous response. The values of other method parameters should be
+  // identical to those in the previous call.
   string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. The maximum number of results to return from this request.
-  // Non-positive values are ignored. The presence of `nextPageToken` in the
-  // response indicates that more results might be available.
+  // Optional. The maximum number of results to return from this request. Non-positive
+  // values are ignored. The presence of `nextPageToken` in the response
+  // indicates that more results might be available.
   int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// The response from ListBuckets (Beta).
+// The response from ListBuckets.
 message ListBucketsResponse {
   // A list of buckets.
   repeated LogBucket buckets = 1;
@@ -639,7 +999,34 @@ message ListBucketsResponse {
   string next_page_token = 2;
 }
 
-// The parameters to `UpdateBucket` (Beta).
+// The parameters to `CreateBucket`.
+message CreateBucketRequest {
+  // Required. The resource in which to create the log bucket:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global"`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+
+  // Required. A client-assigned identifier such as `"my-bucket"`. Identifiers are limited
+  // to 100 characters and can include only letters, digits, underscores,
+  // hyphens, and periods.
+  string bucket_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The new bucket. The region specified in the new bucket must be compliant
+  // with any Location Restriction Org Policy. The name field in the bucket is
+  // ignored.
+  LogBucket bucket = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The parameters to `UpdateBucket`.
 message UpdateBucketRequest {
   // Required. The full resource name of the bucket to update.
   //
@@ -648,10 +1035,9 @@ message UpdateBucketRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //
-  // Example:
-  // `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`. Also
-  // requires permission "resourcemanager.projects.updateLiens" to set the
-  // locked property
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -663,17 +1049,17 @@ message UpdateBucketRequest {
   LogBucket bucket = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Required. Field mask that specifies the fields in `bucket` that need an update. A
-  // bucket field will be overwritten if, and only if, it is in the update
-  // mask. `name` and output only fields cannot be updated.
+  // bucket field will be overwritten if, and only if, it is in the update mask.
+  // `name` and output only fields cannot be updated.
   //
-  // For a detailed `FieldMask` definition, see
+  // For a detailed `FieldMask` definition, see:
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
   //
-  // Example: `updateMask=retention_days`.
+  // For example: `updateMask=retention_days`
   google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// The parameters to `GetBucket` (Beta).
+// The parameters to `GetBucket`.
 message GetBucketRequest {
   // Required. The resource name of the bucket:
   //
@@ -682,12 +1068,161 @@ message GetBucketRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //
-  // Example:
-  // `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `DeleteBucket`.
+message DeleteBucketRequest {
+  // Required. The full resource name of the bucket to delete.
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `UndeleteBucket`.
+message UndeleteBucketRequest {
+  // Required. The full resource name of the bucket to undelete.
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `ListViews`.
+message ListViewsRequest {
+  // Required. The bucket whose views are to be listed:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. If present, then retrieve the next batch of results from the preceding call
+  // to this method. `pageToken` must be the value of `nextPageToken` from the
+  // previous response. The values of other method parameters should be
+  // identical to those in the previous call.
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The maximum number of results to return from this request.
+  //
+  // Non-positive values are ignored. The presence of `nextPageToken` in the
+  // response indicates that more results might be available.
+  int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The response from ListViews.
+message ListViewsResponse {
+  // A list of views.
+  repeated LogView views = 1;
+
+  // If there might be more results than appear in this response, then
+  // `nextPageToken` is included. To get the next set of results, call the same
+  // method again using the value of `nextPageToken` as `pageToken`.
+  string next_page_token = 2;
+}
+
+// The parameters to `CreateView`.
+message CreateViewRequest {
+  // Required. The bucket in which to create the view
+  //
+  //     `"projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"`
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The id to use for this view.
+  string view_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The new view.
+  LogView view = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The parameters to `UpdateView`.
+message UpdateViewRequest {
+  // Required. The full resource name of the view to update
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The updated view.
+  LogView view = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Field mask that specifies the fields in `view` that need
+  // an update. A field will be overwritten if, and only if, it is
+  // in the update mask. `name` and output only fields cannot be updated.
+  //
+  // For a detailed `FieldMask` definition, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
+  //
+  // For example: `updateMask=filter`
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The parameters to `GetView`.
+message GetViewRequest {
+  // Required. The resource name of the policy:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogView"
+    }
+  ];
+}
+
+// The parameters to `DeleteView`.
+message DeleteViewRequest {
+  // Required. The full resource name of the view to delete:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //    `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogView"
     }
   ];
 }
@@ -739,7 +1274,9 @@ message GetSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -757,7 +1294,10 @@ message CreateSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]"
   //     "folders/[FOLDER_ID]"
   //
-  // Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+  // For examples:
+  //
+  //   `"projects/my-project"`
+  //   `"organizations/123456789"`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -772,9 +1312,9 @@ message CreateSinkRequest {
   // Optional. Determines the kind of IAM identity returned as `writer_identity`
   // in the new sink. If this value is omitted or set to false, and if the
   // sink's parent is a project, then the value returned as `writer_identity` is
-  // the same group or service account used by Logging before the addition of
-  // writer identities to this API. The sink's destination must be in the same
-  // project as the sink itself.
+  // the same group or service account used by Cloud Logging before the addition
+  // of writer identities to this API. The sink's destination must be in the
+  // same project as the sink itself.
   //
   // If this field is set to true, or if the sink is owned by a non-project
   // resource such as an organization, then the value of `writer_identity` will
@@ -793,7 +1333,9 @@ message UpdateSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -822,16 +1364,18 @@ message UpdateSinkRequest {
   // an update. A sink field will be overwritten if, and only if, it is
   // in the update mask. `name` and output only fields cannot be updated.
   //
-  // An empty updateMask is temporarily treated as using the following mask
+  // An empty `updateMask` is temporarily treated as using the following mask
   // for backwards compatibility purposes:
-  //   destination,filter,includeChildren
+  //
+  //   `destination,filter,includeChildren`
+  //
   // At some point in the future, behavior will be removed and specifying an
-  // empty updateMask will be an error.
+  // empty `updateMask` will be an error.
   //
   // For a detailed `FieldMask` definition, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
   //
-  // Example: `updateMask=filter`.
+  // For example: `updateMask=filter`
   google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -845,7 +1389,9 @@ message DeleteSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -854,12 +1400,11 @@ message DeleteSinkRequest {
   ];
 }
 
-// Specifies a set of log entries that are not to be stored in
-// Logging. If your GCP resource receives a large volume of logs, you can
-// use exclusions to reduce your chargeable logs. Exclusions are
-// processed after log sinks, so you can export log entries before they are
-// excluded. Note that organization-level and folder-level exclusions don't
-// apply to child resources, and that you can't exclude audit log entries.
+// Specifies a set of log entries that are filtered out by a sink. If
+// your Google Cloud resource receives a large volume of log entries, you can
+// use exclusions to reduce your chargeable logs. Note that exclusions on
+// organization-level and folder-level sinks don't apply to child resources.
+// Note also that you cannot modify the _Required sink or exclude logs from it.
 message LogExclusion {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogExclusion"
@@ -878,14 +1423,16 @@ message LogExclusion {
   // Optional. A description of this exclusion.
   string description = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Required. An [advanced logs filter](/logging/docs/view/advanced-queries)
-  // that matches the log entries to be excluded. By using the
-  // [sample function](/logging/docs/view/advanced-queries#sample),
+  // Required. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced-queries) that
+  // matches the log entries to be excluded. By using the [sample
+  // function](https://cloud.google.com/logging/docs/view/advanced-queries#sample),
   // you can exclude less than 100% of the matching log entries.
-  // For example, the following query matches 99% of low-severity log
-  // entries from Google Cloud Storage buckets:
   //
-  // `"resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)"`
+  // For example, the following query matches 99% of low-severity log entries
+  // from Google Cloud Storage buckets:
+  //
+  //   `resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)`
   string filter = 3 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. If set to True, then this exclusion is disabled and it does not
@@ -952,7 +1499,9 @@ message GetExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -970,7 +1519,10 @@ message CreateExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]"
   //     "folders/[FOLDER_ID]"
   //
-  // Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+  // For examples:
+  //
+  //   `"projects/my-logging-project"`
+  //   `"organizations/123456789"`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -992,7 +1544,9 @@ message UpdateExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1023,7 +1577,9 @@ message DeleteExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1035,8 +1591,9 @@ message DeleteExclusionRequest {
 // The parameters to
 // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings].
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message GetCmekSettingsRequest {
   // Required. The resource for which to retrieve CMEK settings.
   //
@@ -1045,11 +1602,14 @@ message GetCmekSettingsRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
   //     "folders/[FOLDER_ID]/cmekSettings"
   //
-  // Example: `"organizations/12345/cmekSettings"`.
+  // For example:
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  //   `"organizations/12345/cmekSettings"`
+  //
+  // Note: CMEK for the Log Router can be configured for Google Cloud projects,
+  // folders, organizations and billing accounts. Once configured for an
+  // organization, it applies to all projects and folders in the Google Cloud
+  // organization.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1061,8 +1621,9 @@ message GetCmekSettingsRequest {
 // The parameters to
 // [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings].
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message UpdateCmekSettingsRequest {
   // Required. The resource name for the CMEK settings to update.
   //
@@ -1071,17 +1632,20 @@ message UpdateCmekSettingsRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
   //     "folders/[FOLDER_ID]/cmekSettings"
   //
-  // Example: `"organizations/12345/cmekSettings"`.
+  // For example:
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  //   `"organizations/12345/cmekSettings"`
+  //
+  // Note: CMEK for the Log Router can currently only be configured for Google
+  // Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The CMEK settings to update.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   CmekSettings cmek_settings = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Field mask identifying which fields from `cmek_settings` should
@@ -1090,19 +1654,20 @@ message UpdateCmekSettingsRequest {
   //
   // See [FieldMask][google.protobuf.FieldMask] for more information.
   //
-  // Example: `"updateMask=kmsKeyName"`
+  // For example: `"updateMask=kmsKeyName"`
   google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Describes the customer-managed encryption key (CMEK) settings associated with
 // a project, folder, organization, billing account, or flexible resource.
 //
-// Note: CMEK for the Logs Router can currently only be configured for GCP
-// organizations. Once configured, it applies to all projects and folders in the
-// GCP organization.
+// Note: CMEK for the Log Router can currently only be configured for Google
+// Cloud organizations. Once configured, it applies to all projects and folders
+// in the Google Cloud organization.
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message CmekSettings {
   option (google.api.resource) = {
     type: "logging.googleapis.com/CmekSettings"
@@ -1118,14 +1683,142 @@ message CmekSettings {
   // The resource name for the configured Cloud KMS key.
   //
   // KMS key name format:
+  //
   //     "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]"
   //
   // For example:
-  //     `"projects/my-project-id/locations/my-region/keyRings/key-ring-name/cryptoKeys/key-name"`
+  //
+  //   `"projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"`
   //
   //
   //
-  // To enable CMEK for the Logs Router, set this field to a valid
+  // To enable CMEK for the Log Router, set this field to a valid
+  // `kms_key_name` for which the associated service account has the required
+  // cloudkms.cryptoKeyEncrypterDecrypter roles assigned for the key.
+  //
+  // The Cloud KMS key used by the Log Router can be updated by changing the
+  // `kms_key_name` to a new valid key name or disabled by setting the key name
+  // to an empty string. Encryption operations that are in progress will be
+  // completed with the key that was in use when they started. Decryption
+  // operations will be completed using the key that was used at the time of
+  // encryption unless access to that key has been revoked.
+  //
+  // To disable CMEK for the Log Router, set this field to an empty string.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_key_name = 2;
+
+  // Output only. The service account that will be used by the Log Router to access your
+  // Cloud KMS key.
+  //
+  // Before enabling CMEK for Log Router, you must first assign the
+  // cloudkms.cryptoKeyEncrypterDecrypter role to the service account that
+  // the Log Router will use to access your Cloud KMS key. Use
+  // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings] to
+  // obtain the service account ID.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// The parameters to
+// [GetSettings][google.logging.v2.ConfigServiceV2.GetSettings].
+//
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
+message GetSettingsRequest {
+  // Required. The resource for which to retrieve settings.
+  //
+  //     "projects/[PROJECT_ID]/settings"
+  //     "organizations/[ORGANIZATION_ID]/settings"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/settings"
+  //     "folders/[FOLDER_ID]/settings"
+  //
+  // For example:
+  //
+  //   `"organizations/12345/settings"`
+  //
+  // Note: Settings for the Log Router can be get for Google Cloud projects,
+  // folders, organizations and billing accounts. Currently it can only be
+  // configured for organizations. Once configured for an organization, it
+  // applies to all projects and folders in the Google Cloud organization.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/Settings"
+    }
+  ];
+}
+
+// The parameters to
+// [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings].
+//
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
+message UpdateSettingsRequest {
+  // Required. The resource name for the settings to update.
+  //
+  //     "organizations/[ORGANIZATION_ID]/settings"
+  //
+  // For example:
+  //
+  //   `"organizations/12345/settings"`
+  //
+  // Note: Settings for the Log Router can currently only be configured for
+  // Google Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The settings to update.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  Settings settings = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Field mask identifying which fields from `settings` should
+  // be updated. A field will be overwritten if and only if it is in the update
+  // mask. Output only fields cannot be updated.
+  //
+  // See [FieldMask][google.protobuf.FieldMask] for more information.
+  //
+  // For example: `"updateMask=kmsKeyName"`
+  google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Describes the settings associated with a project, folder, organization,
+// billing account, or flexible resource.
+message Settings {
+  option (google.api.resource) = {
+    type: "logging.googleapis.com/Settings"
+    pattern: "projects/{project}/settings"
+    pattern: "organizations/{organization}/settings"
+    pattern: "folders/{folder}/settings"
+    pattern: "billingAccounts/{billing_account}/settings"
+  };
+
+  // Output only. The resource name of the settings.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Optional. The resource name for the configured Cloud KMS key.
+  //
+  // KMS key name format:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"`
+  //
+  //
+  //
+  // To enable CMEK for the Log Router, set this field to a valid
   // `kms_key_name` for which the associated service account has the required
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key.
   //
@@ -1135,22 +1828,130 @@ message CmekSettings {
   // Decryption operations will be completed using the key that was used at the
   // time of encryption unless access to that key has been revoked.
   //
-  // To disable CMEK for the Logs Router, set this field to an empty string.
+  // To disable CMEK for the Log Router, set this field to an empty string.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
-  string kms_key_name = 2;
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_key_name = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Output only. The service account that will be used by the Logs Router to access your
+  // Output only. The service account that will be used by the Log Router to access your
   // Cloud KMS key.
   //
-  // Before enabling CMEK for Logs Router, you must first assign the role
+  // Before enabling CMEK for Log Router, you must first assign the role
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` to the service account that
-  // the Logs Router will use to access your Cloud KMS key. Use
-  // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings] to
+  // the Log Router will use to access your Cloud KMS key. Use
+  // [GetSettings][google.logging.v2.ConfigServiceV2.GetSettings] to
   // obtain the service account ID.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
-  string service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Optional. The Cloud region that will be used for _Default and _Required log buckets
+  // for newly created projects and folders. For example `europe-west1`.
+  // This setting does not affect the location of custom log buckets.
+  string storage_location = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. If set to true, the _Default sink in newly created projects and folders
+  // will created in a disabled state. This can be used to automatically disable
+  // log ingestion if there is already an aggregated sink configured in the
+  // hierarchy. The _Default sink can be re-enabled manually if needed.
+  bool disable_default_sink = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The parameters to CopyLogEntries.
+message CopyLogEntriesRequest {
+  // Required. Log bucket from which to copy log entries.
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-source-bucket"`
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. A filter specifying which log entries to copy. The filter must be no more
+  // than 20k characters. An empty filter matches all log entries.
+  string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Required. Destination to which to copy log entries.
+  string destination = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Metadata for CopyLogEntries long running operations.
+message CopyLogEntriesMetadata {
+  // The create time of an operation.
+  google.protobuf.Timestamp start_time = 1;
+
+  // The end time of an operation.
+  google.protobuf.Timestamp end_time = 2;
+
+  // State of an operation.
+  OperationState state = 3;
+
+  // Identifies whether the user has requested cancellation of the operation.
+  bool cancellation_requested = 4;
+
+  // CopyLogEntries RPC request.
+  CopyLogEntriesRequest request = 5;
+
+  // Estimated progress of the operation (0 - 100%).
+  int32 progress = 6;
+
+  // The IAM identity of a service account that must be granted access to the
+  // destination.
+  //
+  // If the service account is not granted permission to the destination within
+  // an hour, the operation will be cancelled.
+  //
+  // For example: `"serviceAccount:foo@bar.com"`
+  string writer_identity = 7;
+}
+
+// Response type for CopyLogEntries long running operations.
+message CopyLogEntriesResponse {
+  // Number of log entries copied.
+  int64 log_entries_copied_count = 1;
+}
+
+// LogBucket lifecycle states.
+enum LifecycleState {
+  // Unspecified state. This is only used/useful for distinguishing unset
+  // values.
+  LIFECYCLE_STATE_UNSPECIFIED = 0;
+
+  // The normal and active state.
+  ACTIVE = 1;
+
+  // The resource has been marked for deletion by the user. For some resources
+  // (e.g. buckets), this can be reversed by an un-delete operation.
+  DELETE_REQUESTED = 2;
+}
+
+// List of different operation states.
+// High level state of the operation. This is used to report the job's
+// current state to the user. Once a long running operation is created,
+// the current state of the operation can be queried even before the
+// operation is finished and the final result is available.
+enum OperationState {
+  // Should not be used.
+  OPERATION_STATE_UNSPECIFIED = 0;
+
+  // The operation is scheduled.
+  OPERATION_STATE_SCHEDULED = 1;
+
+  // Waiting for necessary permissions.
+  OPERATION_STATE_WAITING_FOR_PERMISSIONS = 2;
+
+  // The operation is running.
+  OPERATION_STATE_RUNNING = 3;
+
+  // The operation was completed successfully.
+  OPERATION_STATE_SUCCEEDED = 4;
+
+  // The operation failed.
+  OPERATION_STATE_FAILED = 5;
+
+  // The operation was cancelled by the user.
+  OPERATION_STATE_CANCELLED = 6;
 }

--- a/baselines/logging/protos/google/logging/v2/logging_metrics.proto.baseline
+++ b/baselines/logging/protos/google/logging/v2/logging_metrics.proto.baseline
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,22 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/distribution.proto";
 import "google/api/field_behavior.proto";
 import "google/api/metric.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -35,6 +32,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingMetricsProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // Service for configuring logs-based metrics.
 service MetricsServiceV2 {
@@ -92,8 +90,8 @@ service MetricsServiceV2 {
 // Describes a logs-based metric. The value of the metric is the number of log
 // entries that match a logs filter in a given time interval.
 //
-// Logs-based metric can also be used to extract values from logs and create a
-// a distribution of the values. The distribution records the statistics of the
+// Logs-based metrics can also be used to extract values from logs and create a
+// distribution of the values. The distribution records the statistics of the
 // extracted values along with an optional histogram of the values as specified
 // by the bucket options.
 message LogMetric {
@@ -119,25 +117,29 @@ message LogMetric {
   // `_-.,+!*',()%/`. The forward-slash character (`/`) denotes a hierarchy of
   // name pieces, and it cannot be the first character of the name.
   //
-  // The metric identifier in this field must not be
-  // [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
-  // However, when the metric identifier appears as the `[METRIC_ID]` part of a
-  // `metric_name` API parameter, then the metric identifier must be
-  // URL-encoded. Example: `"projects/my-project/metrics/nginx%2Frequests"`.
+  // This field is the `[METRIC_ID]` part of a metric resource name in the
+  // format "projects/[PROJECT_ID]/metrics/[METRIC_ID]". Example: If the
+  // resource name of a metric is
+  // `"projects/my-project/metrics/nginx%2Frequests"`, this field's value is
+  // `"nginx/requests"`.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. A description of this metric, which is used in documentation.
   // The maximum length of the description is 8000 characters.
   string description = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Required. An [advanced logs filter](/logging/docs/view/advanced_filters) which is
-  // used to match log entries.
-  // Example:
+  // Required. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced_filters) which
+  // is used to match log entries. Example:
   //
   //     "resource.type=gae_app AND severity>=ERROR"
   //
   // The maximum length of the filter is 20000 characters.
   string filter = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. If set to True, then this metric is disabled and it does not
+  // generate any points.
+  bool disabled = 12 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. The metric descriptor associated with the logs-based metric.
   // If unspecified, it uses a default metric descriptor with a DELTA metric

--- a/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name, destination) {
+  // [START logging_v2_generated_ConfigServiceV2_CopyLogEntries_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,20 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. Log bucket from which to copy log entries.
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-source-bucket"`
    */
-  // const parent = 'abc123'
+  // const name = 'abc123'
   /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
+   *  Optional. A filter specifying which log entries to copy. The filter must be no more
+   *  than 20k characters. An empty filter matches all log entries.
    */
-  // const pageToken = 'abc123'
+  // const filter = 'abc123'
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Required. Destination to which to copy log entries.
    */
-  // const pageSize = 1234
+  // const destination = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +50,21 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callCopyLogEntries() {
     // Construct request
     const request = {
-      parent,
+      name,
+      destination,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const [operation] = await loggingClient.copyLogEntries(request);
+    const [response] = await operation.promise();
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callCopyLogEntries();
+  // [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(parent, bucketId, bucket) {
+  // [START logging_v2_generated_ConfigServiceV2_CreateBucket_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,24 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
+   *  Required. The resource in which to create the log bucket:
    *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  For example:
+   *    `"projects/my-project/locations/global"`
    */
   // const parent = 'abc123'
   /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
+   *  Required. A client-assigned identifier such as `"my-bucket"`. Identifiers are limited
+   *  to 100 characters and can include only letters, digits, underscores,
+   *  hyphens, and periods.
    */
-  // const pageToken = 'abc123'
+  // const bucketId = 'abc123'
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Required. The new bucket. The region specified in the new bucket must be compliant
+   *  with any Location Restriction Org Policy. The name field in the bucket is
+   *  ignored.
    */
-  // const pageSize = 1234
+  // const bucket = {}
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +54,21 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callCreateBucket() {
     // Construct request
     const request = {
       parent,
+      bucketId,
+      bucket,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.createBucket(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callCreateBucket();
+  // [END logging_v2_generated_ConfigServiceV2_CreateBucket_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
@@ -34,7 +34,9 @@ function main(parent, exclusion) {
    *      "organizations/[ORGANIZATION_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]"
    *      "folders/[FOLDER_ID]"
-   *  Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+   *  For examples:
+   *    `"projects/my-logging-project"`
+   *    `"organizations/123456789"`
    */
   // const parent = 'abc123'
   /**

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
@@ -34,7 +34,9 @@ function main(parent, sink) {
    *      "organizations/[ORGANIZATION_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]"
    *      "folders/[FOLDER_ID]"
-   *  Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+   *  For examples:
+   *    `"projects/my-project"`
+   *    `"organizations/123456789"`
    */
   // const parent = 'abc123'
   /**
@@ -46,9 +48,9 @@ function main(parent, sink) {
    *  Optional. Determines the kind of IAM identity returned as `writer_identity`
    *  in the new sink. If this value is omitted or set to false, and if the
    *  sink's parent is a project, then the value returned as `writer_identity` is
-   *  the same group or service account used by Logging before the addition of
-   *  writer identities to this API. The sink's destination must be in the same
-   *  project as the sink itself.
+   *  the same group or service account used by Cloud Logging before the addition
+   *  of writer identities to this API. The sink's destination must be in the
+   *  same project as the sink itself.
    *  If this field is set to true, or if the sink is owned by a non-project
    *  resource such as an organization, then the value of `writer_identity` will
    *  be a unique service account used only for exports from the new sink. For

--- a/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(parent, viewId, view) {
+  // [START logging_v2_generated_ConfigServiceV2_CreateView_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,20 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The bucket in which to create the view
+   *      `"projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"`
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket"`
    */
   // const parent = 'abc123'
   /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
+   *  Required. The id to use for this view.
    */
-  // const pageToken = 'abc123'
+  // const viewId = 'abc123'
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Required. The new view.
    */
-  // const pageSize = 1234
+  // const view = {}
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +50,21 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callCreateView() {
     // Construct request
     const request = {
       parent,
+      viewId,
+      view,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.createView(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callCreateView();
+  // [END logging_v2_generated_ConfigServiceV2_CreateView_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name) {
+  // [START logging_v2_generated_ConfigServiceV2_DeleteBucket_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,15 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The full resource name of the bucket to delete.
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket"`
    */
-  // const parent = 'abc123'
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
-   */
-  // const pageSize = 1234
+  // const name = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +45,19 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callDeleteBucket() {
     // Construct request
     const request = {
-      parent,
+      name,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.deleteBucket(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callDeleteBucket();
+  // [END logging_v2_generated_ConfigServiceV2_DeleteBucket_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
@@ -34,7 +34,8 @@ function main(name) {
    *      "organizations/[ORGANIZATION_ID]/exclusions/[EXCLUSION_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
    *      "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
-   *  Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+   *  For example:
+   *    `"projects/my-project/exclusions/my-exclusion"`
    */
   // const name = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
@@ -35,7 +35,8 @@ function main(sinkName) {
    *      "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
    *      "folders/[FOLDER_ID]/sinks/[SINK_ID]"
-   *  Example: `"projects/my-project-id/sinks/my-sink-id"`.
+   *  For example:
+   *    `"projects/my-project/sinks/my-sink"`
    */
   // const sinkName = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name) {
+  // [START logging_v2_generated_ConfigServiceV2_DeleteView_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,12 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The full resource name of the view to delete:
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+   *  For example:
+   *     `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
    */
-  // const parent = 'abc123'
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
-   */
-  // const pageSize = 1234
+  // const name = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +42,19 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callDeleteView() {
     // Construct request
     const request = {
-      parent,
+      name,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.deleteView(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callDeleteView();
+  // [END logging_v2_generated_ConfigServiceV2_DeleteView_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
@@ -34,8 +34,8 @@ function main(name) {
    *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
    *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
-   *  Example:
-   *  `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`.
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket"`
    */
   // const name = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
@@ -34,10 +34,12 @@ function main(name) {
    *      "organizations/[ORGANIZATION_ID]/cmekSettings"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
    *      "folders/[FOLDER_ID]/cmekSettings"
-   *  Example: `"organizations/12345/cmekSettings"`.
-   *  Note: CMEK for the Logs Router can currently only be configured for GCP
-   *  organizations. Once configured, it applies to all projects and folders in
-   *  the GCP organization.
+   *  For example:
+   *    `"organizations/12345/cmekSettings"`
+   *  Note: CMEK for the Log Router can be configured for Google Cloud projects,
+   *  folders, organizations and billing accounts. Once configured for an
+   *  organization, it applies to all projects and folders in the Google Cloud
+   *  organization.
    */
   // const name = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
@@ -34,7 +34,8 @@ function main(name) {
    *      "organizations/[ORGANIZATION_ID]/exclusions/[EXCLUSION_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
    *      "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
-   *  Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+   *  For example:
+   *    `"projects/my-project/exclusions/my-exclusion"`
    */
   // const name = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name) {
+  // [START logging_v2_generated_ConfigServiceV2_GetSettings_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,19 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The resource for which to retrieve settings.
+   *      "projects/[PROJECT_ID]/settings"
+   *      "organizations/[ORGANIZATION_ID]/settings"
+   *      "billingAccounts/[BILLING_ACCOUNT_ID]/settings"
+   *      "folders/[FOLDER_ID]/settings"
+   *  For example:
+   *    `"organizations/12345/settings"`
+   *  Note: Settings for the Log Router can be get for Google Cloud projects,
+   *  folders, organizations and billing accounts. Currently it can only be
+   *  configured for organizations. Once configured for an organization, it
+   *  applies to all projects and folders in the Google Cloud organization.
    */
-  // const parent = 'abc123'
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
-   */
-  // const pageSize = 1234
+  // const name = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +49,19 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callGetSettings() {
     // Construct request
     const request = {
-      parent,
+      name,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.getSettings(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callGetSettings();
+  // [END logging_v2_generated_ConfigServiceV2_GetSettings_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
@@ -34,7 +34,8 @@ function main(sinkName) {
    *      "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
    *      "folders/[FOLDER_ID]/sinks/[SINK_ID]"
-   *  Example: `"projects/my-project-id/sinks/my-sink-id"`.
+   *  For example:
+   *    `"projects/my-project/sinks/my-sink"`
    */
   // const sinkName = 'abc123'
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name) {
+  // [START logging_v2_generated_ConfigServiceV2_GetView_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,12 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The resource name of the policy:
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
    */
-  // const parent = 'abc123'
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
-   */
-  // const pageSize = 1234
+  // const name = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +42,19 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callGetView() {
     // Construct request
     const request = {
-      parent,
+      name,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.getView(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callGetView();
+  // [END logging_v2_generated_ConfigServiceV2_GetView_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
@@ -21,7 +21,7 @@
 'use strict';
 
 function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  // [START logging_v2_generated_ConfigServiceV2_ListViews_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,14 +29,8 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The bucket whose views are to be listed:
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
    */
   // const parent = 'abc123'
   /**
@@ -47,9 +41,9 @@ function main(parent) {
    */
   // const pageToken = 'abc123'
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Optional. The maximum number of results to return from this request.
+   *  Non-positive values are ignored. The presence of `nextPageToken` in the
+   *  response indicates that more results might be available.
    */
   // const pageSize = 1234
 
@@ -59,21 +53,21 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callListViews() {
     // Construct request
     const request = {
       parent,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
+    const iterable = await loggingClient.listViewsAsync(request);
     for await (const response of iterable) {
         console.log(response);
     }
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callListViews();
+  // [END logging_v2_generated_ConfigServiceV2_ListViews_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name) {
+  // [START logging_v2_generated_ConfigServiceV2_UndeleteBucket_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,15 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The full resource name of the bucket to undelete.
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket"`
    */
-  // const parent = 'abc123'
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
-   */
-  // const pageSize = 1234
+  // const name = 'abc123'
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +45,19 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callUndeleteBucket() {
     // Construct request
     const request = {
-      parent,
+      name,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.undeleteBucket(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callUndeleteBucket();
+  // [END logging_v2_generated_ConfigServiceV2_UndeleteBucket_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
@@ -34,10 +34,8 @@ function main(name, bucket, updateMask) {
    *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
    *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
-   *  Example:
-   *  `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`. Also
-   *  requires permission "resourcemanager.projects.updateLiens" to set the
-   *  locked property
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket"`
    */
   // const name = 'abc123'
   /**
@@ -46,11 +44,11 @@ function main(name, bucket, updateMask) {
   // const bucket = {}
   /**
    *  Required. Field mask that specifies the fields in `bucket` that need an update. A
-   *  bucket field will be overwritten if, and only if, it is in the update
-   *  mask. `name` and output only fields cannot be updated.
-   *  For a detailed `FieldMask` definition, see
+   *  bucket field will be overwritten if, and only if, it is in the update mask.
+   *  `name` and output only fields cannot be updated.
+   *  For a detailed `FieldMask` definition, see:
    *  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
-   *  Example: `updateMask=retention_days`.
+   *  For example: `updateMask=retention_days`
    */
   // const updateMask = {}
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
@@ -34,16 +34,18 @@ function main(name, cmekSettings) {
    *      "organizations/[ORGANIZATION_ID]/cmekSettings"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
    *      "folders/[FOLDER_ID]/cmekSettings"
-   *  Example: `"organizations/12345/cmekSettings"`.
-   *  Note: CMEK for the Logs Router can currently only be configured for GCP
-   *  organizations. Once configured, it applies to all projects and folders in
-   *  the GCP organization.
+   *  For example:
+   *    `"organizations/12345/cmekSettings"`
+   *  Note: CMEK for the Log Router can currently only be configured for Google
+   *  Cloud organizations. Once configured, it applies to all projects and
+   *  folders in the Google Cloud organization.
    */
   // const name = 'abc123'
   /**
    *  Required. The CMEK settings to update.
-   *  See Enabling CMEK for Logs
-   *  Router (/logging/docs/routing/managed-encryption) for more information.
+   *  See Enabling CMEK for Log
+   *  Router (https://cloud.google.com/logging/docs/routing/managed-encryption)
+   *  for more information.
    */
   // const cmekSettings = {}
   /**
@@ -51,7 +53,7 @@ function main(name, cmekSettings) {
    *  be updated. A field will be overwritten if and only if it is in the update
    *  mask. Output only fields cannot be updated.
    *  See FieldMask google.protobuf.FieldMask  for more information.
-   *  Example: `"updateMask=kmsKeyName"`
+   *  For example: `"updateMask=kmsKeyName"`
    */
   // const updateMask = {}
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
@@ -34,7 +34,8 @@ function main(name, exclusion, updateMask) {
    *      "organizations/[ORGANIZATION_ID]/exclusions/[EXCLUSION_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
    *      "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
-   *  Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+   *  For example:
+   *    `"projects/my-project/exclusions/my-exclusion"`
    */
   // const name = 'abc123'
   /**

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name, settings) {
+  // [START logging_v2_generated_ConfigServiceV2_UpdateSettings_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,30 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The resource name for the settings to update.
+   *      "organizations/[ORGANIZATION_ID]/settings"
+   *  For example:
+   *    `"organizations/12345/settings"`
+   *  Note: Settings for the Log Router can currently only be configured for
+   *  Google Cloud organizations. Once configured, it applies to all projects and
+   *  folders in the Google Cloud organization.
    */
-  // const parent = 'abc123'
+  // const name = 'abc123'
   /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
+   *  Required. The settings to update.
+   *  See Enabling CMEK for Log
+   *  Router (https://cloud.google.com/logging/docs/routing/managed-encryption)
+   *  for more information.
    */
-  // const pageToken = 'abc123'
+  // const settings = {}
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Optional. Field mask identifying which fields from `settings` should
+   *  be updated. A field will be overwritten if and only if it is in the update
+   *  mask. Output only fields cannot be updated.
+   *  See FieldMask google.protobuf.FieldMask  for more information.
+   *  For example: `"updateMask=kmsKeyName"`
    */
-  // const pageSize = 1234
+  // const updateMask = {}
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +60,20 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callUpdateSettings() {
     // Construct request
     const request = {
-      parent,
+      name,
+      settings,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.updateSettings(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callUpdateSettings();
+  // [END logging_v2_generated_ConfigServiceV2_UpdateSettings_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
@@ -35,7 +35,8 @@ function main(sinkName, sink) {
    *      "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
    *      "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
    *      "folders/[FOLDER_ID]/sinks/[SINK_ID]"
-   *  Example: `"projects/my-project-id/sinks/my-sink-id"`.
+   *  For example:
+   *    `"projects/my-project/sinks/my-sink"`
    */
   // const sinkName = 'abc123'
   /**
@@ -60,14 +61,14 @@ function main(sinkName, sink) {
    *  Optional. Field mask that specifies the fields in `sink` that need
    *  an update. A sink field will be overwritten if, and only if, it is
    *  in the update mask. `name` and output only fields cannot be updated.
-   *  An empty updateMask is temporarily treated as using the following mask
+   *  An empty `updateMask` is temporarily treated as using the following mask
    *  for backwards compatibility purposes:
-   *    destination,filter,includeChildren
+   *    `destination,filter,includeChildren`
    *  At some point in the future, behavior will be removed and specifying an
-   *  empty updateMask will be an error.
+   *  empty `updateMask` will be an error.
    *  For a detailed `FieldMask` definition, see
    *  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
-   *  Example: `updateMask=filter`.
+   *  For example: `updateMask=filter`
    */
   // const updateMask = {}
 

--- a/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
+++ b/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+function main(name, view) {
+  // [START logging_v2_generated_ConfigServiceV2_UpdateView_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,29 +29,25 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The parent resource whose buckets are to be listed:
-   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
-   *      "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]"
-   *      "folders/[FOLDER_ID]/locations/[LOCATION_ID]"
-   *  Note: The locations portion of the resource must be specified, but
-   *  supplying the character `-` in place of LOCATION_ID  will return all
-   *  buckets.
+   *  Required. The full resource name of the view to update
+   *      "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+   *  For example:
+   *    `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
    */
-  // const parent = 'abc123'
+  // const name = 'abc123'
   /**
-   *  Optional. If present, then retrieve the next batch of results from the preceding call
-   *  to this method. `pageToken` must be the value of `nextPageToken` from the
-   *  previous response. The values of other method parameters should be
-   *  identical to those in the previous call.
+   *  Required. The updated view.
    */
-  // const pageToken = 'abc123'
+  // const view = {}
   /**
-   *  Optional. The maximum number of results to return from this request. Non-positive
-   *  values are ignored. The presence of `nextPageToken` in the response
-   *  indicates that more results might be available.
+   *  Optional. Field mask that specifies the fields in `view` that need
+   *  an update. A field will be overwritten if, and only if, it is
+   *  in the update mask. `name` and output only fields cannot be updated.
+   *  For a detailed `FieldMask` definition, see
+   *  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
+   *  For example: `updateMask=filter`
    */
-  // const pageSize = 1234
+  // const updateMask = {}
 
   // Imports the Logging library
   const {ConfigServiceV2Client} = require('logging').v2;
@@ -59,21 +55,20 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new ConfigServiceV2Client();
 
-  async function callListBuckets() {
+  async function callUpdateView() {
     // Construct request
     const request = {
-      parent,
+      name,
+      view,
     };
 
     // Run request
-    const iterable = await loggingClient.listBucketsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const response = await loggingClient.updateView(request);
+    console.log(response);
   }
 
-  callListBuckets();
-  // [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]
+  callUpdateView();
+  // [END logging_v2_generated_ConfigServiceV2_UpdateView_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
@@ -30,13 +30,13 @@ function main(logName) {
    */
   /**
    *  Required. The resource name of the log to delete:
-   *      "projects/[PROJECT_ID]/logs/[LOG_ID]"
-   *      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-   *      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+   *  * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+   *  * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+   *  * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+   *  * `folders/[FOLDER_ID]/logs/[LOG_ID]`
    *  `[LOG_ID]` must be URL-encoded. For example,
    *  `"projects/my-project-id/logs/syslog"`,
-   *  `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+   *  `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
    *  For more information about log names, see
    *  LogEntry google.logging.v2.LogEntry.
    */

--- a/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
@@ -31,21 +31,26 @@ function main(resourceNames) {
   /**
    *  Required. Names of one or more parent resources from which to
    *  retrieve log entries:
-   *      "projects/[PROJECT_ID]"
-   *      "organizations/[ORGANIZATION_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]"
-   *      "folders/[FOLDER_ID]"
+   *  *  `projects/[PROJECT_ID]`
+   *  *  `organizations/[ORGANIZATION_ID]`
+   *  *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+   *  *  `folders/[FOLDER_ID]`
+   *  May alternatively be one or more views:
+   *   * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+   *   * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+   *   * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+   *   * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
    *  Projects listed in the `project_ids` field are added to this list.
    */
   // const resourceNames = 'abc123'
   /**
    *  Optional. A filter that chooses which log entries to return.  See Advanced
-   *  Logs Queries (/logging/docs/view/advanced-queries).  Only log entries that
-   *  match the filter are returned.  An empty filter matches all log entries in
-   *  the resources listed in `resource_names`. Referencing a parent resource
-   *  that is not listed in `resource_names` will cause the filter to return no
-   *  results.
-   *  The maximum length of the filter is 20000 characters.
+   *  Logs Queries (https://cloud.google.com/logging/docs/view/advanced-queries).
+   *  Only log entries that match the filter are returned.  An empty filter
+   *  matches all log entries in the resources listed in `resource_names`.
+   *  Referencing a parent resource that is not listed in `resource_names` will
+   *  cause the filter to return no results. The maximum length of the filter is
+   *  20000 characters.
    */
   // const filter = 'abc123'
   /**
@@ -58,9 +63,10 @@ function main(resourceNames) {
    */
   // const orderBy = 'abc123'
   /**
-   *  Optional. The maximum number of results to return from this request.
-   *  Non-positive values are ignored.  The presence of `next_page_token` in the
-   *  response indicates that more results might be available.
+   *  Optional. The maximum number of results to return from this request. Default is 50.
+   *  If the value is negative or exceeds 1000, the request is rejected. The
+   *  presence of `next_page_token` in the response indicates that more results
+   *  might be available.
    */
   // const pageSize = 1234
   /**

--- a/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
@@ -20,8 +20,8 @@
 
 'use strict';
 
-function main(parent) {
-  // [START logging_v2_generated_LoggingServiceV2_ListLogs_async]
+function main(resourceNames) {
+  // [START logging_v2_generated_LoggingServiceV2_TailLogEntries_async]
   /**
    * This snippet has been automatically generated and should be regarded as a code template only.
    * It will require modifications to work.
@@ -29,39 +29,35 @@ function main(parent) {
    * TODO(developer): Uncomment these variables before running the sample.
    */
   /**
-   *  Required. The resource name that owns the logs:
+   *  Required. Name of a parent resource from which to retrieve log entries:
    *  *  `projects/[PROJECT_ID]`
    *  *  `organizations/[ORGANIZATION_ID]`
    *  *  `billingAccounts/[BILLING_ACCOUNT_ID]`
    *  *  `folders/[FOLDER_ID]`
-   */
-  // const parent = 'abc123'
-  /**
-   *  Optional. The maximum number of results to return from this request.
-   *  Non-positive values are ignored.  The presence of `nextPageToken` in the
-   *  response indicates that more results might be available.
-   */
-  // const pageSize = 1234
-  /**
-   *  Optional. If present, then retrieve the next batch of results from the
-   *  preceding call to this method.  `pageToken` must be the value of
-   *  `nextPageToken` from the previous response.  The values of other method
-   *  parameters should be identical to those in the previous call.
-   */
-  // const pageToken = 'abc123'
-  /**
-   *  Optional. The resource name that owns the logs:
+   *  May alternatively be one or more views:
    *   * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
    *   * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
    *   * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
    *   * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
-   *  To support legacy queries, it could also be:
-   *  *  `projects/[PROJECT_ID]`
-   *  *  `organizations/[ORGANIZATION_ID]`
-   *  *  `billingAccounts/[BILLING_ACCOUNT_ID]`
-   *  *  `folders/[FOLDER_ID]`
    */
   // const resourceNames = 'abc123'
+  /**
+   *  Optional. A filter that chooses which log entries to return.  See Advanced
+   *  Logs Filters (https://cloud.google.com/logging/docs/view/advanced_filters).
+   *  Only log entries that match the filter are returned.  An empty filter
+   *  matches all log entries in the resources listed in `resource_names`.
+   *  Referencing a parent resource that is not in `resource_names` will cause
+   *  the filter to return no results. The maximum length of the filter is 20000
+   *  characters.
+   */
+  // const filter = 'abc123'
+  /**
+   *  Optional. The amount of time to buffer log entries at the server before
+   *  being returned to prevent out of order results due to late arriving log
+   *  entries. Valid values are between 0-60000 milliseconds. Defaults to 2000
+   *  milliseconds.
+   */
+  // const bufferWindow = {}
 
   // Imports the Logging library
   const {LoggingServiceV2Client} = require('logging').v2;
@@ -69,21 +65,23 @@ function main(parent) {
   // Instantiates a client
   const loggingClient = new LoggingServiceV2Client();
 
-  async function callListLogs() {
+  async function callTailLogEntries() {
     // Construct request
     const request = {
-      parent,
+      resourceNames,
     };
 
     // Run request
-    const iterable = await loggingClient.listLogsAsync(request);
-    for await (const response of iterable) {
-        console.log(response);
-    }
+    const stream = await loggingClient.tailLogEntries();
+    stream.on('data', (response) => { console.log(response) });
+    stream.on('error', (err) => { throw(err) });
+    stream.on('end', () => { /* API call completed */ });
+    stream.write(request);
+    stream.end(); 
   }
 
-  callListLogs();
-  // [END logging_v2_generated_LoggingServiceV2_ListLogs_async]
+  callTailLogEntries();
+  // [END logging_v2_generated_LoggingServiceV2_TailLogEntries_async]
 }
 
 process.on('unhandledRejection', err => {

--- a/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
+++ b/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
@@ -31,13 +31,13 @@ function main(entries) {
   /**
    *  Optional. A default log resource name that is assigned to all log entries
    *  in `entries` that do not specify a value for `log_name`:
-   *      "projects/[PROJECT_ID]/logs/[LOG_ID]"
-   *      "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-   *      "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-   *      "folders/[FOLDER_ID]/logs/[LOG_ID]"
+   *  * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+   *  * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+   *  * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+   *  * `folders/[FOLDER_ID]/logs/[LOG_ID]`
    *  `[LOG_ID]` must be URL-encoded. For example:
    *      "projects/my-project-id/logs/syslog"
-   *      "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+   *      "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
    *  The permission `logging.logEntries.create` is needed on each project,
    *  organization, billing account, or folder that is receiving new log
    *  entries, whether the resource is specified in `logName` or in an
@@ -73,14 +73,15 @@ function main(entries) {
    *  supply their own values, the entries earlier in the list will sort before
    *  the entries later in the list. See the `entries.list` method.
    *  Log entries with timestamps that are more than the
-   *  logs retention period (/logging/quota-policy) in the past or more than
-   *  24 hours in the future will not be available when calling `entries.list`.
-   *  However, those log entries can still be
-   *  exported with LogSinks (/logging/docs/api/tasks/exporting-logs).
+   *  logs retention period (https://cloud.google.com/logging/quotas) in
+   *  the past or more than 24 hours in the future will not be available when
+   *  calling `entries.list`. However, those log entries can still be exported
+   *  with
+   *  LogSinks (https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
    *  To improve throughput and to avoid exceeding the
-   *  quota limit (/logging/quota-policy) for calls to `entries.write`,
-   *  you should try to include several log entries in this list,
-   *  rather than calling this method for each individual log entry.
+   *  quota limit (https://cloud.google.com/logging/quotas) for calls to
+   *  `entries.write`, you should try to include several log entries in this
+   *  list, rather than calling this method for each individual log entry.
    */
   // const entries = 1234
   /**

--- a/baselines/logging/samples/generated/v2/snippet_metadata.google.logging.v2.json.baseline
+++ b/baselines/logging/samples/generated/v2/snippet_metadata.google.logging.v2.json.baseline
@@ -15,7 +15,7 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListBuckets_async",
       "title": "LoggingService listBuckets Sample",
       "origin": "API_DEFINITION",
-      "description": " Lists buckets (Beta).",
+      "description": " Lists log buckets.",
       "canonical": true,
       "file": "config_service_v2.list_buckets.js",
       "language": "JAVASCRIPT",
@@ -63,7 +63,7 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetBucket_async",
       "title": "LoggingService getBucket Sample",
       "origin": "API_DEFINITION",
-      "description": " Gets a bucket (Beta).",
+      "description": " Gets a log bucket.",
       "canonical": true,
       "file": "config_service_v2.get_bucket.js",
       "language": "JAVASCRIPT",
@@ -100,17 +100,65 @@
       }
     },
     {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucket_async",
+      "title": "LoggingService createBucket Sample",
+      "origin": "API_DEFINITION",
+      "description": " Creates a log bucket that can be used to store log entries. After a bucket has been created, the bucket's location cannot be changed.",
+      "canonical": true,
+      "file": "config_service_v2.create_bucket.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 70,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "CreateBucket",
+        "fullName": "google.logging.v2.ConfigServiceV2.CreateBucket",
+        "async": true,
+        "parameters": [
+          {
+            "name": "parent",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "bucket_id",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "bucket",
+            "type": ".google.logging.v2.LogBucket"
+          }
+        ],
+        "resultType": ".google.logging.v2.LogBucket",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "CreateBucket",
+          "fullName": "google.logging.v2.ConfigServiceV2.CreateBucket",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucket_async",
       "title": "LoggingService updateBucket Sample",
       "origin": "API_DEFINITION",
-      "description": " Updates a bucket. This method replaces the following fields in the existing bucket with values from the new bucket: `retention_period` If the retention period is decreased and the bucket is locked, FAILED_PRECONDITION will be returned. If the bucket has a LifecycleState of DELETE_REQUESTED, FAILED_PRECONDITION will be returned. A buckets region may not be modified after it is created. This method is in Beta.",
+      "description": " Updates a log bucket. This method replaces the following fields in the existing bucket with values from the new bucket: `retention_period` If the retention period is decreased and the bucket is locked, `FAILED_PRECONDITION` will be returned. If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then `FAILED_PRECONDITION` will be returned. After a bucket has been created, the bucket's location cannot be changed.",
       "canonical": true,
       "file": "config_service_v2.update_bucket.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 76,
+          "end": 74,
           "type": "FULL"
         }
       ],
@@ -140,6 +188,310 @@
         "method": {
           "shortName": "UpdateBucket",
           "fullName": "google.logging.v2.ConfigServiceV2.UpdateBucket",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteBucket_async",
+      "title": "LoggingService deleteBucket Sample",
+      "origin": "API_DEFINITION",
+      "description": " Deletes a log bucket. Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state. After 7 days, the bucket will be purged and all log entries in the bucket will be permanently deleted.",
+      "canonical": true,
+      "file": "config_service_v2.delete_bucket.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 59,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "DeleteBucket",
+        "fullName": "google.logging.v2.ConfigServiceV2.DeleteBucket",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.protobuf.Empty",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "DeleteBucket",
+          "fullName": "google.logging.v2.ConfigServiceV2.DeleteBucket",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_UndeleteBucket_async",
+      "title": "LoggingService undeleteBucket Sample",
+      "origin": "API_DEFINITION",
+      "description": " Undeletes a log bucket. A bucket that has been deleted can be undeleted within the grace period of 7 days.",
+      "canonical": true,
+      "file": "config_service_v2.undelete_bucket.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 59,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "UndeleteBucket",
+        "fullName": "google.logging.v2.ConfigServiceV2.UndeleteBucket",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.protobuf.Empty",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "UndeleteBucket",
+          "fullName": "google.logging.v2.ConfigServiceV2.UndeleteBucket",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_ListViews_async",
+      "title": "LoggingService listViews Sample",
+      "origin": "API_DEFINITION",
+      "description": " Lists views on a log bucket.",
+      "canonical": true,
+      "file": "config_service_v2.list_views.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 69,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "ListViews",
+        "fullName": "google.logging.v2.ConfigServiceV2.ListViews",
+        "async": true,
+        "parameters": [
+          {
+            "name": "parent",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "page_token",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "page_size",
+            "type": "TYPE_INT32"
+          }
+        ],
+        "resultType": ".google.logging.v2.ListViewsResponse",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "ListViews",
+          "fullName": "google.logging.v2.ConfigServiceV2.ListViews",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_GetView_async",
+      "title": "LoggingService getView Sample",
+      "origin": "API_DEFINITION",
+      "description": " Gets a view on a log bucket..",
+      "canonical": true,
+      "file": "config_service_v2.get_view.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 56,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "GetView",
+        "fullName": "google.logging.v2.ConfigServiceV2.GetView",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.logging.v2.LogView",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "GetView",
+          "fullName": "google.logging.v2.ConfigServiceV2.GetView",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_CreateView_async",
+      "title": "LoggingService createView Sample",
+      "origin": "API_DEFINITION",
+      "description": " Creates a view over log entries in a log bucket. A bucket may contain a maximum of 30 views.",
+      "canonical": true,
+      "file": "config_service_v2.create_view.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 66,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "CreateView",
+        "fullName": "google.logging.v2.ConfigServiceV2.CreateView",
+        "async": true,
+        "parameters": [
+          {
+            "name": "parent",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "view_id",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "view",
+            "type": ".google.logging.v2.LogView"
+          }
+        ],
+        "resultType": ".google.logging.v2.LogView",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "CreateView",
+          "fullName": "google.logging.v2.ConfigServiceV2.CreateView",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateView_async",
+      "title": "LoggingService updateView Sample",
+      "origin": "API_DEFINITION",
+      "description": " Updates a view on a log bucket. This method replaces the following fields in the existing view with values from the new view: `filter`. If an `UNAVAILABLE` error is returned, this indicates that system is not in a state where it can update the view. If this occurs, please try again in a few minutes.",
+      "canonical": true,
+      "file": "config_service_v2.update_view.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 70,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "UpdateView",
+        "fullName": "google.logging.v2.ConfigServiceV2.UpdateView",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "view",
+            "type": ".google.logging.v2.LogView"
+          },
+          {
+            "name": "update_mask",
+            "type": ".google.protobuf.FieldMask"
+          }
+        ],
+        "resultType": ".google.logging.v2.LogView",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "UpdateView",
+          "fullName": "google.logging.v2.ConfigServiceV2.UpdateView",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteView_async",
+      "title": "LoggingService deleteView Sample",
+      "origin": "API_DEFINITION",
+      "description": " Deletes a view on a log bucket. If an `UNAVAILABLE` error is returned, this indicates that system is not in a state where it can delete the view. If this occurs, please try again in a few minutes.",
+      "canonical": true,
+      "file": "config_service_v2.delete_view.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 56,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "DeleteView",
+        "fullName": "google.logging.v2.ConfigServiceV2.DeleteView",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.protobuf.Empty",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "DeleteView",
+          "fullName": "google.logging.v2.ConfigServiceV2.DeleteView",
           "service": {
             "shortName": "ConfigServiceV2",
             "fullName": "google.logging.v2.ConfigServiceV2"
@@ -206,7 +558,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 58,
+          "end": 59,
           "type": "FULL"
         }
       ],
@@ -246,7 +598,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 77,
+          "end": 79,
           "type": "FULL"
         }
       ],
@@ -294,7 +646,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 92,
+          "end": 93,
           "type": "FULL"
         }
       ],
@@ -346,7 +698,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 59,
+          "end": 60,
           "type": "FULL"
         }
       ],
@@ -379,7 +731,7 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListExclusions_async",
       "title": "LoggingService listExclusions Sample",
       "origin": "API_DEFINITION",
-      "description": " Lists all the exclusions in a parent resource.",
+      "description": " Lists all the exclusions on the _Default sink in a parent resource.",
       "canonical": true,
       "file": "config_service_v2.list_exclusions.js",
       "language": "JAVASCRIPT",
@@ -427,14 +779,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetExclusion_async",
       "title": "LoggingService getExclusion Sample",
       "origin": "API_DEFINITION",
-      "description": " Gets the description of an exclusion.",
+      "description": " Gets the description of an exclusion in the _Default sink.",
       "canonical": true,
       "file": "config_service_v2.get_exclusion.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 58,
+          "end": 59,
           "type": "FULL"
         }
       ],
@@ -467,14 +819,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateExclusion_async",
       "title": "LoggingService createExclusion Sample",
       "origin": "API_DEFINITION",
-      "description": " Creates a new exclusion in a specified parent resource. Only log entries belonging to that resource can be excluded. You can have up to 10 exclusions in a resource.",
+      "description": " Creates a new exclusion in the _Default sink in a specified parent resource. Only log entries belonging to that resource can be excluded. You can have up to 10 exclusions in a resource.",
       "canonical": true,
       "file": "config_service_v2.create_exclusion.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 64,
+          "end": 66,
           "type": "FULL"
         }
       ],
@@ -511,14 +863,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateExclusion_async",
       "title": "LoggingService updateExclusion Sample",
       "origin": "API_DEFINITION",
-      "description": " Changes one or more properties of an existing exclusion.",
+      "description": " Changes one or more properties of an existing exclusion in the _Default sink.",
       "canonical": true,
       "file": "config_service_v2.update_exclusion.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 74,
+          "end": 75,
           "type": "FULL"
         }
       ],
@@ -559,14 +911,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteExclusion_async",
       "title": "LoggingService deleteExclusion Sample",
       "origin": "API_DEFINITION",
-      "description": " Deletes an exclusion.",
+      "description": " Deletes an exclusion in the _Default sink.",
       "canonical": true,
       "file": "config_service_v2.delete_exclusion.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 58,
+          "end": 59,
           "type": "FULL"
         }
       ],
@@ -599,14 +951,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetCmekSettings_async",
       "title": "LoggingService getCmekSettings Sample",
       "origin": "API_DEFINITION",
-      "description": " Gets the Logs Router CMEK settings for the given resource. Note: CMEK for the Logs Router can currently only be configured for GCP organizations. Once configured, it applies to all projects and folders in the GCP organization. See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption) for more information.",
+      "description": " Gets the Logging CMEK settings for the given resource. Note: CMEK for the Log Router can be configured for Google Cloud projects, folders, organizations and billing accounts. Once configured for an organization, it applies to all projects and folders in the Google Cloud organization. See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.",
       "canonical": true,
       "file": "config_service_v2.get_cmek_settings.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 61,
+          "end": 63,
           "type": "FULL"
         }
       ],
@@ -639,14 +991,14 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async",
       "title": "LoggingService updateCmekSettings Sample",
       "origin": "API_DEFINITION",
-      "description": " Updates the Logs Router CMEK settings for the given resource. Note: CMEK for the Logs Router can currently only be configured for GCP organizations. Once configured, it applies to all projects and folders in the GCP organization. [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings] will fail if 1) `kms_key_name` is invalid, or 2) the associated service account does not have the required `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or 3) access to the key is disabled. See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption) for more information.",
+      "description": " Updates the Log Router CMEK settings for the given resource. Note: CMEK for the Log Router can currently only be configured for Google Cloud organizations. Once configured, it applies to all projects and folders in the Google Cloud organization. [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings] will fail if 1) `kms_key_name` is invalid, or 2) the associated service account does not have the required `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or 3) access to the key is disabled. See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.",
       "canonical": true,
       "file": "config_service_v2.update_cmek_settings.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 76,
+          "end": 78,
           "type": "FULL"
         }
       ],
@@ -684,10 +1036,146 @@
       }
     },
     {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_GetSettings_async",
+      "title": "LoggingService getSettings Sample",
+      "origin": "API_DEFINITION",
+      "description": " Gets the Log Router settings for the given resource. Note: Settings for the Log Router can be get for Google Cloud projects, folders, organizations and billing accounts. Currently it can only be configured for organizations. Once configured for an organization, it applies to all projects and folders in the Google Cloud organization. See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.",
+      "canonical": true,
+      "file": "config_service_v2.get_settings.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 63,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "GetSettings",
+        "fullName": "google.logging.v2.ConfigServiceV2.GetSettings",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.logging.v2.Settings",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "GetSettings",
+          "fullName": "google.logging.v2.ConfigServiceV2.GetSettings",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSettings_async",
+      "title": "LoggingService updateSettings Sample",
+      "origin": "API_DEFINITION",
+      "description": " Updates the Log Router settings for the given resource. Note: Settings for the Log Router can currently only be configured for Google Cloud organizations. Once configured, it applies to all projects and folders in the Google Cloud organization. [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings] will fail if 1) `kms_key_name` is invalid, or 2) the associated service account does not have the required `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or 3) access to the key is disabled. 4) `location_id` is not supported by Logging. 5) `location_id` violate OrgPolicy. See [Enabling CMEK for Log Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.",
+      "canonical": true,
+      "file": "config_service_v2.update_settings.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 75,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "UpdateSettings",
+        "fullName": "google.logging.v2.ConfigServiceV2.UpdateSettings",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "settings",
+            "type": ".google.logging.v2.Settings"
+          },
+          {
+            "name": "update_mask",
+            "type": ".google.protobuf.FieldMask"
+          }
+        ],
+        "resultType": ".google.logging.v2.Settings",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "UpdateSettings",
+          "fullName": "google.logging.v2.ConfigServiceV2.UpdateSettings",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_ConfigServiceV2_CopyLogEntries_async",
+      "title": "LoggingService copyLogEntries Sample",
+      "origin": "API_DEFINITION",
+      "description": " Copies a set of log entries from a log bucket to a Cloud Storage bucket.",
+      "canonical": true,
+      "file": "config_service_v2.copy_log_entries.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 66,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "CopyLogEntries",
+        "fullName": "google.logging.v2.ConfigServiceV2.CopyLogEntries",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "filter",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "destination",
+            "type": "TYPE_STRING"
+          }
+        ],
+        "resultType": ".google.longrunning.Operation",
+        "client": {
+          "shortName": "ConfigServiceV2Client",
+          "fullName": "google.logging.v2.ConfigServiceV2Client"
+        },
+        "method": {
+          "shortName": "CopyLogEntries",
+          "fullName": "google.logging.v2.ConfigServiceV2.CopyLogEntries",
+          "service": {
+            "shortName": "ConfigServiceV2",
+            "fullName": "google.logging.v2.ConfigServiceV2"
+          }
+        }
+      }
+    },
+    {
       "regionTag": "logging_v2_generated_LoggingServiceV2_DeleteLog_async",
       "title": "LoggingService deleteLog Sample",
       "origin": "API_DEFINITION",
-      "description": " Deletes all the log entries in a log. The log reappears if it receives new entries. Log entries written shortly before the delete operation might not be deleted. Entries received after the delete operation with a timestamp before the operation will be deleted.",
+      "description": " Deletes all the log entries in a log for the _Default Log Bucket. The log reappears if it receives new entries. Log entries written shortly before the delete operation might not be deleted. Entries received after the delete operation with a timestamp before the operation will be deleted.",
       "canonical": true,
       "file": "logging_service_v2.delete_log.js",
       "language": "JAVASCRIPT",
@@ -734,7 +1222,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 118,
+          "end": 119,
           "type": "FULL"
         }
       ],
@@ -787,14 +1275,14 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogEntries_async",
       "title": "LoggingService listLogEntries Sample",
       "origin": "API_DEFINITION",
-      "description": " Lists log entries.  Use this method to retrieve log entries that originated from a project/folder/organization/billing account.  For ways to export log entries, see [Exporting Logs](/logging/docs/export).",
+      "description": " Lists log entries.  Use this method to retrieve log entries that originated from a project/folder/organization/billing account.  For ways to export log entries, see [Exporting Logs](https://cloud.google.com/logging/docs/export).",
       "canonical": true,
       "file": "logging_service_v2.list_log_entries.js",
       "language": "JAVASCRIPT",
       "segments": [
         {
           "start": 25,
-          "end": 93,
+          "end": 99,
           "type": "FULL"
         }
       ],
@@ -894,7 +1382,7 @@
       "segments": [
         {
           "start": 25,
-          "end": 72,
+          "end": 85,
           "type": "FULL"
         }
       ],
@@ -914,6 +1402,10 @@
           {
             "name": "page_token",
             "type": "TYPE_STRING"
+          },
+          {
+            "name": "resource_names",
+            "type": "TYPE_STRING[]"
           }
         ],
         "resultType": ".google.logging.v2.ListLogsResponse",
@@ -924,6 +1416,54 @@
         "method": {
           "shortName": "ListLogs",
           "fullName": "google.logging.v2.LoggingServiceV2.ListLogs",
+          "service": {
+            "shortName": "LoggingServiceV2",
+            "fullName": "google.logging.v2.LoggingServiceV2"
+          }
+        }
+      }
+    },
+    {
+      "regionTag": "logging_v2_generated_LoggingServiceV2_TailLogEntries_async",
+      "title": "LoggingService tailLogEntries Sample",
+      "origin": "API_DEFINITION",
+      "description": " Streaming read of log entries as they are ingested. Until the stream is terminated, it will continue reading logs.",
+      "canonical": true,
+      "file": "logging_service_v2.tail_log_entries.js",
+      "language": "JAVASCRIPT",
+      "segments": [
+        {
+          "start": 25,
+          "end": 83,
+          "type": "FULL"
+        }
+      ],
+      "clientMethod": {
+        "shortName": "TailLogEntries",
+        "fullName": "google.logging.v2.LoggingServiceV2.TailLogEntries",
+        "async": true,
+        "parameters": [
+          {
+            "name": "resource_names",
+            "type": "TYPE_STRING[]"
+          },
+          {
+            "name": "filter",
+            "type": "TYPE_STRING"
+          },
+          {
+            "name": "buffer_window",
+            "type": ".google.protobuf.Duration"
+          }
+        ],
+        "resultType": ".google.logging.v2.TailLogEntriesResponse",
+        "client": {
+          "shortName": "LoggingServiceV2Client",
+          "fullName": "google.logging.v2.LoggingServiceV2Client"
+        },
+        "method": {
+          "shortName": "TailLogEntries",
+          "fullName": "google.logging.v2.LoggingServiceV2.TailLogEntries",
           "service": {
             "shortName": "LoggingServiceV2",
             "fullName": "google.logging.v2.LoggingServiceV2"

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -18,7 +18,7 @@
 
 /* global window */
 import type * as gax from 'google-gax';
-import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
+import type {Callback, CallOptions, Descriptors, ClientOptions, GrpcClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 import {Transform} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
@@ -53,6 +53,7 @@ export class ConfigServiceV2Client {
   warn: (code: string, message: string, warnType?: string) => void;
   innerApiCalls: {[name: string]: Function};
   pathTemplates: {[name: string]: gax.PathTemplate};
+  operationsClient: gax.OperationsClient;
   configServiceV2Stub?: Promise<{[name: string]: Function}>;
 
   /**
@@ -172,8 +173,14 @@ export class ConfigServiceV2Client {
       billingAccountLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
       ),
+      billingAccountLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/logs/{log}'
+      ),
+      billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/sinks/{sink}'
@@ -187,8 +194,14 @@ export class ConfigServiceV2Client {
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
+      folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/logs/{log}'
+      ),
+      folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/sinks/{sink}'
@@ -208,8 +221,14 @@ export class ConfigServiceV2Client {
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
+      organizationLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/logs/{log}'
+      ),
+      organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sinks/{sink}'
@@ -226,8 +245,14 @@ export class ConfigServiceV2Client {
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
+      projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/logs/{log}'
+      ),
+      projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/sinks/{sink}'
@@ -240,10 +265,37 @@ export class ConfigServiceV2Client {
     this.descriptors.page = {
       listBuckets:
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'buckets'),
+      listViews:
+          new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'views'),
       listSinks:
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'sinks'),
       listExclusions:
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'exclusions')
+    };
+
+    const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
+    // This API contains "long-running operations", which return a
+    // an Operation object that allows for tracking of the operation,
+    // rather than holding a request open.
+    const lroOptions: GrpcClientOptions = {
+      auth: this.auth,
+      grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined
+    };
+    if (opts.fallback === 'rest') {
+      lroOptions.protoJson = protoFilesRoot;
+      lroOptions.httpRules = [];
+    }
+    this.operationsClient = this._gaxModule.lro(lroOptions).operationsClient(opts);
+    const copyLogEntriesResponse = protoFilesRoot.lookup(
+      '.google.logging.v2.CopyLogEntriesResponse') as gax.protobuf.Type;
+    const copyLogEntriesMetadata = protoFilesRoot.lookup(
+      '.google.logging.v2.CopyLogEntriesMetadata') as gax.protobuf.Type;
+
+    this.descriptors.longrunning = {
+      copyLogEntries: new this._gaxModule.LongrunningDescriptor(
+        this.operationsClient,
+        copyLogEntriesResponse.decode.bind(copyLogEntriesResponse),
+        copyLogEntriesMetadata.decode.bind(copyLogEntriesMetadata))
     };
 
     // Put together the default options sent with requests.
@@ -289,7 +341,7 @@ export class ConfigServiceV2Client {
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
     const configServiceV2StubMethods =
-        ['listBuckets', 'getBucket', 'updateBucket', 'listSinks', 'getSink', 'createSink', 'updateSink', 'deleteSink', 'listExclusions', 'getExclusion', 'createExclusion', 'updateExclusion', 'deleteExclusion', 'getCmekSettings', 'updateCmekSettings'];
+        ['listBuckets', 'getBucket', 'createBucket', 'updateBucket', 'deleteBucket', 'undeleteBucket', 'listViews', 'getView', 'createView', 'updateView', 'deleteView', 'listSinks', 'getSink', 'createSink', 'updateSink', 'deleteSink', 'listExclusions', 'getExclusion', 'createExclusion', 'updateExclusion', 'deleteExclusion', 'getCmekSettings', 'updateCmekSettings', 'getSettings', 'updateSettings', 'copyLogEntries'];
     for (const methodName of configServiceV2StubMethods) {
       const callPromise = this.configServiceV2Stub.then(
         stub => (...args: Array<{}>) => {
@@ -305,6 +357,7 @@ export class ConfigServiceV2Client {
 
       const descriptor =
         this.descriptors.page[methodName] ||
+        this.descriptors.longrunning[methodName] ||
         undefined;
       const apiCall = this._gaxModule.createApiCall(
         callPromise,
@@ -377,7 +430,7 @@ export class ConfigServiceV2Client {
   // -- Service calls --
   // -------------------
 /**
- * Gets a bucket (Beta).
+ * Gets a log bucket.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -389,8 +442,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
  *       "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
  *
- *   Example:
- *   `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -456,17 +510,102 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getBucket(request, options, callback);
   }
 /**
- * Updates a bucket. This method replaces the following fields in the
+ * Creates a log bucket that can be used to store log entries. After a bucket
+ * has been created, the bucket's location cannot be changed.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The resource in which to create the log bucket:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global"`
+ * @param {string} request.bucketId
+ *   Required. A client-assigned identifier such as `"my-bucket"`. Identifiers are limited
+ *   to 100 characters and can include only letters, digits, underscores,
+ *   hyphens, and periods.
+ * @param {google.logging.v2.LogBucket} request.bucket
+ *   Required. The new bucket. The region specified in the new bucket must be compliant
+ *   with any Location Restriction Org Policy. The name field in the bucket is
+ *   ignored.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [LogBucket]{@link google.logging.v2.LogBucket}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.create_bucket.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_CreateBucket_async
+ */
+  createBucket(
+      request?: protos.google.logging.v2.ICreateBucketRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogBucket,
+        protos.google.logging.v2.ICreateBucketRequest|undefined, {}|undefined
+      ]>;
+  createBucket(
+      request: protos.google.logging.v2.ICreateBucketRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.ICreateBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  createBucket(
+      request: protos.google.logging.v2.ICreateBucketRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.ICreateBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  createBucket(
+      request?: protos.google.logging.v2.ICreateBucketRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.ICreateBucketRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ILogBucket,
+          protos.google.logging.v2.ICreateBucketRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ILogBucket,
+        protos.google.logging.v2.ICreateBucketRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.createBucket(request, options, callback);
+  }
+/**
+ * Updates a log bucket. This method replaces the following fields in the
  * existing bucket with values from the new bucket: `retention_period`
  *
  * If the retention period is decreased and the bucket is locked,
- * FAILED_PRECONDITION will be returned.
+ * `FAILED_PRECONDITION` will be returned.
  *
- * If the bucket has a LifecycleState of DELETE_REQUESTED, FAILED_PRECONDITION
- * will be returned.
+ * If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then
+ * `FAILED_PRECONDITION` will be returned.
  *
- * A buckets region may not be modified after it is created.
- * This method is in Beta.
+ * After a bucket has been created, the bucket's location cannot be changed.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -478,21 +617,20 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
  *       "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
  *
- *   Example:
- *   `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`. Also
- *   requires permission "resourcemanager.projects.updateLiens" to set the
- *   locked property
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket"`
  * @param {google.logging.v2.LogBucket} request.bucket
  *   Required. The updated bucket.
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required. Field mask that specifies the fields in `bucket` that need an update. A
- *   bucket field will be overwritten if, and only if, it is in the update
- *   mask. `name` and output only fields cannot be updated.
+ *   bucket field will be overwritten if, and only if, it is in the update mask.
+ *   `name` and output only fields cannot be updated.
  *
- *   For a detailed `FieldMask` definition, see
+ *   For a detailed `FieldMask` definition, see:
  *   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
  *
- *   Example: `updateMask=retention_days`.
+ *   For example: `updateMask=retention_days`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -558,6 +696,502 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateBucket(request, options, callback);
   }
 /**
+ * Deletes a log bucket.
+ *
+ * Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
+ * After 7 days, the bucket will be purged and all log entries in the bucket
+ * will be permanently deleted.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The full resource name of the bucket to delete.
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket"`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.delete_bucket.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_DeleteBucket_async
+ */
+  deleteBucket(
+      request?: protos.google.logging.v2.IDeleteBucketRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteBucketRequest|undefined, {}|undefined
+      ]>;
+  deleteBucket(
+      request: protos.google.logging.v2.IDeleteBucketRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteBucket(
+      request: protos.google.logging.v2.IDeleteBucketRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteBucket(
+      request?: protos.google.logging.v2.IDeleteBucketRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteBucketRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteBucketRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteBucketRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.deleteBucket(request, options, callback);
+  }
+/**
+ * Undeletes a log bucket. A bucket that has been deleted can be undeleted
+ * within the grace period of 7 days.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The full resource name of the bucket to undelete.
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *       "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket"`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.undelete_bucket.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_UndeleteBucket_async
+ */
+  undeleteBucket(
+      request?: protos.google.logging.v2.IUndeleteBucketRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IUndeleteBucketRequest|undefined, {}|undefined
+      ]>;
+  undeleteBucket(
+      request: protos.google.logging.v2.IUndeleteBucketRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IUndeleteBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  undeleteBucket(
+      request: protos.google.logging.v2.IUndeleteBucketRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IUndeleteBucketRequest|null|undefined,
+          {}|null|undefined>): void;
+  undeleteBucket(
+      request?: protos.google.logging.v2.IUndeleteBucketRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IUndeleteBucketRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IUndeleteBucketRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IUndeleteBucketRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.undeleteBucket(request, options, callback);
+  }
+/**
+ * Gets a view on a log bucket..
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The resource name of the policy:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [LogView]{@link google.logging.v2.LogView}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.get_view.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_GetView_async
+ */
+  getView(
+      request?: protos.google.logging.v2.IGetViewRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.IGetViewRequest|undefined, {}|undefined
+      ]>;
+  getView(
+      request: protos.google.logging.v2.IGetViewRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IGetViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  getView(
+      request: protos.google.logging.v2.IGetViewRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IGetViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  getView(
+      request?: protos.google.logging.v2.IGetViewRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IGetViewRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IGetViewRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.IGetViewRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.getView(request, options, callback);
+  }
+/**
+ * Creates a view over log entries in a log bucket. A bucket may contain a
+ * maximum of 30 views.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The bucket in which to create the view
+ *
+ *       `"projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"`
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket"`
+ * @param {string} request.viewId
+ *   Required. The id to use for this view.
+ * @param {google.logging.v2.LogView} request.view
+ *   Required. The new view.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [LogView]{@link google.logging.v2.LogView}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.create_view.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_CreateView_async
+ */
+  createView(
+      request?: protos.google.logging.v2.ICreateViewRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.ICreateViewRequest|undefined, {}|undefined
+      ]>;
+  createView(
+      request: protos.google.logging.v2.ICreateViewRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.ICreateViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  createView(
+      request: protos.google.logging.v2.ICreateViewRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.ICreateViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  createView(
+      request?: protos.google.logging.v2.ICreateViewRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.ICreateViewRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.ICreateViewRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.ICreateViewRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.createView(request, options, callback);
+  }
+/**
+ * Updates a view on a log bucket. This method replaces the following fields
+ * in the existing view with values from the new view: `filter`.
+ * If an `UNAVAILABLE` error is returned, this indicates that system is not in
+ * a state where it can update the view. If this occurs, please try again in a
+ * few minutes.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The full resource name of the view to update
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+ * @param {google.logging.v2.LogView} request.view
+ *   Required. The updated view.
+ * @param {google.protobuf.FieldMask} [request.updateMask]
+ *   Optional. Field mask that specifies the fields in `view` that need
+ *   an update. A field will be overwritten if, and only if, it is
+ *   in the update mask. `name` and output only fields cannot be updated.
+ *
+ *   For a detailed `FieldMask` definition, see
+ *   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
+ *
+ *   For example: `updateMask=filter`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [LogView]{@link google.logging.v2.LogView}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.update_view.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_UpdateView_async
+ */
+  updateView(
+      request?: protos.google.logging.v2.IUpdateViewRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.IUpdateViewRequest|undefined, {}|undefined
+      ]>;
+  updateView(
+      request: protos.google.logging.v2.IUpdateViewRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IUpdateViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateView(
+      request: protos.google.logging.v2.IUpdateViewRequest,
+      callback: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IUpdateViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateView(
+      request?: protos.google.logging.v2.IUpdateViewRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IUpdateViewRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ILogView,
+          protos.google.logging.v2.IUpdateViewRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ILogView,
+        protos.google.logging.v2.IUpdateViewRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.updateView(request, options, callback);
+  }
+/**
+ * Deletes a view on a log bucket.
+ * If an `UNAVAILABLE` error is returned, this indicates that system is not in
+ * a state where it can delete the view. If this occurs, please try again in a
+ * few minutes.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The full resource name of the view to delete:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+ *
+ *   For example:
+ *
+ *      `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.delete_view.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_DeleteView_async
+ */
+  deleteView(
+      request?: protos.google.logging.v2.IDeleteViewRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteViewRequest|undefined, {}|undefined
+      ]>;
+  deleteView(
+      request: protos.google.logging.v2.IDeleteViewRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteView(
+      request: protos.google.logging.v2.IDeleteViewRequest,
+      callback: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteViewRequest|null|undefined,
+          {}|null|undefined>): void;
+  deleteView(
+      request?: protos.google.logging.v2.IDeleteViewRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteViewRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.protobuf.IEmpty,
+          protos.google.logging.v2.IDeleteViewRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.protobuf.IEmpty,
+        protos.google.logging.v2.IDeleteViewRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.deleteView(request, options, callback);
+  }
+/**
  * Gets a sink.
  *
  * @param {Object} request
@@ -570,7 +1204,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
  *       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
  *
- *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/sinks/my-sink"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -651,7 +1287,10 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]"
  *       "folders/[FOLDER_ID]"
  *
- *   Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+ *   For examples:
+ *
+ *     `"projects/my-project"`
+ *     `"organizations/123456789"`
  * @param {google.logging.v2.LogSink} request.sink
  *   Required. The new sink, whose `name` parameter is a sink identifier that
  *   is not already in use.
@@ -659,9 +1298,9 @@ export class ConfigServiceV2Client {
  *   Optional. Determines the kind of IAM identity returned as `writer_identity`
  *   in the new sink. If this value is omitted or set to false, and if the
  *   sink's parent is a project, then the value returned as `writer_identity` is
- *   the same group or service account used by Logging before the addition of
- *   writer identities to this API. The sink's destination must be in the same
- *   project as the sink itself.
+ *   the same group or service account used by Cloud Logging before the addition
+ *   of writer identities to this API. The sink's destination must be in the
+ *   same project as the sink itself.
  *
  *   If this field is set to true, or if the sink is owned by a non-project
  *   resource such as an organization, then the value of `writer_identity` will
@@ -749,7 +1388,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
  *       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
  *
- *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/sinks/my-sink"`
  * @param {google.logging.v2.LogSink} request.sink
  *   Required. The updated sink, whose name is the same identifier that appears as part
  *   of `sink_name`.
@@ -770,16 +1411,18 @@ export class ConfigServiceV2Client {
  *   an update. A sink field will be overwritten if, and only if, it is
  *   in the update mask. `name` and output only fields cannot be updated.
  *
- *   An empty updateMask is temporarily treated as using the following mask
+ *   An empty `updateMask` is temporarily treated as using the following mask
  *   for backwards compatibility purposes:
- *     destination,filter,includeChildren
+ *
+ *     `destination,filter,includeChildren`
+ *
  *   At some point in the future, behavior will be removed and specifying an
- *   empty updateMask will be an error.
+ *   empty `updateMask` will be an error.
  *
  *   For a detailed `FieldMask` definition, see
  *   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
  *
- *   Example: `updateMask=filter`.
+ *   For example: `updateMask=filter`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -859,7 +1502,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
  *       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
  *
- *   Example: `"projects/my-project-id/sinks/my-sink-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/sinks/my-sink"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -925,7 +1570,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.deleteSink(request, options, callback);
   }
 /**
- * Gets the description of an exclusion.
+ * Gets the description of an exclusion in the _Default sink.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -937,7 +1582,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
  *       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
  *
- *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/exclusions/my-exclusion"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1003,9 +1650,9 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getExclusion(request, options, callback);
   }
 /**
- * Creates a new exclusion in a specified parent resource.
- * Only log entries belonging to that resource can be excluded.
- * You can have up to 10 exclusions in a resource.
+ * Creates a new exclusion in the _Default sink in a specified parent
+ * resource. Only log entries belonging to that resource can be excluded. You
+ * can have up to 10 exclusions in a resource.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1017,7 +1664,10 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]"
  *       "folders/[FOLDER_ID]"
  *
- *   Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+ *   For examples:
+ *
+ *     `"projects/my-logging-project"`
+ *     `"organizations/123456789"`
  * @param {google.logging.v2.LogExclusion} request.exclusion
  *   Required. The new exclusion, whose `name` parameter is an exclusion name
  *   that is not already used in the parent resource.
@@ -1086,7 +1736,8 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.createExclusion(request, options, callback);
   }
 /**
- * Changes one or more properties of an existing exclusion.
+ * Changes one or more properties of an existing exclusion in the _Default
+ * sink.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1098,7 +1749,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
  *       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
  *
- *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/exclusions/my-exclusion"`
  * @param {google.logging.v2.LogExclusion} request.exclusion
  *   Required. New values for the existing exclusion. Only the fields specified in
  *   `update_mask` are relevant.
@@ -1175,7 +1828,7 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.updateExclusion(request, options, callback);
   }
 /**
- * Deletes an exclusion.
+ * Deletes an exclusion in the _Default sink.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1187,7 +1840,9 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
  *       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
  *
- *   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+ *   For example:
+ *
+ *     `"projects/my-project/exclusions/my-exclusion"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1253,14 +1908,16 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.deleteExclusion(request, options, callback);
   }
 /**
- * Gets the Logs Router CMEK settings for the given resource.
+ * Gets the Logging CMEK settings for the given resource.
  *
- * Note: CMEK for the Logs Router can currently only be configured for GCP
- * organizations. Once configured, it applies to all projects and folders in
- * the GCP organization.
+ * Note: CMEK for the Log Router can be configured for Google Cloud projects,
+ * folders, organizations and billing accounts. Once configured for an
+ * organization, it applies to all projects and folders in the Google Cloud
+ * organization.
  *
- * See [Enabling CMEK for Logs
- * Router](/logging/docs/routing/managed-encryption) for more information.
+ * See [Enabling CMEK for Log
+ * Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ * for more information.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1272,11 +1929,14 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
  *       "folders/[FOLDER_ID]/cmekSettings"
  *
- *   Example: `"organizations/12345/cmekSettings"`.
+ *   For example:
  *
- *   Note: CMEK for the Logs Router can currently only be configured for GCP
- *   organizations. Once configured, it applies to all projects and folders in
- *   the GCP organization.
+ *     `"organizations/12345/cmekSettings"`
+ *
+ *   Note: CMEK for the Log Router can be configured for Google Cloud projects,
+ *   folders, organizations and billing accounts. Once configured for an
+ *   organization, it applies to all projects and folders in the Google Cloud
+ *   organization.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1342,11 +2002,11 @@ export class ConfigServiceV2Client {
     return this.innerApiCalls.getCmekSettings(request, options, callback);
   }
 /**
- * Updates the Logs Router CMEK settings for the given resource.
+ * Updates the Log Router CMEK settings for the given resource.
  *
- * Note: CMEK for the Logs Router can currently only be configured for GCP
- * organizations. Once configured, it applies to all projects and folders in
- * the GCP organization.
+ * Note: CMEK for the Log Router can currently only be configured for Google
+ * Cloud organizations. Once configured, it applies to all projects and
+ * folders in the Google Cloud organization.
  *
  * {@link google.logging.v2.ConfigServiceV2.UpdateCmekSettings|UpdateCmekSettings}
  * will fail if 1) `kms_key_name` is invalid, or 2) the associated service
@@ -1354,8 +2014,9 @@ export class ConfigServiceV2Client {
  * `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
  * 3) access to the key is disabled.
  *
- * See [Enabling CMEK for Logs
- * Router](/logging/docs/routing/managed-encryption) for more information.
+ * See [Enabling CMEK for Log
+ * Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ * for more information.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1367,16 +2028,19 @@ export class ConfigServiceV2Client {
  *       "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
  *       "folders/[FOLDER_ID]/cmekSettings"
  *
- *   Example: `"organizations/12345/cmekSettings"`.
+ *   For example:
  *
- *   Note: CMEK for the Logs Router can currently only be configured for GCP
- *   organizations. Once configured, it applies to all projects and folders in
- *   the GCP organization.
+ *     `"organizations/12345/cmekSettings"`
+ *
+ *   Note: CMEK for the Log Router can currently only be configured for Google
+ *   Cloud organizations. Once configured, it applies to all projects and
+ *   folders in the Google Cloud organization.
  * @param {google.logging.v2.CmekSettings} request.cmekSettings
  *   Required. The CMEK settings to update.
  *
- *   See [Enabling CMEK for Logs
- *   Router](/logging/docs/routing/managed-encryption) for more information.
+ *   See [Enabling CMEK for Log
+ *   Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ *   for more information.
  * @param {google.protobuf.FieldMask} [request.updateMask]
  *   Optional. Field mask identifying which fields from `cmek_settings` should
  *   be updated. A field will be overwritten if and only if it is in the update
@@ -1384,7 +2048,7 @@ export class ConfigServiceV2Client {
  *
  *   See {@link google.protobuf.FieldMask|FieldMask} for more information.
  *
- *   Example: `"updateMask=kmsKeyName"`
+ *   For example: `"updateMask=kmsKeyName"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1449,9 +2113,308 @@ export class ConfigServiceV2Client {
     this.initialize();
     return this.innerApiCalls.updateCmekSettings(request, options, callback);
   }
+/**
+ * Gets the Log Router settings for the given resource.
+ *
+ * Note: Settings for the Log Router can be get for Google Cloud projects,
+ * folders, organizations and billing accounts. Currently it can only be
+ * configured for organizations. Once configured for an organization, it
+ * applies to all projects and folders in the Google Cloud organization.
+ *
+ * See [Enabling CMEK for Log
+ * Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ * for more information.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The resource for which to retrieve settings.
+ *
+ *       "projects/[PROJECT_ID]/settings"
+ *       "organizations/[ORGANIZATION_ID]/settings"
+ *       "billingAccounts/[BILLING_ACCOUNT_ID]/settings"
+ *       "folders/[FOLDER_ID]/settings"
+ *
+ *   For example:
+ *
+ *     `"organizations/12345/settings"`
+ *
+ *   Note: Settings for the Log Router can be get for Google Cloud projects,
+ *   folders, organizations and billing accounts. Currently it can only be
+ *   configured for organizations. Once configured for an organization, it
+ *   applies to all projects and folders in the Google Cloud organization.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Settings]{@link google.logging.v2.Settings}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.get_settings.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_GetSettings_async
+ */
+  getSettings(
+      request?: protos.google.logging.v2.IGetSettingsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ISettings,
+        protos.google.logging.v2.IGetSettingsRequest|undefined, {}|undefined
+      ]>;
+  getSettings(
+      request: protos.google.logging.v2.IGetSettingsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IGetSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  getSettings(
+      request: protos.google.logging.v2.IGetSettingsRequest,
+      callback: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IGetSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  getSettings(
+      request?: protos.google.logging.v2.IGetSettingsRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IGetSettingsRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IGetSettingsRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ISettings,
+        protos.google.logging.v2.IGetSettingsRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.getSettings(request, options, callback);
+  }
+/**
+ * Updates the Log Router settings for the given resource.
+ *
+ * Note: Settings for the Log Router can currently only be configured for
+ * Google Cloud organizations. Once configured, it applies to all projects and
+ * folders in the Google Cloud organization.
+ *
+ * {@link google.logging.v2.ConfigServiceV2.UpdateSettings|UpdateSettings}
+ * will fail if 1) `kms_key_name` is invalid, or 2) the associated service
+ * account does not have the required
+ * `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
+ * 3) access to the key is disabled. 4) `location_id` is not supported by
+ * Logging. 5) `location_id` violate OrgPolicy.
+ *
+ * See [Enabling CMEK for Log
+ * Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ * for more information.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. The resource name for the settings to update.
+ *
+ *       "organizations/[ORGANIZATION_ID]/settings"
+ *
+ *   For example:
+ *
+ *     `"organizations/12345/settings"`
+ *
+ *   Note: Settings for the Log Router can currently only be configured for
+ *   Google Cloud organizations. Once configured, it applies to all projects and
+ *   folders in the Google Cloud organization.
+ * @param {google.logging.v2.Settings} request.settings
+ *   Required. The settings to update.
+ *
+ *   See [Enabling CMEK for Log
+ *   Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+ *   for more information.
+ * @param {google.protobuf.FieldMask} [request.updateMask]
+ *   Optional. Field mask identifying which fields from `settings` should
+ *   be updated. A field will be overwritten if and only if it is in the update
+ *   mask. Output only fields cannot be updated.
+ *
+ *   See {@link google.protobuf.FieldMask|FieldMask} for more information.
+ *
+ *   For example: `"updateMask=kmsKeyName"`
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing [Settings]{@link google.logging.v2.Settings}.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.update_settings.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_UpdateSettings_async
+ */
+  updateSettings(
+      request?: protos.google.logging.v2.IUpdateSettingsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ISettings,
+        protos.google.logging.v2.IUpdateSettingsRequest|undefined, {}|undefined
+      ]>;
+  updateSettings(
+      request: protos.google.logging.v2.IUpdateSettingsRequest,
+      options: CallOptions,
+      callback: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IUpdateSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateSettings(
+      request: protos.google.logging.v2.IUpdateSettingsRequest,
+      callback: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IUpdateSettingsRequest|null|undefined,
+          {}|null|undefined>): void;
+  updateSettings(
+      request?: protos.google.logging.v2.IUpdateSettingsRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IUpdateSettingsRequest|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          protos.google.logging.v2.ISettings,
+          protos.google.logging.v2.IUpdateSettingsRequest|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        protos.google.logging.v2.ISettings,
+        protos.google.logging.v2.IUpdateSettingsRequest|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'name': request.name || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.updateSettings(request, options, callback);
+  }
 
+/**
+ * Copies a set of log entries from a log bucket to a Cloud Storage bucket.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   Required. Log bucket from which to copy log entries.
+ *
+ *   For example:
+ *
+ *     `"projects/my-project/locations/global/buckets/my-source-bucket"`
+ * @param {string} [request.filter]
+ *   Optional. A filter specifying which log entries to copy. The filter must be no more
+ *   than 20k characters. An empty filter matches all log entries.
+ * @param {string} request.destination
+ *   Required. Destination to which to copy log entries.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is an object representing
+ *   a long running operation. Its `promise()` method returns a promise
+ *   you can `await` for.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.copy_log_entries.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_CopyLogEntries_async
+ */
+  copyLogEntries(
+      request?: protos.google.logging.v2.ICopyLogEntriesRequest,
+      options?: CallOptions):
+      Promise<[
+        LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>;
+  copyLogEntries(
+      request: protos.google.logging.v2.ICopyLogEntriesRequest,
+      options: CallOptions,
+      callback: Callback<
+          LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  copyLogEntries(
+      request: protos.google.logging.v2.ICopyLogEntriesRequest,
+      callback: Callback<
+          LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>): void;
+  copyLogEntries(
+      request?: protos.google.logging.v2.ICopyLogEntriesRequest,
+      optionsOrCallback?: CallOptions|Callback<
+          LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>,
+      callback?: Callback<
+          LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+          protos.google.longrunning.IOperation|null|undefined,
+          {}|null|undefined>):
+      Promise<[
+        LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>,
+        protos.google.longrunning.IOperation|undefined, {}|undefined
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    this.initialize();
+    return this.innerApiCalls.copyLogEntries(request, options, callback);
+  }
+/**
+ * Check the status of the long running operation returned by `copyLogEntries()`.
+ * @param {String} name
+ *   The operation name that will be passed.
+ * @returns {Promise} - The promise which resolves to an object.
+ *   The decoded operation object has result and metadata field to get information from.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.copy_log_entries.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_CopyLogEntries_async
+ */
+  async checkCopyLogEntriesProgress(name: string): Promise<LROperation<protos.google.logging.v2.CopyLogEntriesResponse, protos.google.logging.v2.CopyLogEntriesMetadata>>{
+    const request = new this._gaxModule.operationsProtos.google.longrunning.GetOperationRequest({name});
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new this._gaxModule.Operation(operation, this.descriptors.longrunning.copyLogEntries, this._gaxModule.createDefaultBackoffSettings());
+    return decodeOperation as LROperation<protos.google.logging.v2.CopyLogEntriesResponse, protos.google.logging.v2.CopyLogEntriesMetadata>;
+  }
  /**
- * Lists buckets (Beta).
+ * Lists log buckets.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -1467,14 +2430,14 @@ export class ConfigServiceV2Client {
  *   supplying the character `-` in place of [LOCATION_ID] will return all
  *   buckets.
  * @param {string} [request.pageToken]
- *   Optional. If present, then retrieve the next batch of results from the
- *   preceding call to this method. `pageToken` must be the value of
- *   `nextPageToken` from the previous response. The values of other method
- *   parameters should be identical to those in the previous call.
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored. The presence of `nextPageToken` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Non-positive
+ *   values are ignored. The presence of `nextPageToken` in the response
+ *   indicates that more results might be available.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1561,14 +2524,14 @@ export class ConfigServiceV2Client {
  *   supplying the character `-` in place of [LOCATION_ID] will return all
  *   buckets.
  * @param {string} [request.pageToken]
- *   Optional. If present, then retrieve the next batch of results from the
- *   preceding call to this method. `pageToken` must be the value of
- *   `nextPageToken` from the previous response. The values of other method
- *   parameters should be identical to those in the previous call.
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored. The presence of `nextPageToken` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Non-positive
+ *   values are ignored. The presence of `nextPageToken` in the response
+ *   indicates that more results might be available.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
@@ -1622,14 +2585,14 @@ export class ConfigServiceV2Client {
  *   supplying the character `-` in place of [LOCATION_ID] will return all
  *   buckets.
  * @param {string} [request.pageToken]
- *   Optional. If present, then retrieve the next batch of results from the
- *   preceding call to this method. `pageToken` must be the value of
- *   `nextPageToken` from the previous response. The values of other method
- *   parameters should be identical to those in the previous call.
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored. The presence of `nextPageToken` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Non-positive
+ *   values are ignored. The presence of `nextPageToken` in the response
+ *   indicates that more results might be available.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
@@ -1664,6 +2627,203 @@ export class ConfigServiceV2Client {
       request as {},
       callSettings
     ) as AsyncIterable<protos.google.logging.v2.ILogBucket>;
+  }
+ /**
+ * Lists views on a log bucket.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The bucket whose views are to be listed:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ * @param {string} [request.pageToken]
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
+ * @param {number} [request.pageSize]
+ *   Optional. The maximum number of results to return from this request.
+ *
+ *   Non-positive values are ignored. The presence of `nextPageToken` in the
+ *   response indicates that more results might be available.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Promise} - The promise which resolves to an array.
+ *   The first element of the array is Array of [LogView]{@link google.logging.v2.LogView}.
+ *   The client library will perform auto-pagination by default: it will call the API as many
+ *   times as needed and will merge results from all the pages into this array.
+ *   Note that it can affect your quota.
+ *   We recommend using `listViewsAsync()`
+ *   method described below for async iteration which you can stop as needed.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   for more details and examples.
+ */
+  listViews(
+      request?: protos.google.logging.v2.IListViewsRequest,
+      options?: CallOptions):
+      Promise<[
+        protos.google.logging.v2.ILogView[],
+        protos.google.logging.v2.IListViewsRequest|null,
+        protos.google.logging.v2.IListViewsResponse
+      ]>;
+  listViews(
+      request: protos.google.logging.v2.IListViewsRequest,
+      options: CallOptions,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListViewsRequest,
+          protos.google.logging.v2.IListViewsResponse|null|undefined,
+          protos.google.logging.v2.ILogView>): void;
+  listViews(
+      request: protos.google.logging.v2.IListViewsRequest,
+      callback: PaginationCallback<
+          protos.google.logging.v2.IListViewsRequest,
+          protos.google.logging.v2.IListViewsResponse|null|undefined,
+          protos.google.logging.v2.ILogView>): void;
+  listViews(
+      request?: protos.google.logging.v2.IListViewsRequest,
+      optionsOrCallback?: CallOptions|PaginationCallback<
+          protos.google.logging.v2.IListViewsRequest,
+          protos.google.logging.v2.IListViewsResponse|null|undefined,
+          protos.google.logging.v2.ILogView>,
+      callback?: PaginationCallback<
+          protos.google.logging.v2.IListViewsRequest,
+          protos.google.logging.v2.IListViewsResponse|null|undefined,
+          protos.google.logging.v2.ILogView>):
+      Promise<[
+        protos.google.logging.v2.ILogView[],
+        protos.google.logging.v2.IListViewsRequest|null,
+        protos.google.logging.v2.IListViewsResponse
+      ]>|void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    }
+    else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.listViews(request, options, callback);
+  }
+
+/**
+ * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The bucket whose views are to be listed:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ * @param {string} [request.pageToken]
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
+ * @param {number} [request.pageSize]
+ *   Optional. The maximum number of results to return from this request.
+ *
+ *   Non-positive values are ignored. The presence of `nextPageToken` in the
+ *   response indicates that more results might be available.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Stream}
+ *   An object stream which emits an object representing [LogView]{@link google.logging.v2.LogView} on 'data' event.
+ *   The client library will perform auto-pagination by default: it will call the API as many
+ *   times as needed. Note that it can affect your quota.
+ *   We recommend using `listViewsAsync()`
+ *   method described below for async iteration which you can stop as needed.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   for more details and examples.
+ */
+  listViewsStream(
+      request?: protos.google.logging.v2.IListViewsRequest,
+      options?: CallOptions):
+    Transform{
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
+    const defaultCallSettings = this._defaults['listViews'];
+    const callSettings = defaultCallSettings.merge(options);
+    this.initialize();
+    return this.descriptors.page.listViews.createStream(
+      this.innerApiCalls.listViews as GaxCall,
+      request,
+      callSettings
+    );
+  }
+
+/**
+ * Equivalent to `listViews`, but returns an iterable object.
+ *
+ * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.parent
+ *   Required. The bucket whose views are to be listed:
+ *
+ *       "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+ * @param {string} [request.pageToken]
+ *   Optional. If present, then retrieve the next batch of results from the preceding call
+ *   to this method. `pageToken` must be the value of `nextPageToken` from the
+ *   previous response. The values of other method parameters should be
+ *   identical to those in the previous call.
+ * @param {number} [request.pageSize]
+ *   Optional. The maximum number of results to return from this request.
+ *
+ *   Non-positive values are ignored. The presence of `nextPageToken` in the
+ *   response indicates that more results might be available.
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Object}
+ *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   When you iterate the returned iterable, each element will be an object representing
+ *   [LogView]{@link google.logging.v2.LogView}. The API will be called under the hood as needed, once per the page,
+ *   so you can stop the iteration when you don't need more results.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/config_service_v2.list_views.js</caption>
+ * region_tag:logging_v2_generated_ConfigServiceV2_ListViews_async
+ */
+  listViewsAsync(
+      request?: protos.google.logging.v2.IListViewsRequest,
+      options?: CallOptions):
+    AsyncIterable<protos.google.logging.v2.ILogView>{
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = this._gaxModule.routingHeader.fromParams({
+      'parent': request.parent || '',
+    });
+    const defaultCallSettings = this._defaults['listViews'];
+    const callSettings = defaultCallSettings.merge(options);
+    this.initialize();
+    return this.descriptors.page.listViews.asyncIterate(
+      this.innerApiCalls['listViews'] as GaxCall,
+      request as {},
+      callSettings
+    ) as AsyncIterable<protos.google.logging.v2.ILogView>;
   }
  /**
  * Lists sinks.
@@ -1869,7 +3029,7 @@ export class ConfigServiceV2Client {
     ) as AsyncIterable<protos.google.logging.v2.ILogSink>;
   }
  /**
- * Lists all the exclusions in a parent resource.
+ * Lists all the exclusions on the _Default sink in a parent resource.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -2184,6 +3344,68 @@ export class ConfigServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified billingAccountLocationBucketView resource name string.
+   *
+   * @param {string} billing_account
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  billingAccountLocationBucketViewPath(billingAccount:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render({
+      billing_account: billingAccount,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).billing_account;
+  }
+
+  /**
+   * Parse the location from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified billingAccountLog resource name string.
    *
    * @param {string} billing_account
@@ -2217,6 +3439,29 @@ export class ConfigServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(billingAccountLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified billingAccountSettings resource name string.
+   *
+   * @param {string} billing_account
+   * @returns {string} Resource name string.
+   */
+  billingAccountSettingsPath(billingAccount:string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.render({
+      billing_account: billingAccount,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountSettings resource.
+   *
+   * @param {string} billingAccountSettingsName
+   *   A fully-qualified path representing billing_account_settings resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountSettingsName(billingAccountSettingsName: string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.match(billingAccountSettingsName).billing_account;
   }
 
   /**
@@ -2364,6 +3609,68 @@ export class ConfigServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified folderLocationBucketView resource name string.
+   *
+   * @param {string} folder
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  folderLocationBucketViewPath(folder:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
+      folder: folder,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).folder;
+  }
+
+  /**
+   * Parse the location from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified folderLog resource name string.
    *
    * @param {string} folder
@@ -2397,6 +3704,29 @@ export class ConfigServiceV2Client {
    */
   matchLogFromFolderLogName(folderLogName: string) {
     return this.pathTemplates.folderLogPathTemplate.match(folderLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified folderSettings resource name string.
+   *
+   * @param {string} folder
+   * @returns {string} Resource name string.
+   */
+  folderSettingsPath(folder:string) {
+    return this.pathTemplates.folderSettingsPathTemplate.render({
+      folder: folder,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderSettings resource.
+   *
+   * @param {string} folderSettingsName
+   *   A fully-qualified path representing folder_settings resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderSettingsName(folderSettingsName: string) {
+    return this.pathTemplates.folderSettingsPathTemplate.match(folderSettingsName).folder;
   }
 
   /**
@@ -2616,6 +3946,68 @@ export class ConfigServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified organizationLocationBucketView resource name string.
+   *
+   * @param {string} organization
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  organizationLocationBucketViewPath(organization:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.render({
+      organization: organization,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).organization;
+  }
+
+  /**
+   * Parse the location from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified organizationLog resource name string.
    *
    * @param {string} organization
@@ -2649,6 +4041,29 @@ export class ConfigServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(organizationLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified organizationSettings resource name string.
+   *
+   * @param {string} organization
+   * @returns {string} Resource name string.
+   */
+  organizationSettingsPath(organization:string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.render({
+      organization: organization,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationSettings resource.
+   *
+   * @param {string} organizationSettingsName
+   *   A fully-qualified path representing organization_settings resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationSettingsName(organizationSettingsName: string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.match(organizationSettingsName).organization;
   }
 
   /**
@@ -2819,6 +4234,68 @@ export class ConfigServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified projectLocationBucketView resource name string.
+   *
+   * @param {string} project
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  projectLocationBucketViewPath(project:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
+      project: project,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).project;
+  }
+
+  /**
+   * Parse the location from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified projectLog resource name string.
    *
    * @param {string} project
@@ -2852,6 +4329,29 @@ export class ConfigServiceV2Client {
    */
   matchLogFromProjectLogName(projectLogName: string) {
     return this.pathTemplates.projectLogPathTemplate.match(projectLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified projectSettings resource name string.
+   *
+   * @param {string} project
+   * @returns {string} Resource name string.
+   */
+  projectSettingsPath(project:string) {
+    return this.pathTemplates.projectSettingsPathTemplate.render({
+      project: project,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectSettings resource.
+   *
+   * @param {string} projectSettingsName
+   *   A fully-qualified path representing project_settings resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectSettingsName(projectSettingsName: string) {
+    return this.pathTemplates.projectSettingsPathTemplate.match(projectSettingsName).project;
   }
 
   /**
@@ -2901,6 +4401,7 @@ export class ConfigServiceV2Client {
       return this.configServiceV2Stub.then(stub => {
         this._terminated = true;
         stub.close();
+        this.operationsClient.close();
       });
     }
     return Promise.resolve();

--- a/baselines/logging/src/v2/config_service_v2_client_config.json.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client_config.json.baseline
@@ -6,6 +6,11 @@
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
+        ],
+        "deadline_exceeded_internal_unavailable": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -65,43 +70,53 @@
           "retry_params_name": "default"
         },
         "ListSinks": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "GetSink": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "CreateSink": {
+          "timeout_millis": 120000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "UpdateSink": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "DeleteSink": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "ListExclusions": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "GetExclusion": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "CreateExclusion": {
+          "timeout_millis": 120000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "UpdateExclusion": {
+          "timeout_millis": 120000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "DeleteExclusion": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "GetCmekSettings": {

--- a/baselines/logging/src/v2/config_service_v2_client_config.json.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client_config.json.baseline
@@ -28,7 +28,39 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "CreateBucket": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "UpdateBucket": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteBucket": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UndeleteBucket": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ListViews": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetView": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateView": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateView": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteView": {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
@@ -77,6 +109,18 @@
           "retry_params_name": "default"
         },
         "UpdateCmekSettings": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetSettings": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateSettings": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CopyLogEntries": {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -252,7 +252,7 @@ export class LoggingServiceV2Client {
         'entries',
         ['log_name','resource','labels'],
         null,
-        gax.createByteLengthFunction(
+        this._gaxModule.createByteLengthFunction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           protoFilesRoot.lookupType('google.logging.v2.LogEntry') as any
         )

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -19,7 +19,7 @@
 /* global window */
 import type * as gax from 'google-gax';
 import type {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
-import {Transform} from 'stream';
+import {Transform, PassThrough} from 'stream';
 import * as protos from '../../protos/protos';
 import jsonProtos = require('../../protos/protos.json');
 /**
@@ -172,8 +172,14 @@ export class LoggingServiceV2Client {
       billingAccountLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
       ),
+      billingAccountLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/logs/{log}'
+      ),
+      billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/sinks/{sink}'
@@ -187,8 +193,14 @@ export class LoggingServiceV2Client {
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
+      folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/logs/{log}'
+      ),
+      folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/sinks/{sink}'
@@ -205,8 +217,14 @@ export class LoggingServiceV2Client {
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
+      organizationLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/logs/{log}'
+      ),
+      organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sinks/{sink}'
@@ -223,8 +241,14 @@ export class LoggingServiceV2Client {
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
+      projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/logs/{log}'
+      ),
+      projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/sinks/{sink}'
@@ -243,6 +267,12 @@ export class LoggingServiceV2Client {
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'logNames')
     };
 
+    // Some of the methods on this service provide streaming responses.
+    // Provide descriptors for these.
+    this.descriptors.stream = {
+      tailLogEntries: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+    };
+
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
     // Some methods on this API support automatically batching
     // requests; denote this.
@@ -252,7 +282,7 @@ export class LoggingServiceV2Client {
         'entries',
         ['log_name','resource','labels'],
         null,
-        this._gaxModule.createByteLengthFunction(
+        this._gaxModule.GrpcClient.createByteLengthFunction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           protoFilesRoot.lookupType('google.logging.v2.LogEntry') as any
         )
@@ -302,11 +332,18 @@ export class LoggingServiceV2Client {
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
     const loggingServiceV2StubMethods =
-        ['deleteLog', 'writeLogEntries', 'listLogEntries', 'listMonitoredResourceDescriptors', 'listLogs'];
+        ['deleteLog', 'writeLogEntries', 'listLogEntries', 'listMonitoredResourceDescriptors', 'listLogs', 'tailLogEntries'];
     for (const methodName of loggingServiceV2StubMethods) {
       const callPromise = this.loggingServiceV2Stub.then(
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
+            if (methodName in this.descriptors.stream) {
+              const stream = new PassThrough();
+              setImmediate(() => {
+                stream.emit('error', new this._gaxModule.GoogleError('The client has already been closed.'));
+              });
+              return stream;
+            }
             return Promise.reject('The client has already been closed.');
           }
           const func = stub[methodName];
@@ -318,6 +355,7 @@ export class LoggingServiceV2Client {
 
       const descriptor =
         this.descriptors.page[methodName] ||
+        this.descriptors.stream[methodName] ||
         this.descriptors.batching?.[methodName] ||
         undefined;
       const apiCall = this._gaxModule.createApiCall(
@@ -392,24 +430,25 @@ export class LoggingServiceV2Client {
   // -- Service calls --
   // -------------------
 /**
- * Deletes all the log entries in a log. The log reappears if it receives new
- * entries. Log entries written shortly before the delete operation might not
- * be deleted. Entries received after the delete operation with a timestamp
- * before the operation will be deleted.
+ * Deletes all the log entries in a log for the _Default Log Bucket. The log
+ * reappears if it receives new entries. Log entries written shortly before
+ * the delete operation might not be deleted. Entries received after the
+ * delete operation with a timestamp before the operation will be deleted.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.logName
  *   Required. The resource name of the log to delete:
  *
- *       "projects/[PROJECT_ID]/logs/[LOG_ID]"
- *       "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
- *       "folders/[FOLDER_ID]/logs/[LOG_ID]"
+ *   * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+ *   * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+ *   * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+ *   * `folders/[FOLDER_ID]/logs/[LOG_ID]`
  *
  *   `[LOG_ID]` must be URL-encoded. For example,
  *   `"projects/my-project-id/logs/syslog"`,
- *   `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+ *   `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
+ *
  *   For more information about log names, see
  *   {@link google.logging.v2.LogEntry|LogEntry}.
  * @param {object} [options]
@@ -491,15 +530,15 @@ export class LoggingServiceV2Client {
  *   Optional. A default log resource name that is assigned to all log entries
  *   in `entries` that do not specify a value for `log_name`:
  *
- *       "projects/[PROJECT_ID]/logs/[LOG_ID]"
- *       "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
- *       "folders/[FOLDER_ID]/logs/[LOG_ID]"
+ *   * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+ *   * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+ *   * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+ *   * `folders/[FOLDER_ID]/logs/[LOG_ID]`
  *
  *   `[LOG_ID]` must be URL-encoded. For example:
  *
  *       "projects/my-project-id/logs/syslog"
- *       "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+ *       "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
  *
  *   The permission `logging.logEntries.create` is needed on each project,
  *   organization, billing account, or folder that is receiving new log
@@ -534,15 +573,16 @@ export class LoggingServiceV2Client {
  *   the entries later in the list. See the `entries.list` method.
  *
  *   Log entries with timestamps that are more than the
- *   [logs retention period](/logging/quota-policy) in the past or more than
- *   24 hours in the future will not be available when calling `entries.list`.
- *   However, those log entries can still be
- *   [exported with LogSinks](/logging/docs/api/tasks/exporting-logs).
+ *   [logs retention period](https://cloud.google.com/logging/quotas) in
+ *   the past or more than 24 hours in the future will not be available when
+ *   calling `entries.list`. However, those log entries can still be [exported
+ *   with
+ *   LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
  *
  *   To improve throughput and to avoid exceeding the
- *   [quota limit](/logging/quota-policy) for calls to `entries.write`,
- *   you should try to include several log entries in this list,
- *   rather than calling this method for each individual log entry.
+ *   [quota limit](https://cloud.google.com/logging/quotas) for calls to
+ *   `entries.write`, you should try to include several log entries in this
+ *   list, rather than calling this method for each individual log entry.
  * @param {boolean} [request.partialSuccess]
  *   Optional. Whether valid entries should be written even if some other
  *   entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any
@@ -613,10 +653,34 @@ export class LoggingServiceV2Client {
     return this.innerApiCalls.writeLogEntries(request, options, callback);
   }
 
+/**
+ * Streaming read of log entries as they are ingested. Until the stream is
+ * terminated, it will continue reading logs.
+ *
+ * @param {object} [options]
+ *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+ * @returns {Stream}
+ *   An object stream which is both readable and writable. It accepts objects
+ *   representing [TailLogEntriesRequest]{@link google.logging.v2.TailLogEntriesRequest} for write() method, and
+ *   will emit objects representing [TailLogEntriesResponse]{@link google.logging.v2.TailLogEntriesResponse} on 'data' event asynchronously.
+ *   Please see the
+ *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   for more details and examples.
+ * @example <caption>include:samples/generated/v2/logging_service_v2.tail_log_entries.js</caption>
+ * region_tag:logging_v2_generated_LoggingServiceV2_TailLogEntries_async
+ */
+  tailLogEntries(
+      options?: CallOptions):
+    gax.CancellableStream {
+    this.initialize();
+    return this.innerApiCalls.tailLogEntries(null, options);
+  }
+
  /**
  * Lists log entries.  Use this method to retrieve log entries that originated
  * from a project/folder/organization/billing account.  For ways to export log
- * entries, see [Exporting Logs](/logging/docs/export).
+ * entries, see [Exporting
+ * Logs](https://cloud.google.com/logging/docs/export).
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -624,21 +688,27 @@ export class LoggingServiceV2Client {
  *   Required. Names of one or more parent resources from which to
  *   retrieve log entries:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  *
+ *   May alternatively be one or more views:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
  *
  *   Projects listed in the `project_ids` field are added to this list.
  * @param {string} [request.filter]
  *   Optional. A filter that chooses which log entries to return.  See [Advanced
- *   Logs Queries](/logging/docs/view/advanced-queries).  Only log entries that
- *   match the filter are returned.  An empty filter matches all log entries in
- *   the resources listed in `resource_names`. Referencing a parent resource
- *   that is not listed in `resource_names` will cause the filter to return no
- *   results.
- *   The maximum length of the filter is 20000 characters.
+ *   Logs Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+ *   Only log entries that match the filter are returned.  An empty filter
+ *   matches all log entries in the resources listed in `resource_names`.
+ *   Referencing a parent resource that is not listed in `resource_names` will
+ *   cause the filter to return no results. The maximum length of the filter is
+ *   20000 characters.
  * @param {string} [request.orderBy]
  *   Optional. How the results should be sorted.  Presently, the only permitted
  *   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
@@ -647,9 +717,10 @@ export class LoggingServiceV2Client {
  *   in order of decreasing timestamps (newest first).  Entries with equal
  *   timestamps are returned in order of their `insert_id` values.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored.  The presence of `next_page_token` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Default is 50.
+ *   If the value is negative or exceeds 1000, the request is rejected. The
+ *   presence of `next_page_token` in the response indicates that more results
+ *   might be available.
  * @param {string} [request.pageToken]
  *   Optional. If present, then retrieve the next batch of results from the
  *   preceding call to this method.  `page_token` must be the value of
@@ -728,21 +799,27 @@ export class LoggingServiceV2Client {
  *   Required. Names of one or more parent resources from which to
  *   retrieve log entries:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  *
+ *   May alternatively be one or more views:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
  *
  *   Projects listed in the `project_ids` field are added to this list.
  * @param {string} [request.filter]
  *   Optional. A filter that chooses which log entries to return.  See [Advanced
- *   Logs Queries](/logging/docs/view/advanced-queries).  Only log entries that
- *   match the filter are returned.  An empty filter matches all log entries in
- *   the resources listed in `resource_names`. Referencing a parent resource
- *   that is not listed in `resource_names` will cause the filter to return no
- *   results.
- *   The maximum length of the filter is 20000 characters.
+ *   Logs Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+ *   Only log entries that match the filter are returned.  An empty filter
+ *   matches all log entries in the resources listed in `resource_names`.
+ *   Referencing a parent resource that is not listed in `resource_names` will
+ *   cause the filter to return no results. The maximum length of the filter is
+ *   20000 characters.
  * @param {string} [request.orderBy]
  *   Optional. How the results should be sorted.  Presently, the only permitted
  *   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
@@ -751,9 +828,10 @@ export class LoggingServiceV2Client {
  *   in order of decreasing timestamps (newest first).  Entries with equal
  *   timestamps are returned in order of their `insert_id` values.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored.  The presence of `next_page_token` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Default is 50.
+ *   If the value is negative or exceeds 1000, the request is rejected. The
+ *   presence of `next_page_token` in the response indicates that more results
+ *   might be available.
  * @param {string} [request.pageToken]
  *   Optional. If present, then retrieve the next batch of results from the
  *   preceding call to this method.  `page_token` must be the value of
@@ -799,21 +877,27 @@ export class LoggingServiceV2Client {
  *   Required. Names of one or more parent resources from which to
  *   retrieve log entries:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  *
+ *   May alternatively be one or more views:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
  *
  *   Projects listed in the `project_ids` field are added to this list.
  * @param {string} [request.filter]
  *   Optional. A filter that chooses which log entries to return.  See [Advanced
- *   Logs Queries](/logging/docs/view/advanced-queries).  Only log entries that
- *   match the filter are returned.  An empty filter matches all log entries in
- *   the resources listed in `resource_names`. Referencing a parent resource
- *   that is not listed in `resource_names` will cause the filter to return no
- *   results.
- *   The maximum length of the filter is 20000 characters.
+ *   Logs Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+ *   Only log entries that match the filter are returned.  An empty filter
+ *   matches all log entries in the resources listed in `resource_names`.
+ *   Referencing a parent resource that is not listed in `resource_names` will
+ *   cause the filter to return no results. The maximum length of the filter is
+ *   20000 characters.
  * @param {string} [request.orderBy]
  *   Optional. How the results should be sorted.  Presently, the only permitted
  *   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
@@ -822,9 +906,10 @@ export class LoggingServiceV2Client {
  *   in order of decreasing timestamps (newest first).  Entries with equal
  *   timestamps are returned in order of their `insert_id` values.
  * @param {number} [request.pageSize]
- *   Optional. The maximum number of results to return from this request.
- *   Non-positive values are ignored.  The presence of `next_page_token` in the
- *   response indicates that more results might be available.
+ *   Optional. The maximum number of results to return from this request. Default is 50.
+ *   If the value is negative or exceeds 1000, the request is rejected. The
+ *   presence of `next_page_token` in the response indicates that more results
+ *   might be available.
  * @param {string} [request.pageToken]
  *   Optional. If present, then retrieve the next batch of results from the
  *   preceding call to this method.  `page_token` must be the value of
@@ -1036,10 +1121,10 @@ export class LoggingServiceV2Client {
  * @param {string} request.parent
  *   Required. The resource name that owns the logs:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {number} [request.pageSize]
  *   Optional. The maximum number of results to return from this request.
  *   Non-positive values are ignored.  The presence of `nextPageToken` in the
@@ -1049,6 +1134,20 @@ export class LoggingServiceV2Client {
  *   preceding call to this method.  `pageToken` must be the value of
  *   `nextPageToken` from the previous response.  The values of other method
  *   parameters should be identical to those in the previous call.
+ * @param {string[]} [request.resourceNames]
+ *   Optional. The resource name that owns the logs:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *
+ *   To support legacy queries, it could also be:
+ *
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
@@ -1126,10 +1225,10 @@ export class LoggingServiceV2Client {
  * @param {string} request.parent
  *   Required. The resource name that owns the logs:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {number} [request.pageSize]
  *   Optional. The maximum number of results to return from this request.
  *   Non-positive values are ignored.  The presence of `nextPageToken` in the
@@ -1139,6 +1238,20 @@ export class LoggingServiceV2Client {
  *   preceding call to this method.  `pageToken` must be the value of
  *   `nextPageToken` from the previous response.  The values of other method
  *   parameters should be identical to those in the previous call.
+ * @param {string[]} [request.resourceNames]
+ *   Optional. The resource name that owns the logs:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *
+ *   To support legacy queries, it could also be:
+ *
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
@@ -1183,10 +1296,10 @@ export class LoggingServiceV2Client {
  * @param {string} request.parent
  *   Required. The resource name that owns the logs:
  *
- *       "projects/[PROJECT_ID]"
- *       "organizations/[ORGANIZATION_ID]"
- *       "billingAccounts/[BILLING_ACCOUNT_ID]"
- *       "folders/[FOLDER_ID]"
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {number} [request.pageSize]
  *   Optional. The maximum number of results to return from this request.
  *   Non-positive values are ignored.  The presence of `nextPageToken` in the
@@ -1196,6 +1309,20 @@ export class LoggingServiceV2Client {
  *   preceding call to this method.  `pageToken` must be the value of
  *   `nextPageToken` from the previous response.  The values of other method
  *   parameters should be identical to those in the previous call.
+ * @param {string[]} [request.resourceNames]
+ *   Optional. The resource name that owns the logs:
+ *
+ *    * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *    * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+ *
+ *   To support legacy queries, it could also be:
+ *
+ *   *  `projects/[PROJECT_ID]`
+ *   *  `organizations/[ORGANIZATION_ID]`
+ *   *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+ *   *  `folders/[FOLDER_ID]`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
@@ -1344,6 +1471,68 @@ export class LoggingServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified billingAccountLocationBucketView resource name string.
+   *
+   * @param {string} billing_account
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  billingAccountLocationBucketViewPath(billingAccount:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render({
+      billing_account: billingAccount,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).billing_account;
+  }
+
+  /**
+   * Parse the location from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified billingAccountLog resource name string.
    *
    * @param {string} billing_account
@@ -1377,6 +1566,29 @@ export class LoggingServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(billingAccountLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified billingAccountSettings resource name string.
+   *
+   * @param {string} billing_account
+   * @returns {string} Resource name string.
+   */
+  billingAccountSettingsPath(billingAccount:string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.render({
+      billing_account: billingAccount,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountSettings resource.
+   *
+   * @param {string} billingAccountSettingsName
+   *   A fully-qualified path representing billing_account_settings resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountSettingsName(billingAccountSettingsName: string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.match(billingAccountSettingsName).billing_account;
   }
 
   /**
@@ -1524,6 +1736,68 @@ export class LoggingServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified folderLocationBucketView resource name string.
+   *
+   * @param {string} folder
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  folderLocationBucketViewPath(folder:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
+      folder: folder,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).folder;
+  }
+
+  /**
+   * Parse the location from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified folderLog resource name string.
    *
    * @param {string} folder
@@ -1557,6 +1831,29 @@ export class LoggingServiceV2Client {
    */
   matchLogFromFolderLogName(folderLogName: string) {
     return this.pathTemplates.folderLogPathTemplate.match(folderLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified folderSettings resource name string.
+   *
+   * @param {string} folder
+   * @returns {string} Resource name string.
+   */
+  folderSettingsPath(folder:string) {
+    return this.pathTemplates.folderSettingsPathTemplate.render({
+      folder: folder,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderSettings resource.
+   *
+   * @param {string} folderSettingsName
+   *   A fully-qualified path representing folder_settings resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderSettingsName(folderSettingsName: string) {
+    return this.pathTemplates.folderSettingsPathTemplate.match(folderSettingsName).folder;
   }
 
   /**
@@ -1740,6 +2037,68 @@ export class LoggingServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified organizationLocationBucketView resource name string.
+   *
+   * @param {string} organization
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  organizationLocationBucketViewPath(organization:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.render({
+      organization: organization,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).organization;
+  }
+
+  /**
+   * Parse the location from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified organizationLog resource name string.
    *
    * @param {string} organization
@@ -1773,6 +2132,29 @@ export class LoggingServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(organizationLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified organizationSettings resource name string.
+   *
+   * @param {string} organization
+   * @returns {string} Resource name string.
+   */
+  organizationSettingsPath(organization:string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.render({
+      organization: organization,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationSettings resource.
+   *
+   * @param {string} organizationSettingsName
+   *   A fully-qualified path representing organization_settings resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationSettingsName(organizationSettingsName: string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.match(organizationSettingsName).organization;
   }
 
   /**
@@ -1943,6 +2325,68 @@ export class LoggingServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified projectLocationBucketView resource name string.
+   *
+   * @param {string} project
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  projectLocationBucketViewPath(project:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
+      project: project,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).project;
+  }
+
+  /**
+   * Parse the location from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified projectLog resource name string.
    *
    * @param {string} project
@@ -1976,6 +2420,29 @@ export class LoggingServiceV2Client {
    */
   matchLogFromProjectLogName(projectLogName: string) {
     return this.pathTemplates.projectLogPathTemplate.match(projectLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified projectSettings resource name string.
+   *
+   * @param {string} project
+   * @returns {string} Resource name string.
+   */
+  projectSettingsPath(project:string) {
+    return this.pathTemplates.projectSettingsPathTemplate.render({
+      project: project,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectSettings resource.
+   *
+   * @param {string} projectSettingsName
+   *   A fully-qualified path representing project_settings resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectSettingsName(projectSettingsName: string) {
+    return this.pathTemplates.projectSettingsPathTemplate.match(projectSettingsName).project;
   }
 
   /**

--- a/baselines/logging/src/v2/logging_service_v2_client_config.json.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client_config.json.baseline
@@ -45,6 +45,10 @@
         "ListLogs": {
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "TailLogEntries": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/baselines/logging/src/v2/logging_service_v2_client_config.json.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client_config.json.baseline
@@ -6,6 +6,11 @@
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
+        ],
+        "deadline_exceeded_internal_unavailable": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -21,11 +26,13 @@
       },
       "methods": {
         "DeleteLog": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "WriteLogEntries": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default",
           "bundling": {
             "element_count_threshold": 1000,
@@ -35,19 +42,23 @@
           }
         },
         "ListLogEntries": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "ListMonitoredResourceDescriptors": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "ListLogs": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "TailLogEntries": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 3600000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         }
       }

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -172,8 +172,14 @@ export class MetricsServiceV2Client {
       billingAccountLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}'
       ),
+      billingAccountLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       billingAccountLogPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/logs/{log}'
+      ),
+      billingAccountSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'billingAccounts/{billing_account}/settings'
       ),
       billingAccountSinkPathTemplate: new this._gaxModule.PathTemplate(
         'billingAccounts/{billing_account}/sinks/{sink}'
@@ -187,8 +193,14 @@ export class MetricsServiceV2Client {
       folderLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/locations/{location}/buckets/{bucket}'
       ),
+      folderLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       folderLogPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/logs/{log}'
+      ),
+      folderSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'folders/{folder}/settings'
       ),
       folderSinkPathTemplate: new this._gaxModule.PathTemplate(
         'folders/{folder}/sinks/{sink}'
@@ -205,8 +217,14 @@ export class MetricsServiceV2Client {
       organizationLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/locations/{location}/buckets/{bucket}'
       ),
+      organizationLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       organizationLogPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/logs/{log}'
+      ),
+      organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'organizations/{organization}/settings'
       ),
       organizationSinkPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sinks/{sink}'
@@ -223,8 +241,14 @@ export class MetricsServiceV2Client {
       projectLocationBucketPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/buckets/{bucket}'
       ),
+      projectLocationBucketViewPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
+      ),
       projectLogPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/logs/{log}'
+      ),
+      projectSettingsPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/settings'
       ),
       projectSinkPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/sinks/{sink}'
@@ -981,6 +1005,68 @@ export class MetricsServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified billingAccountLocationBucketView resource name string.
+   *
+   * @param {string} billing_account
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  billingAccountLocationBucketViewPath(billingAccount:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.render({
+      billing_account: billingAccount,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).billing_account;
+  }
+
+  /**
+   * Parse the location from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from BillingAccountLocationBucketView resource.
+   *
+   * @param {string} billingAccountLocationBucketViewName
+   *   A fully-qualified path representing billing_account_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromBillingAccountLocationBucketViewName(billingAccountLocationBucketViewName: string) {
+    return this.pathTemplates.billingAccountLocationBucketViewPathTemplate.match(billingAccountLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified billingAccountLog resource name string.
    *
    * @param {string} billing_account
@@ -1014,6 +1100,29 @@ export class MetricsServiceV2Client {
    */
   matchLogFromBillingAccountLogName(billingAccountLogName: string) {
     return this.pathTemplates.billingAccountLogPathTemplate.match(billingAccountLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified billingAccountSettings resource name string.
+   *
+   * @param {string} billing_account
+   * @returns {string} Resource name string.
+   */
+  billingAccountSettingsPath(billingAccount:string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.render({
+      billing_account: billingAccount,
+    });
+  }
+
+  /**
+   * Parse the billing_account from BillingAccountSettings resource.
+   *
+   * @param {string} billingAccountSettingsName
+   *   A fully-qualified path representing billing_account_settings resource.
+   * @returns {string} A string representing the billing_account.
+   */
+  matchBillingAccountFromBillingAccountSettingsName(billingAccountSettingsName: string) {
+    return this.pathTemplates.billingAccountSettingsPathTemplate.match(billingAccountSettingsName).billing_account;
   }
 
   /**
@@ -1161,6 +1270,68 @@ export class MetricsServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified folderLocationBucketView resource name string.
+   *
+   * @param {string} folder
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  folderLocationBucketViewPath(folder:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.render({
+      folder: folder,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).folder;
+  }
+
+  /**
+   * Parse the location from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from FolderLocationBucketView resource.
+   *
+   * @param {string} folderLocationBucketViewName
+   *   A fully-qualified path representing folder_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromFolderLocationBucketViewName(folderLocationBucketViewName: string) {
+    return this.pathTemplates.folderLocationBucketViewPathTemplate.match(folderLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified folderLog resource name string.
    *
    * @param {string} folder
@@ -1194,6 +1365,29 @@ export class MetricsServiceV2Client {
    */
   matchLogFromFolderLogName(folderLogName: string) {
     return this.pathTemplates.folderLogPathTemplate.match(folderLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified folderSettings resource name string.
+   *
+   * @param {string} folder
+   * @returns {string} Resource name string.
+   */
+  folderSettingsPath(folder:string) {
+    return this.pathTemplates.folderSettingsPathTemplate.render({
+      folder: folder,
+    });
+  }
+
+  /**
+   * Parse the folder from FolderSettings resource.
+   *
+   * @param {string} folderSettingsName
+   *   A fully-qualified path representing folder_settings resource.
+   * @returns {string} A string representing the folder.
+   */
+  matchFolderFromFolderSettingsName(folderSettingsName: string) {
+    return this.pathTemplates.folderSettingsPathTemplate.match(folderSettingsName).folder;
   }
 
   /**
@@ -1377,6 +1571,68 @@ export class MetricsServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified organizationLocationBucketView resource name string.
+   *
+   * @param {string} organization
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  organizationLocationBucketViewPath(organization:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.render({
+      organization: organization,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).organization;
+  }
+
+  /**
+   * Parse the location from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from OrganizationLocationBucketView resource.
+   *
+   * @param {string} organizationLocationBucketViewName
+   *   A fully-qualified path representing organization_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromOrganizationLocationBucketViewName(organizationLocationBucketViewName: string) {
+    return this.pathTemplates.organizationLocationBucketViewPathTemplate.match(organizationLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified organizationLog resource name string.
    *
    * @param {string} organization
@@ -1410,6 +1666,29 @@ export class MetricsServiceV2Client {
    */
   matchLogFromOrganizationLogName(organizationLogName: string) {
     return this.pathTemplates.organizationLogPathTemplate.match(organizationLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified organizationSettings resource name string.
+   *
+   * @param {string} organization
+   * @returns {string} Resource name string.
+   */
+  organizationSettingsPath(organization:string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.render({
+      organization: organization,
+    });
+  }
+
+  /**
+   * Parse the organization from OrganizationSettings resource.
+   *
+   * @param {string} organizationSettingsName
+   *   A fully-qualified path representing organization_settings resource.
+   * @returns {string} A string representing the organization.
+   */
+  matchOrganizationFromOrganizationSettingsName(organizationSettingsName: string) {
+    return this.pathTemplates.organizationSettingsPathTemplate.match(organizationSettingsName).organization;
   }
 
   /**
@@ -1580,6 +1859,68 @@ export class MetricsServiceV2Client {
   }
 
   /**
+   * Return a fully-qualified projectLocationBucketView resource name string.
+   *
+   * @param {string} project
+   * @param {string} location
+   * @param {string} bucket
+   * @param {string} view
+   * @returns {string} Resource name string.
+   */
+  projectLocationBucketViewPath(project:string,location:string,bucket:string,view:string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.render({
+      project: project,
+      location: location,
+      bucket: bucket,
+      view: view,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).project;
+  }
+
+  /**
+   * Parse the location from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the location.
+   */
+  matchLocationFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).location;
+  }
+
+  /**
+   * Parse the bucket from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the bucket.
+   */
+  matchBucketFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).bucket;
+  }
+
+  /**
+   * Parse the view from ProjectLocationBucketView resource.
+   *
+   * @param {string} projectLocationBucketViewName
+   *   A fully-qualified path representing project_location_bucket_view resource.
+   * @returns {string} A string representing the view.
+   */
+  matchViewFromProjectLocationBucketViewName(projectLocationBucketViewName: string) {
+    return this.pathTemplates.projectLocationBucketViewPathTemplate.match(projectLocationBucketViewName).view;
+  }
+
+  /**
    * Return a fully-qualified projectLog resource name string.
    *
    * @param {string} project
@@ -1613,6 +1954,29 @@ export class MetricsServiceV2Client {
    */
   matchLogFromProjectLogName(projectLogName: string) {
     return this.pathTemplates.projectLogPathTemplate.match(projectLogName).log;
+  }
+
+  /**
+   * Return a fully-qualified projectSettings resource name string.
+   *
+   * @param {string} project
+   * @returns {string} Resource name string.
+   */
+  projectSettingsPath(project:string) {
+    return this.pathTemplates.projectSettingsPathTemplate.render({
+      project: project,
+    });
+  }
+
+  /**
+   * Parse the project from ProjectSettings resource.
+   *
+   * @param {string} projectSettingsName
+   *   A fully-qualified path representing project_settings resource.
+   * @returns {string} A string representing the project.
+   */
+  matchProjectFromProjectSettingsName(projectSettingsName: string) {
+    return this.pathTemplates.projectSettingsPathTemplate.match(projectSettingsName).project;
   }
 
   /**

--- a/baselines/logging/src/v2/metrics_service_v2_client_config.json.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client_config.json.baseline
@@ -6,6 +6,11 @@
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
+        ],
+        "deadline_exceeded_internal_unavailable": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -21,23 +26,28 @@
       },
       "methods": {
         "ListLogMetrics": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "GetLogMetric": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "CreateLogMetric": {
+          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "UpdateLogMetric": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         },
         "DeleteLogMetric": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "deadline_exceeded_internal_unavailable",
           "retry_params_name": "default"
         }
       }

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -25,7 +25,7 @@ import * as configservicev2Module from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
@@ -39,6 +39,22 @@ function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
 
 function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error?: Error) {
     return error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);
+}
+
+function stubLongRunningCall<ResponseType>(response?: ResponseType, callError?: Error, lroError?: Error) {
+    const innerStub = lroError ? sinon.stub().rejects(lroError) : sinon.stub().resolves([response]);
+    const mockOperation = {
+        promise: innerStub,
+    };
+    return callError ? sinon.stub().rejects(callError) : sinon.stub().resolves([mockOperation]);
+}
+
+function stubLongRunningCallWithCallback<ResponseType>(response?: ResponseType, callError?: Error, lroError?: Error) {
+    const innerStub = lroError ? sinon.stub().rejects(lroError) : sinon.stub().resolves([response]);
+    const mockOperation = {
+        promise: innerStub,
+    };
+    return callError ? sinon.stub().callsArgWith(2, callError) : sinon.stub().callsArgWith(2, null, mockOperation);
 }
 
 function stubPageStreamingCall<ResponseType>(responses?: ResponseType[], error?: Error) {
@@ -279,6 +295,103 @@ describe('v2.ConfigServiceV2Client', () => {
         });
     });
 
+    describe('createBucket', () => {
+        it('invokes createBucket without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            client.innerApiCalls.createBucket = stubSimpleCall(expectedResponse);
+            const [response] = await client.createBucket(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes createBucket without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            client.innerApiCalls.createBucket = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.createBucket(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ILogBucket|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes createBucket with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.createBucket = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.createBucket(request), expectedError);
+            assert((client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes createBucket with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            request.parent = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.createBucket(request), expectedError);
+        });
+    });
+
     describe('updateBucket', () => {
         it('invokes updateBucket without error', async () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({
@@ -373,6 +486,588 @@ describe('v2.ConfigServiceV2Client', () => {
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateBucket(request), expectedError);
+        });
+    });
+
+    describe('deleteBucket', () => {
+        it('invokes deleteBucket without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.deleteBucket = stubSimpleCall(expectedResponse);
+            const [response] = await client.deleteBucket(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes deleteBucket without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.deleteBucket = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.deleteBucket(
+                    request,
+                    (err?: Error|null, result?: protos.google.protobuf.IEmpty|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes deleteBucket with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.deleteBucket = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.deleteBucket(request), expectedError);
+            assert((client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes deleteBucket with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.deleteBucket(request), expectedError);
+        });
+    });
+
+    describe('undeleteBucket', () => {
+        it('invokes undeleteBucket without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.undeleteBucket = stubSimpleCall(expectedResponse);
+            const [response] = await client.undeleteBucket(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes undeleteBucket without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.undeleteBucket = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.undeleteBucket(
+                    request,
+                    (err?: Error|null, result?: protos.google.protobuf.IEmpty|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes undeleteBucket with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.undeleteBucket = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.undeleteBucket(request), expectedError);
+            assert((client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes undeleteBucket with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.undeleteBucket(request), expectedError);
+        });
+    });
+
+    describe('getView', () => {
+        it('invokes getView without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.getView = stubSimpleCall(expectedResponse);
+            const [response] = await client.getView(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.getView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes getView without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.getView = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.getView(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ILogView|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.getView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes getView with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.getView = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.getView(request), expectedError);
+            assert((client.innerApiCalls.getView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes getView with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.getView(request), expectedError);
+        });
+    });
+
+    describe('createView', () => {
+        it('invokes createView without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.createView = stubSimpleCall(expectedResponse);
+            const [response] = await client.createView(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.createView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes createView without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.createView = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.createView(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ILogView|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.createView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes createView with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.createView = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.createView(request), expectedError);
+            assert((client.innerApiCalls.createView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes createView with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            request.parent = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.createView(request), expectedError);
+        });
+    });
+
+    describe('updateView', () => {
+        it('invokes updateView without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.updateView = stubSimpleCall(expectedResponse);
+            const [response] = await client.updateView(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes updateView without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            client.innerApiCalls.updateView = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.updateView(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ILogView|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes updateView with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.updateView = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.updateView(request), expectedError);
+            assert((client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes updateView with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.updateView(request), expectedError);
+        });
+    });
+
+    describe('deleteView', () => {
+        it('invokes deleteView without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.deleteView = stubSimpleCall(expectedResponse);
+            const [response] = await client.deleteView(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes deleteView without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            client.innerApiCalls.deleteView = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.deleteView(
+                    request,
+                    (err?: Error|null, result?: protos.google.protobuf.IEmpty|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes deleteView with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.deleteView = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.deleteView(request), expectedError);
+            assert((client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes deleteView with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.deleteView(request), expectedError);
         });
     });
 
@@ -1346,6 +2041,312 @@ describe('v2.ConfigServiceV2Client', () => {
         });
     });
 
+    describe('getSettings', () => {
+        it('invokes getSettings without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            client.innerApiCalls.getSettings = stubSimpleCall(expectedResponse);
+            const [response] = await client.getSettings(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes getSettings without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            client.innerApiCalls.getSettings = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.getSettings(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ISettings|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes getSettings with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.getSettings = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.getSettings(request), expectedError);
+            assert((client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes getSettings with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.getSettings(request), expectedError);
+        });
+    });
+
+    describe('updateSettings', () => {
+        it('invokes updateSettings without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            client.innerApiCalls.updateSettings = stubSimpleCall(expectedResponse);
+            const [response] = await client.updateSettings(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes updateSettings without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            client.innerApiCalls.updateSettings = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.updateSettings(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ISettings|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes updateSettings with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            request.name = '';
+            const expectedHeaderRequestParams = "name=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.updateSettings = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.updateSettings(request), expectedError);
+            assert((client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes updateSettings with closed client', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            request.name = '';
+            const expectedError = new Error('The client has already been closed.');
+            client.close();
+            await assert.rejects(client.updateSettings(request), expectedError);
+        });
+    });
+
+    describe('copyLogEntries', () => {
+        it('invokes copyLogEntries without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
+            const expectedOptions = {otherArgs: {headers: {}}};;
+            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            client.innerApiCalls.copyLogEntries = stubLongRunningCall(expectedResponse);
+            const [operation] = await client.copyLogEntries(request);
+            const [response] = await operation.promise();
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.copyLogEntries as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes copyLogEntries without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
+            const expectedOptions = {otherArgs: {headers: {}}};;
+            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            client.innerApiCalls.copyLogEntries = stubLongRunningCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.copyLogEntries(
+                    request,
+                    (err?: Error|null,
+                     result?: LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>|null
+                    ) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const operation = await promise as LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>;
+            const [response] = await operation.promise();
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.copyLogEntries as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes copyLogEntries with call error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
+            const expectedOptions = {otherArgs: {headers: {}}};;
+            const expectedError = new Error('expected');
+            client.innerApiCalls.copyLogEntries = stubLongRunningCall(undefined, expectedError);
+            await assert.rejects(client.copyLogEntries(request), expectedError);
+            assert((client.innerApiCalls.copyLogEntries as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes copyLogEntries with LRO error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
+            const expectedOptions = {otherArgs: {headers: {}}};;
+            const expectedError = new Error('expected');
+            client.innerApiCalls.copyLogEntries = stubLongRunningCall(undefined, undefined, expectedError);
+            const [operation] = await client.copyLogEntries(request);
+            await assert.rejects(operation.promise(), expectedError);
+            assert((client.innerApiCalls.copyLogEntries as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes checkCopyLogEntriesProgress without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            expectedResponse.name = 'test';
+            expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+            expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
+
+            client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+            const decodedOperation = await client.checkCopyLogEntriesProgress(expectedResponse.name);
+            assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+            assert(decodedOperation.metadata);
+            assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+        });
+
+        it('invokes checkCopyLogEntriesProgress with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const expectedError = new Error('expected');
+
+            client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.checkCopyLogEntriesProgress(''), expectedError);
+            assert((client.operationsClient.getOperation as SinonStub)
+                .getCall(0));
+        });
+    });
+
     describe('listBuckets', () => {
         it('invokes listBuckets without error', async () => {
             const client = new configservicev2Module.v2.ConfigServiceV2Client({
@@ -1563,6 +2564,229 @@ describe('v2.ConfigServiceV2Client', () => {
                     .getCall(0).args[1], request);
             assert.strictEqual(
                 (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
+                expectedHeaderRequestParams
+            );
+        });
+    });
+
+    describe('listViews', () => {
+        it('invokes listViews without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = [
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+            ];
+            client.innerApiCalls.listViews = stubSimpleCall(expectedResponse);
+            const [response] = await client.listViews(request);
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes listViews without error using callback', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedResponse = [
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+            ];
+            client.innerApiCalls.listViews = stubSimpleCallWithCallback(expectedResponse);
+            const promise = new Promise((resolve, reject) => {
+                 client.listViews(
+                    request,
+                    (err?: Error|null, result?: protos.google.logging.v2.ILogView[]|null) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(result);
+                        }
+                    });
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+        });
+
+        it('invokes listViews with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedOptions = {
+                otherArgs: {
+                    headers: {
+                        'x-goog-request-params': expectedHeaderRequestParams,
+                    },
+                },
+            };
+            const expectedError = new Error('expected');
+            client.innerApiCalls.listViews = stubSimpleCall(undefined, expectedError);
+            await assert.rejects(client.listViews(request), expectedError);
+            assert((client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).calledWith(request, expectedOptions, undefined));
+        });
+
+        it('invokes listViewsStream without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedResponse = [
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+            ];
+            client.descriptors.page.listViews.createStream = stubPageStreamingCall(expectedResponse);
+            const stream = client.listViewsStream(request);
+            const promise = new Promise((resolve, reject) => {
+                const responses: protos.google.logging.v2.LogView[] = [];
+                stream.on('data', (response: protos.google.logging.v2.LogView) => {
+                    responses.push(response);
+                });
+                stream.on('end', () => {
+                    resolve(responses);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            const responses = await promise;
+            assert.deepStrictEqual(responses, expectedResponse);
+            assert((client.descriptors.page.listViews.createStream as SinonStub)
+                .getCall(0).calledWith(client.innerApiCalls.listViews, request));
+            assert.strictEqual(
+                (client.descriptors.page.listViews.createStream as SinonStub)
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
+                expectedHeaderRequestParams
+            );
+        });
+
+        it('invokes listViewsStream with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedError = new Error('expected');
+            client.descriptors.page.listViews.createStream = stubPageStreamingCall(undefined, expectedError);
+            const stream = client.listViewsStream(request);
+            const promise = new Promise((resolve, reject) => {
+                const responses: protos.google.logging.v2.LogView[] = [];
+                stream.on('data', (response: protos.google.logging.v2.LogView) => {
+                    responses.push(response);
+                });
+                stream.on('end', () => {
+                    resolve(responses);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+            });
+            await assert.rejects(promise, expectedError);
+            assert((client.descriptors.page.listViews.createStream as SinonStub)
+                .getCall(0).calledWith(client.innerApiCalls.listViews, request));
+            assert.strictEqual(
+                (client.descriptors.page.listViews.createStream as SinonStub)
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
+                expectedHeaderRequestParams
+            );
+        });
+
+        it('uses async iteration with listViews without error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";
+            const expectedResponse = [
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+              generateSampleMessage(new protos.google.logging.v2.LogView()),
+            ];
+            client.descriptors.page.listViews.asyncIterate = stubAsyncIterationCall(expectedResponse);
+            const responses: protos.google.logging.v2.ILogView[] = [];
+            const iterable = client.listViewsAsync(request);
+            for await (const resource of iterable) {
+                responses.push(resource!);
+            }
+            assert.deepStrictEqual(responses, expectedResponse);
+            assert.deepStrictEqual(
+                (client.descriptors.page.listViews.asyncIterate as SinonStub)
+                    .getCall(0).args[1], request);
+            assert.strictEqual(
+                (client.descriptors.page.listViews.asyncIterate as SinonStub)
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
+                expectedHeaderRequestParams
+            );
+        });
+
+        it('uses async iteration with listViews with error', async () => {
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            request.parent = '';
+            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            client.descriptors.page.listViews.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
+            const iterable = client.listViewsAsync(request);
+            await assert.rejects(async () => {
+                const responses: protos.google.logging.v2.ILogView[] = [];
+                for await (const resource of iterable) {
+                    responses.push(resource!);
+                }
+            });
+            assert.deepStrictEqual(
+                (client.descriptors.page.listViews.asyncIterate as SinonStub)
+                    .getCall(0).args[1], request);
+            assert.strictEqual(
+                (client.descriptors.page.listViews.asyncIterate as SinonStub)
                     .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
                 expectedHeaderRequestParams
             );
@@ -2131,6 +3355,60 @@ describe('v2.ConfigServiceV2Client', () => {
             });
         });
 
+        describe('billingAccountLocationBucketView', () => {
+            const fakePath = "/rendered/path/billingAccountLocationBucketView";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountLocationBucketViewPath', () => {
+                const result = client.billingAccountLocationBucketViewPath("billingAccountValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBillingAccountFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchLocationFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBucketFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchViewFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('billingAccountLog', () => {
             const fakePath = "/rendered/path/billingAccountLog";
             const expectedParameters = {
@@ -2165,6 +3443,36 @@ describe('v2.ConfigServiceV2Client', () => {
                 const result = client.matchLogFromBillingAccountLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.billingAccountLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('billingAccountSettings', () => {
+            const fakePath = "/rendered/path/billingAccountSettings";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountSettingsPath', () => {
+                const result = client.billingAccountSettingsPath("billingAccountValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountSettingsName', () => {
+                const result = client.matchBillingAccountFromBillingAccountSettingsName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -2321,6 +3629,60 @@ describe('v2.ConfigServiceV2Client', () => {
             });
         });
 
+        describe('folderLocationBucketView', () => {
+            const fakePath = "/rendered/path/folderLocationBucketView";
+            const expectedParameters = {
+                folder: "folderValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderLocationBucketViewPath', () => {
+                const result = client.folderLocationBucketViewPath("folderValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderLocationBucketViewName', () => {
+                const result = client.matchFolderFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromFolderLocationBucketViewName', () => {
+                const result = client.matchLocationFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromFolderLocationBucketViewName', () => {
+                const result = client.matchBucketFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromFolderLocationBucketViewName', () => {
+                const result = client.matchViewFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('folderLog', () => {
             const fakePath = "/rendered/path/folderLog";
             const expectedParameters = {
@@ -2355,6 +3717,36 @@ describe('v2.ConfigServiceV2Client', () => {
                 const result = client.matchLogFromFolderLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.folderLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('folderSettings', () => {
+            const fakePath = "/rendered/path/folderSettings";
+            const expectedParameters = {
+                folder: "folderValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderSettingsPath', () => {
+                const result = client.folderSettingsPath("folderValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderSettingsName', () => {
+                const result = client.matchFolderFromFolderSettingsName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -2587,6 +3979,60 @@ describe('v2.ConfigServiceV2Client', () => {
             });
         });
 
+        describe('organizationLocationBucketView', () => {
+            const fakePath = "/rendered/path/organizationLocationBucketView";
+            const expectedParameters = {
+                organization: "organizationValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationLocationBucketViewPath', () => {
+                const result = client.organizationLocationBucketViewPath("organizationValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchOrganizationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchLocationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchBucketFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchViewFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('organizationLog', () => {
             const fakePath = "/rendered/path/organizationLog";
             const expectedParameters = {
@@ -2621,6 +4067,36 @@ describe('v2.ConfigServiceV2Client', () => {
                 const result = client.matchLogFromOrganizationLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('organizationSettings', () => {
+            const fakePath = "/rendered/path/organizationSettings";
+            const expectedParameters = {
+                organization: "organizationValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationSettingsPath', () => {
+                const result = client.organizationSettingsPath("organizationValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationSettingsName', () => {
+                const result = client.matchOrganizationFromOrganizationSettingsName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -2807,6 +4283,60 @@ describe('v2.ConfigServiceV2Client', () => {
             });
         });
 
+        describe('projectLocationBucketView', () => {
+            const fakePath = "/rendered/path/projectLocationBucketView";
+            const expectedParameters = {
+                project: "projectValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectLocationBucketViewPath', () => {
+                const result = client.projectLocationBucketViewPath("projectValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectLocationBucketViewName', () => {
+                const result = client.matchProjectFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromProjectLocationBucketViewName', () => {
+                const result = client.matchLocationFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromProjectLocationBucketViewName', () => {
+                const result = client.matchBucketFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromProjectLocationBucketViewName', () => {
+                const result = client.matchViewFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('projectLog', () => {
             const fakePath = "/rendered/path/projectLog";
             const expectedParameters = {
@@ -2841,6 +4371,36 @@ describe('v2.ConfigServiceV2Client', () => {
                 const result = client.matchLogFromProjectLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.projectLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('projectSettings', () => {
+            const fakePath = "/rendered/path/projectSettings";
+            const expectedParameters = {
+                project: "projectValue",
+            };
+            const client = new configservicev2Module.v2.ConfigServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectSettingsPath', () => {
+                const result = client.projectSettingsPath("projectValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectSettingsName', () => {
+                const result = client.matchProjectFromProjectSettingsName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -41,6 +41,15 @@ function stubSimpleCallWithCallback<ResponseType>(response?: ResponseType, error
     return error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);
 }
 
+function stubBidiStreamingCall<ResponseType>(response?: ResponseType, error?: Error) {
+    const transformStub = error ? sinon.stub().callsArgWith(2, error) : sinon.stub().callsArgWith(2, null, response);
+    const mockStream = new PassThrough({
+        objectMode: true,
+        transform: transformStub,
+    });
+    return sinon.stub().returns(mockStream);
+}
+
 function stubPageStreamingCall<ResponseType>(responses?: ResponseType[], error?: Error) {
     const pagingStub = sinon.stub();
     if (responses) {
@@ -348,6 +357,63 @@ describe('v2.LoggingServiceV2Client', () => {
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.writeLogEntries(request), expectedError);
+        });
+    });
+
+    describe('tailLogEntries', () => {
+        it('invokes tailLogEntries without error', async () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesRequest());
+            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesResponse());
+            client.innerApiCalls.tailLogEntries = stubBidiStreamingCall(expectedResponse);
+            const stream = client.tailLogEntries();
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.logging.v2.TailLogEntriesResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+                stream.write(request);
+                stream.end();
+            });
+            const response = await promise;
+            assert.deepStrictEqual(response, expectedResponse);
+            assert((client.innerApiCalls.tailLogEntries as SinonStub)
+                .getCall(0).calledWith(null));
+            assert.deepStrictEqual(((stream as unknown as PassThrough)
+                ._transform as SinonStub).getCall(0).args[0], request);
+        });
+
+        it('invokes tailLogEntries with error', async () => {
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+              credentials: {client_email: 'bogus', private_key: 'bogus'},
+              projectId: 'bogus',
+            });
+            client.initialize();
+            const request = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesRequest());
+            const expectedError = new Error('expected');
+            client.innerApiCalls.tailLogEntries = stubBidiStreamingCall(undefined, expectedError);
+            const stream = client.tailLogEntries();
+            const promise = new Promise((resolve, reject) => {
+                stream.on('data', (response: protos.google.logging.v2.TailLogEntriesResponse) => {
+                    resolve(response);
+                });
+                stream.on('error', (err: Error) => {
+                    reject(err);
+                });
+                stream.write(request);
+                stream.end();
+            });
+            await assert.rejects(promise, expectedError);
+            assert((client.innerApiCalls.tailLogEntries as SinonStub)
+                .getCall(0).calledWith(null));
+            assert.deepStrictEqual(((stream as unknown as PassThrough)
+                ._transform as SinonStub).getCall(0).args[0], request);
         });
     });
 
@@ -1016,6 +1082,60 @@ describe('v2.LoggingServiceV2Client', () => {
             });
         });
 
+        describe('billingAccountLocationBucketView', () => {
+            const fakePath = "/rendered/path/billingAccountLocationBucketView";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountLocationBucketViewPath', () => {
+                const result = client.billingAccountLocationBucketViewPath("billingAccountValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBillingAccountFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchLocationFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBucketFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchViewFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('billingAccountLog', () => {
             const fakePath = "/rendered/path/billingAccountLog";
             const expectedParameters = {
@@ -1050,6 +1170,36 @@ describe('v2.LoggingServiceV2Client', () => {
                 const result = client.matchLogFromBillingAccountLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.billingAccountLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('billingAccountSettings', () => {
+            const fakePath = "/rendered/path/billingAccountSettings";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountSettingsPath', () => {
+                const result = client.billingAccountSettingsPath("billingAccountValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountSettingsName', () => {
+                const result = client.matchBillingAccountFromBillingAccountSettingsName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1206,6 +1356,60 @@ describe('v2.LoggingServiceV2Client', () => {
             });
         });
 
+        describe('folderLocationBucketView', () => {
+            const fakePath = "/rendered/path/folderLocationBucketView";
+            const expectedParameters = {
+                folder: "folderValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderLocationBucketViewPath', () => {
+                const result = client.folderLocationBucketViewPath("folderValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderLocationBucketViewName', () => {
+                const result = client.matchFolderFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromFolderLocationBucketViewName', () => {
+                const result = client.matchLocationFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromFolderLocationBucketViewName', () => {
+                const result = client.matchBucketFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromFolderLocationBucketViewName', () => {
+                const result = client.matchViewFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('folderLog', () => {
             const fakePath = "/rendered/path/folderLog";
             const expectedParameters = {
@@ -1240,6 +1444,36 @@ describe('v2.LoggingServiceV2Client', () => {
                 const result = client.matchLogFromFolderLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.folderLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('folderSettings', () => {
+            const fakePath = "/rendered/path/folderSettings";
+            const expectedParameters = {
+                folder: "folderValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderSettingsPath', () => {
+                const result = client.folderSettingsPath("folderValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderSettingsName', () => {
+                const result = client.matchFolderFromFolderSettingsName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1434,6 +1668,60 @@ describe('v2.LoggingServiceV2Client', () => {
             });
         });
 
+        describe('organizationLocationBucketView', () => {
+            const fakePath = "/rendered/path/organizationLocationBucketView";
+            const expectedParameters = {
+                organization: "organizationValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationLocationBucketViewPath', () => {
+                const result = client.organizationLocationBucketViewPath("organizationValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchOrganizationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchLocationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchBucketFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchViewFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('organizationLog', () => {
             const fakePath = "/rendered/path/organizationLog";
             const expectedParameters = {
@@ -1468,6 +1756,36 @@ describe('v2.LoggingServiceV2Client', () => {
                 const result = client.matchLogFromOrganizationLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('organizationSettings', () => {
+            const fakePath = "/rendered/path/organizationSettings";
+            const expectedParameters = {
+                organization: "organizationValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationSettingsPath', () => {
+                const result = client.organizationSettingsPath("organizationValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationSettingsName', () => {
+                const result = client.matchOrganizationFromOrganizationSettingsName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1654,6 +1972,60 @@ describe('v2.LoggingServiceV2Client', () => {
             });
         });
 
+        describe('projectLocationBucketView', () => {
+            const fakePath = "/rendered/path/projectLocationBucketView";
+            const expectedParameters = {
+                project: "projectValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectLocationBucketViewPath', () => {
+                const result = client.projectLocationBucketViewPath("projectValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectLocationBucketViewName', () => {
+                const result = client.matchProjectFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromProjectLocationBucketViewName', () => {
+                const result = client.matchLocationFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromProjectLocationBucketViewName', () => {
+                const result = client.matchBucketFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromProjectLocationBucketViewName', () => {
+                const result = client.matchViewFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('projectLog', () => {
             const fakePath = "/rendered/path/projectLog";
             const expectedParameters = {
@@ -1688,6 +2060,36 @@ describe('v2.LoggingServiceV2Client', () => {
                 const result = client.matchLogFromProjectLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.projectLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('projectSettings', () => {
+            const fakePath = "/rendered/path/projectSettings";
+            const expectedParameters = {
+                project: "projectValue",
+            };
+            const client = new loggingservicev2Module.v2.LoggingServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectSettingsPath', () => {
+                const result = client.projectSettingsPath("projectValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectSettingsName', () => {
+                const result = client.matchProjectFromProjectSettingsName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -909,6 +909,60 @@ describe('v2.MetricsServiceV2Client', () => {
             });
         });
 
+        describe('billingAccountLocationBucketView', () => {
+            const fakePath = "/rendered/path/billingAccountLocationBucketView";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountLocationBucketViewPath', () => {
+                const result = client.billingAccountLocationBucketViewPath("billingAccountValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBillingAccountFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchLocationFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchBucketFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromBillingAccountLocationBucketViewName', () => {
+                const result = client.matchViewFromBillingAccountLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.billingAccountLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('billingAccountLog', () => {
             const fakePath = "/rendered/path/billingAccountLog";
             const expectedParameters = {
@@ -943,6 +997,36 @@ describe('v2.MetricsServiceV2Client', () => {
                 const result = client.matchLogFromBillingAccountLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.billingAccountLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('billingAccountSettings', () => {
+            const fakePath = "/rendered/path/billingAccountSettings";
+            const expectedParameters = {
+                billing_account: "billingAccountValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.billingAccountSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.billingAccountSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('billingAccountSettingsPath', () => {
+                const result = client.billingAccountSettingsPath("billingAccountValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchBillingAccountFromBillingAccountSettingsName', () => {
+                const result = client.matchBillingAccountFromBillingAccountSettingsName(fakePath);
+                assert.strictEqual(result, "billingAccountValue");
+                assert((client.pathTemplates.billingAccountSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1099,6 +1183,60 @@ describe('v2.MetricsServiceV2Client', () => {
             });
         });
 
+        describe('folderLocationBucketView', () => {
+            const fakePath = "/rendered/path/folderLocationBucketView";
+            const expectedParameters = {
+                folder: "folderValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderLocationBucketViewPath', () => {
+                const result = client.folderLocationBucketViewPath("folderValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderLocationBucketViewName', () => {
+                const result = client.matchFolderFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromFolderLocationBucketViewName', () => {
+                const result = client.matchLocationFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromFolderLocationBucketViewName', () => {
+                const result = client.matchBucketFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromFolderLocationBucketViewName', () => {
+                const result = client.matchViewFromFolderLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.folderLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('folderLog', () => {
             const fakePath = "/rendered/path/folderLog";
             const expectedParameters = {
@@ -1133,6 +1271,36 @@ describe('v2.MetricsServiceV2Client', () => {
                 const result = client.matchLogFromFolderLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.folderLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('folderSettings', () => {
+            const fakePath = "/rendered/path/folderSettings";
+            const expectedParameters = {
+                folder: "folderValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.folderSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.folderSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('folderSettingsPath', () => {
+                const result = client.folderSettingsPath("folderValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.folderSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchFolderFromFolderSettingsName', () => {
+                const result = client.matchFolderFromFolderSettingsName(fakePath);
+                assert.strictEqual(result, "folderValue");
+                assert((client.pathTemplates.folderSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1327,6 +1495,60 @@ describe('v2.MetricsServiceV2Client', () => {
             });
         });
 
+        describe('organizationLocationBucketView', () => {
+            const fakePath = "/rendered/path/organizationLocationBucketView";
+            const expectedParameters = {
+                organization: "organizationValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationLocationBucketViewPath', () => {
+                const result = client.organizationLocationBucketViewPath("organizationValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchOrganizationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchLocationFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchBucketFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromOrganizationLocationBucketViewName', () => {
+                const result = client.matchViewFromOrganizationLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.organizationLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('organizationLog', () => {
             const fakePath = "/rendered/path/organizationLog";
             const expectedParameters = {
@@ -1361,6 +1583,36 @@ describe('v2.MetricsServiceV2Client', () => {
                 const result = client.matchLogFromOrganizationLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.organizationLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('organizationSettings', () => {
+            const fakePath = "/rendered/path/organizationSettings";
+            const expectedParameters = {
+                organization: "organizationValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.organizationSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.organizationSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('organizationSettingsPath', () => {
+                const result = client.organizationSettingsPath("organizationValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.organizationSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchOrganizationFromOrganizationSettingsName', () => {
+                const result = client.matchOrganizationFromOrganizationSettingsName(fakePath);
+                assert.strictEqual(result, "organizationValue");
+                assert((client.pathTemplates.organizationSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });
@@ -1547,6 +1799,60 @@ describe('v2.MetricsServiceV2Client', () => {
             });
         });
 
+        describe('projectLocationBucketView', () => {
+            const fakePath = "/rendered/path/projectLocationBucketView";
+            const expectedParameters = {
+                project: "projectValue",
+                location: "locationValue",
+                bucket: "bucketValue",
+                view: "viewValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectLocationBucketViewPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectLocationBucketViewPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectLocationBucketViewPath', () => {
+                const result = client.projectLocationBucketViewPath("projectValue", "locationValue", "bucketValue", "viewValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectLocationBucketViewName', () => {
+                const result = client.matchProjectFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchLocationFromProjectLocationBucketViewName', () => {
+                const result = client.matchLocationFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "locationValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchBucketFromProjectLocationBucketViewName', () => {
+                const result = client.matchBucketFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "bucketValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+
+            it('matchViewFromProjectLocationBucketViewName', () => {
+                const result = client.matchViewFromProjectLocationBucketViewName(fakePath);
+                assert.strictEqual(result, "viewValue");
+                assert((client.pathTemplates.projectLocationBucketViewPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
         describe('projectLog', () => {
             const fakePath = "/rendered/path/projectLog";
             const expectedParameters = {
@@ -1581,6 +1887,36 @@ describe('v2.MetricsServiceV2Client', () => {
                 const result = client.matchLogFromProjectLogName(fakePath);
                 assert.strictEqual(result, "logValue");
                 assert((client.pathTemplates.projectLogPathTemplate.match as SinonStub)
+                    .getCall(-1).calledWith(fakePath));
+            });
+        });
+
+        describe('projectSettings', () => {
+            const fakePath = "/rendered/path/projectSettings";
+            const expectedParameters = {
+                project: "projectValue",
+            };
+            const client = new metricsservicev2Module.v2.MetricsServiceV2Client({
+                credentials: {client_email: 'bogus', private_key: 'bogus'},
+                projectId: 'bogus',
+            });
+            client.initialize();
+            client.pathTemplates.projectSettingsPathTemplate.render =
+                sinon.stub().returns(fakePath);
+            client.pathTemplates.projectSettingsPathTemplate.match =
+                sinon.stub().returns(expectedParameters);
+
+            it('projectSettingsPath', () => {
+                const result = client.projectSettingsPath("projectValue");
+                assert.strictEqual(result, fakePath);
+                assert((client.pathTemplates.projectSettingsPathTemplate.render as SinonStub)
+                    .getCall(-1).calledWith(expectedParameters));
+            });
+
+            it('matchProjectFromProjectSettingsName', () => {
+                const result = client.matchProjectFromProjectSettingsName(fakePath);
+                assert.strictEqual(result, "projectValue");
+                assert((client.pathTemplates.projectSettingsPathTemplate.match as SinonStub)
                     .getCall(-1).calledWith(fakePath));
             });
         });

--- a/baselines/monitoring/package.json
+++ b/baselines/monitoring/package.json
@@ -42,7 +42,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/naming/package.json
+++ b/baselines/naming/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/redis/package.json
+++ b/baselines/redis/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/routingtest/package.json
+++ b/baselines/routingtest/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/showcase-legacy/package.json
+++ b/baselines/showcase-legacy/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/showcase/package.json
+++ b/baselines/showcase/package.json
@@ -40,7 +40,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/tasks/package.json
+++ b/baselines/tasks/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/texttospeech/package.json
+++ b/baselines/texttospeech/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/translate/package.json
+++ b/baselines/translate/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/baselines/videointelligence/package.json
+++ b/baselines/videointelligence/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/templates/typescript_gapic/package.json
+++ b/templates/typescript_gapic/package.json
@@ -37,7 +37,7 @@
     "test": "c8 mocha build/test"
   },
   "dependencies": {
-    "google-gax": "^3.3.0"
+    "google-gax": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -348,7 +348,7 @@ export class {{ service.name }}Client {
 {%- else %}
         '{{- method.bundleConfig.batchDescriptor.subresponse_field }}',
 {%- endif %}
-        this._gaxModule.createByteLengthFunction(
+        this._gaxModule.GrpcClient.createByteLengthFunction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           protoFilesRoot.lookupType('{{ method.bundleConfig.repeatedField }}') as any
         )

--- a/templates/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/typescript_gapic/src/$version/$service_client.ts.njk
@@ -348,7 +348,7 @@ export class {{ service.name }}Client {
 {%- else %}
         '{{- method.bundleConfig.batchDescriptor.subresponse_field }}',
 {%- endif %}
-        gax.createByteLengthFunction(
+        this._gaxModule.createByteLengthFunction(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           protoFilesRoot.lookupType('{{ method.bundleConfig.repeatedField }}') as any
         )

--- a/test-fixtures/protos/google/logging/type/http_request.proto
+++ b/test-fixtures/protos/google/logging/type/http_request.proto
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.logging.type;
+
+import "google/protobuf/duration.proto";
+
+option csharp_namespace = "Google.Cloud.Logging.Type";
+option go_package = "google.golang.org/genproto/googleapis/logging/type;ltype";
+option java_multiple_files = true;
+option java_outer_classname = "HttpRequestProto";
+option java_package = "com.google.logging.type";
+option php_namespace = "Google\\Cloud\\Logging\\Type";
+option ruby_package = "Google::Cloud::Logging::Type";
+
+// A common proto for logging HTTP requests. Only contains semantics
+// defined by the HTTP specification. Product-specific logging
+// information MUST be defined in a separate message.
+message HttpRequest {
+  // The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
+  string request_method = 1;
+
+  // The scheme (http, https), the host name, the path and the query
+  // portion of the URL that was requested.
+  // Example: `"http://example.com/some/info?color=red"`.
+  string request_url = 2;
+
+  // The size of the HTTP request message in bytes, including the request
+  // headers and the request body.
+  int64 request_size = 3;
+
+  // The response code indicating the status of response.
+  // Examples: 200, 404.
+  int32 status = 4;
+
+  // The size of the HTTP response message sent back to the client, in bytes,
+  // including the response headers and the response body.
+  int64 response_size = 5;
+
+  // The user agent sent by the client. Example:
+  // `"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET
+  // CLR 1.0.3705)"`.
+  string user_agent = 6;
+
+  // The IP address (IPv4 or IPv6) of the client that issued the HTTP
+  // request. This field can include port information. Examples:
+  // `"192.168.1.1"`, `"10.0.0.1:80"`, `"FE80::0202:B3FF:FE1E:8329"`.
+  string remote_ip = 7;
+
+  // The IP address (IPv4 or IPv6) of the origin server that the request was
+  // sent to. This field can include port information. Examples:
+  // `"192.168.1.1"`, `"10.0.0.1:80"`, `"FE80::0202:B3FF:FE1E:8329"`.
+  string server_ip = 13;
+
+  // The referer URL of the request, as defined in
+  // [HTTP/1.1 Header Field
+  // Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
+  string referer = 8;
+
+  // The request processing latency on the server, from the time the request was
+  // received until the response was sent.
+  google.protobuf.Duration latency = 14;
+
+  // Whether or not a cache lookup was attempted.
+  bool cache_lookup = 11;
+
+  // Whether or not an entity was served from cache
+  // (with or without validation).
+  bool cache_hit = 9;
+
+  // Whether or not the response was validated with the origin server before
+  // being served from cache. This field is only meaningful if `cache_hit` is
+  // True.
+  bool cache_validated_with_origin_server = 10;
+
+  // The number of HTTP response bytes inserted into cache. Set only when a
+  // cache fill was attempted.
+  int64 cache_fill_bytes = 12;
+
+  // Protocol used for the request. Examples: "HTTP/1.1", "HTTP/2", "websocket"
+  string protocol = 15;
+}

--- a/test-fixtures/protos/google/logging/type/log_severity.proto
+++ b/test-fixtures/protos/google/logging/type/log_severity.proto
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.logging.type;
+
+option csharp_namespace = "Google.Cloud.Logging.Type";
+option go_package = "google.golang.org/genproto/googleapis/logging/type;ltype";
+option java_multiple_files = true;
+option java_outer_classname = "LogSeverityProto";
+option java_package = "com.google.logging.type";
+option objc_class_prefix = "GLOG";
+option php_namespace = "Google\\Cloud\\Logging\\Type";
+option ruby_package = "Google::Cloud::Logging::Type";
+
+// The severity of the event described in a log entry, expressed as one of the
+// standard severity levels listed below.  For your reference, the levels are
+// assigned the listed numeric values. The effect of using numeric values other
+// than those listed is undefined.
+//
+// You can filter for log entries by severity.  For example, the following
+// filter expression will match log entries with severities `INFO`, `NOTICE`,
+// and `WARNING`:
+//
+//     severity > DEBUG AND severity <= WARNING
+//
+// If you are writing log entries, you should map other severity encodings to
+// one of these standard levels. For example, you might map all of Java's FINE,
+// FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
+// original severity level in the log entry payload if you wish.
+enum LogSeverity {
+  // (0) The log entry has no assigned severity level.
+  DEFAULT = 0;
+
+  // (100) Debug or trace information.
+  DEBUG = 100;
+
+  // (200) Routine information, such as ongoing status or performance.
+  INFO = 200;
+
+  // (300) Normal but significant events, such as start up, shut down, or
+  // a configuration change.
+  NOTICE = 300;
+
+  // (400) Warning events might cause problems.
+  WARNING = 400;
+
+  // (500) Error events are likely to cause problems.
+  ERROR = 500;
+
+  // (600) Critical events cause more severe problems or outages.
+  CRITICAL = 600;
+
+  // (700) A person must take an action immediately.
+  ALERT = 700;
+
+  // (800) One or more systems are unusable.
+  EMERGENCY = 800;
+}

--- a/test-fixtures/protos/google/logging/v2/log_entry.proto
+++ b/test-fixtures/protos/google/logging/v2/log_entry.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -25,8 +24,6 @@ import "google/logging/type/log_severity.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/rpc/status.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -35,10 +32,9 @@ option java_multiple_files = true;
 option java_outer_classname = "LogEntryProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // An individual entry in a log.
-//
-//
 message LogEntry {
   option (google.api.resource) = {
     type: "logging.googleapis.com/Log"
@@ -62,12 +58,13 @@ message LogEntry {
   //
   // `[LOG_ID]` must be URL-encoded within `log_name`. Example:
   // `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+  //
   // `[LOG_ID]` must be less than 512 characters long and can only include the
   // following characters: upper and lower case alphanumeric characters,
   // forward-slash, underscore, hyphen, and period.
   //
   // For backward compatibility, if `log_name` begins with a forward-slash, such
-  // as `/projects/...`, then the log entry is ingested as usual but the
+  // as `/projects/...`, then the log entry is ingested as usual, but the
   // forward-slash is removed. Listing the log entry will not show the leading
   // slash and filtering for a log name with a leading slash will never return
   // any results.
@@ -106,11 +103,11 @@ message LogEntry {
   // current time. Timestamps have nanosecond accuracy, but trailing zeros in
   // the fractional seconds might be omitted when the timestamp is displayed.
   //
-  // Incoming log entries should have timestamps that are no more than the [logs
-  // retention period](/logging/quotas) in the past, and no more than 24 hours
-  // in the future. Log entries outside those time boundaries will not be
-  // available when calling `entries.list`, but those log entries can still be
-  // [exported with LogSinks](/logging/docs/api/tasks/exporting-logs).
+  // Incoming log entries must have timestamps that don't exceed the
+  // [logs retention
+  // period](https://cloud.google.com/logging/quotas#logs_retention_periods) in
+  // the past, and that don't exceed 24 hours in the future. Log entries outside
+  // those time boundaries aren't ingested by Logging.
   google.protobuf.Timestamp timestamp = 9 [(google.api.field_behavior) = OPTIONAL];
 
   // Output only. The time the log entry was received by Logging.
@@ -126,7 +123,7 @@ message LogEntry {
   // de-duplication in the export of logs.
   //
   // If the `insert_id` is omitted when writing a log entry, the Logging API
-  //  assigns its own unique identifier in this field.
+  // assigns its own unique identifier in this field.
   //
   // In queries, the `insert_id` is also used to order log entries that have
   // the same `log_name` and `timestamp` values.
@@ -136,8 +133,20 @@ message LogEntry {
   // applicable.
   google.logging.type.HttpRequest http_request = 7 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. A set of user-defined (key, value) data that provides additional
-  // information about the log entry.
+  // Optional. A map of key, value pairs that provides additional information about the
+  // log entry. The labels can be user-defined or system-defined.
+  //
+  // User-defined labels are arbitrary key, value pairs that you can use to
+  // classify logs.
+  //
+  // System-defined labels are defined by GCP services for platform logs.
+  // They have two components - a service namespace component and the
+  // attribute name. For example: `compute.googleapis.com/resource_name`.
+  //
+  // Cloud Logging truncates label keys that exceed 512 B and label
+  // values that exceed 64 KB upon their associated log entry being
+  // written. The truncation is indicated by an ellipsis at the
+  // end of the character string.
   map<string, string> labels = 11 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. Information about an operation associated with the log entry, if
@@ -168,6 +177,10 @@ message LogEntry {
 
   // Optional. Source code location information associated with the log entry, if any.
   LogEntrySourceLocation source_location = 23 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. Information indicating this LogEntry is part of a sequence of multiple log
+  // entries split from a single LogEntry.
+  LogSplit split = 35 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Additional information about a potentially long-running operation with which
@@ -207,4 +220,22 @@ message LogEntrySourceLocation {
   // `qual.if.ied.Class.method` (Java), `dir/package.func` (Go), `function`
   // (Python).
   string function = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Additional information used to correlate multiple log entries. Used when a
+// single LogEntry would exceed the Google Cloud Logging size limit and is
+// split across multiple log entries.
+message LogSplit {
+  // A globally unique identifier for all log entries in a sequence of split log
+  // entries. All log entries with the same |LogSplit.uid| are assumed to be
+  // part of the same sequence of split log entries.
+  string uid = 1;
+
+  // The index of this LogEntry in the sequence of split log entries. Log
+  // entries are given |index| values 0, 1, ..., n-1 for a sequence of n log
+  // entries.
+  int32 index = 2;
+
+  // The total number of log entries that the original LogEntry was split into.
+  int32 total_splits = 3;
 }

--- a/test-fixtures/protos/google/logging/v2/logging.proto
+++ b/test-fixtures/protos/google/logging/v2/logging.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,23 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/monitored_resource.proto";
 import "google/api/resource.proto";
 import "google/logging/v2/log_entry.proto";
-import "google/logging/v2/logging_config.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -36,6 +33,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // Service for ingesting and querying logs.
 service LoggingServiceV2 {
@@ -47,10 +45,10 @@ service LoggingServiceV2 {
       "https://www.googleapis.com/auth/logging.read,"
       "https://www.googleapis.com/auth/logging.write";
 
-  // Deletes all the log entries in a log. The log reappears if it receives new
-  // entries. Log entries written shortly before the delete operation might not
-  // be deleted. Entries received after the delete operation with a timestamp
-  // before the operation will be deleted.
+  // Deletes all the log entries in a log for the _Default Log Bucket. The log
+  // reappears if it receives new entries. Log entries written shortly before
+  // the delete operation might not be deleted. Entries received after the
+  // delete operation with a timestamp before the operation will be deleted.
   rpc DeleteLog(DeleteLogRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v2/{log_name=projects/*/logs/*}"
@@ -87,7 +85,8 @@ service LoggingServiceV2 {
 
   // Lists log entries.  Use this method to retrieve log entries that originated
   // from a project/folder/organization/billing account.  For ways to export log
-  // entries, see [Exporting Logs](/logging/docs/export).
+  // entries, see [Exporting
+  // Logs](https://cloud.google.com/logging/docs/export).
   rpc ListLogEntries(ListLogEntriesRequest) returns (ListLogEntriesResponse) {
     option (google.api.http) = {
       post: "/v2/entries:list"
@@ -123,20 +122,30 @@ service LoggingServiceV2 {
     };
     option (google.api.method_signature) = "parent";
   }
+
+  // Streaming read of log entries as they are ingested. Until the stream is
+  // terminated, it will continue reading logs.
+  rpc TailLogEntries(stream TailLogEntriesRequest) returns (stream TailLogEntriesResponse) {
+    option (google.api.http) = {
+      post: "/v2/entries:tail"
+      body: "*"
+    };
+  }
 }
 
 // The parameters to DeleteLog.
 message DeleteLogRequest {
   // Required. The resource name of the log to delete:
   //
-  //     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-  //     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-  //     "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  // * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+  // * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+  // * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+  // * `folders/[FOLDER_ID]/logs/[LOG_ID]`
   //
   // `[LOG_ID]` must be URL-encoded. For example,
   // `"projects/my-project-id/logs/syslog"`,
-  // `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+  // `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
+  //
   // For more information about log names, see
   // [LogEntry][google.logging.v2.LogEntry].
   string log_name = 1 [
@@ -152,15 +161,15 @@ message WriteLogEntriesRequest {
   // Optional. A default log resource name that is assigned to all log entries
   // in `entries` that do not specify a value for `log_name`:
   //
-  //     "projects/[PROJECT_ID]/logs/[LOG_ID]"
-  //     "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
-  //     "folders/[FOLDER_ID]/logs/[LOG_ID]"
+  // * `projects/[PROJECT_ID]/logs/[LOG_ID]`
+  // * `organizations/[ORGANIZATION_ID]/logs/[LOG_ID]`
+  // * `billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]`
+  // * `folders/[FOLDER_ID]/logs/[LOG_ID]`
   //
   // `[LOG_ID]` must be URL-encoded. For example:
   //
   //     "projects/my-project-id/logs/syslog"
-  //     "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+  //     "organizations/123/logs/cloudaudit.googleapis.com%2Factivity"
   //
   // The permission `logging.logEntries.create` is needed on each project,
   // organization, billing account, or folder that is receiving new log
@@ -203,15 +212,16 @@ message WriteLogEntriesRequest {
   // the entries later in the list. See the `entries.list` method.
   //
   // Log entries with timestamps that are more than the
-  // [logs retention period](/logging/quota-policy) in the past or more than
-  // 24 hours in the future will not be available when calling `entries.list`.
-  // However, those log entries can still be
-  // [exported with LogSinks](/logging/docs/api/tasks/exporting-logs).
+  // [logs retention period](https://cloud.google.com/logging/quotas) in
+  // the past or more than 24 hours in the future will not be available when
+  // calling `entries.list`. However, those log entries can still be [exported
+  // with
+  // LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
   //
   // To improve throughput and to avoid exceeding the
-  // [quota limit](/logging/quota-policy) for calls to `entries.write`,
-  // you should try to include several log entries in this list,
-  // rather than calling this method for each individual log entry.
+  // [quota limit](https://cloud.google.com/logging/quotas) for calls to
+  // `entries.write`, you should try to include several log entries in this
+  // list, rather than calling this method for each individual log entry.
   repeated LogEntry entries = 4 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Whether valid entries should be written even if some other
@@ -228,7 +238,9 @@ message WriteLogEntriesRequest {
 }
 
 // Result returned from WriteLogEntries.
-message WriteLogEntriesResponse {}
+message WriteLogEntriesResponse {
+
+}
 
 // Error details for WriteLogEntries with partial success.
 message WriteLogEntriesPartialErrors {
@@ -246,11 +258,17 @@ message ListLogEntriesRequest {
   // Required. Names of one or more parent resources from which to
   // retrieve log entries:
   //
-  //     "projects/[PROJECT_ID]"
-  //     "organizations/[ORGANIZATION_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]"
-  //     "folders/[FOLDER_ID]"
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
   //
+  // May alternatively be one or more views:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
   //
   // Projects listed in the `project_ids` field are added to this list.
   repeated string resource_names = 8 [
@@ -261,12 +279,12 @@ message ListLogEntriesRequest {
   ];
 
   // Optional. A filter that chooses which log entries to return.  See [Advanced
-  // Logs Queries](/logging/docs/view/advanced-queries).  Only log entries that
-  // match the filter are returned.  An empty filter matches all log entries in
-  // the resources listed in `resource_names`. Referencing a parent resource
-  // that is not listed in `resource_names` will cause the filter to return no
-  // results.
-  // The maximum length of the filter is 20000 characters.
+  // Logs Queries](https://cloud.google.com/logging/docs/view/advanced-queries).
+  // Only log entries that match the filter are returned.  An empty filter
+  // matches all log entries in the resources listed in `resource_names`.
+  // Referencing a parent resource that is not listed in `resource_names` will
+  // cause the filter to return no results. The maximum length of the filter is
+  // 20000 characters.
   string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. How the results should be sorted.  Presently, the only permitted
@@ -277,9 +295,10 @@ message ListLogEntriesRequest {
   // timestamps are returned in order of their `insert_id` values.
   string order_by = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. The maximum number of results to return from this request.
-  // Non-positive values are ignored.  The presence of `next_page_token` in the
-  // response indicates that more results might be available.
+  // Optional. The maximum number of results to return from this request. Default is 50.
+  // If the value is negative or exceeds 1000, the request is rejected. The
+  // presence of `next_page_token` in the response indicates that more results
+  // might be available.
   int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. If present, then retrieve the next batch of results from the
@@ -338,10 +357,10 @@ message ListMonitoredResourceDescriptorsResponse {
 message ListLogsRequest {
   // Required. The resource name that owns the logs:
   //
-  //     "projects/[PROJECT_ID]"
-  //     "organizations/[ORGANIZATION_ID]"
-  //     "billingAccounts/[BILLING_ACCOUNT_ID]"
-  //     "folders/[FOLDER_ID]"
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -359,6 +378,26 @@ message ListLogsRequest {
   // `nextPageToken` from the previous response.  The values of other method
   // parameters should be identical to those in the previous call.
   string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The resource name that owns the logs:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //
+  // To support legacy queries, it could also be:
+  //
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
+  repeated string resource_names = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.resource_reference) = {
+      child_type: "logging.googleapis.com/Log"
+    }
+  ];
 }
 
 // Result returned from ListLogs.
@@ -372,4 +411,77 @@ message ListLogsResponse {
   // `nextPageToken` is included.  To get the next set of results, call this
   // method again using the value of `nextPageToken` as `pageToken`.
   string next_page_token = 2;
+}
+
+// The parameters to `TailLogEntries`.
+message TailLogEntriesRequest {
+  // Required. Name of a parent resource from which to retrieve log entries:
+  //
+  // *  `projects/[PROJECT_ID]`
+  // *  `organizations/[ORGANIZATION_ID]`
+  // *  `billingAccounts/[BILLING_ACCOUNT_ID]`
+  // *  `folders/[FOLDER_ID]`
+  //
+  // May alternatively be one or more views:
+  //
+  //  * `projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  //  * `folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]`
+  repeated string resource_names = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. A filter that chooses which log entries to return.  See [Advanced
+  // Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
+  // Only log entries that match the filter are returned.  An empty filter
+  // matches all log entries in the resources listed in `resource_names`.
+  // Referencing a parent resource that is not in `resource_names` will cause
+  // the filter to return no results. The maximum length of the filter is 20000
+  // characters.
+  string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The amount of time to buffer log entries at the server before
+  // being returned to prevent out of order results due to late arriving log
+  // entries. Valid values are between 0-60000 milliseconds. Defaults to 2000
+  // milliseconds.
+  google.protobuf.Duration buffer_window = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Result returned from `TailLogEntries`.
+message TailLogEntriesResponse {
+  // Information about entries that were omitted from the session.
+  message SuppressionInfo {
+    // An indicator of why entries were omitted.
+    enum Reason {
+      // Unexpected default.
+      REASON_UNSPECIFIED = 0;
+
+      // Indicates suppression occurred due to relevant entries being
+      // received in excess of rate limits. For quotas and limits, see
+      // [Logging API quotas and
+      // limits](https://cloud.google.com/logging/quotas#api-limits).
+      RATE_LIMIT = 1;
+
+      // Indicates suppression occurred due to the client not consuming
+      // responses quickly enough.
+      NOT_CONSUMED = 2;
+    }
+
+    // The reason that entries were omitted from the session.
+    Reason reason = 1;
+
+    // A lower bound on the count of entries omitted due to `reason`.
+    int32 suppressed_count = 2;
+  }
+
+  // A list of log entries. Each response in the stream will order entries with
+  // increasing values of `LogEntry.timestamp`. Ordering is not guaranteed
+  // between separate responses.
+  repeated LogEntry entries = 1;
+
+  // If entries that otherwise would have been included in the session were not
+  // sent back to the client, counts of relevant entries omitted from the
+  // session with the reason that they were not included. There will be at most
+  // one of each reason per response. The counts represent the number of
+  // suppressed entries since the last streamed response.
+  repeated SuppressionInfo suppression_info = 2;
 }

--- a/test-fixtures/protos/google/logging/v2/logging_config.proto
+++ b/test-fixtures/protos/google/logging/v2/logging_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,20 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
+import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -33,6 +32,19 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingConfigProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/OrganizationLocation"
+  pattern: "organizations/{organization}/locations/{location}"
+};
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/FolderLocation"
+  pattern: "folders/{folder}/locations/{location}"
+};
+option (google.api.resource_definition) = {
+  type: "logging.googleapis.com/BillingAccountLocation"
+  pattern: "billingAccounts/{billing_account}/locations/{location}"
+};
 
 // Service for configuring sinks used to route log entries.
 service ConfigServiceV2 {
@@ -43,7 +55,7 @@ service ConfigServiceV2 {
       "https://www.googleapis.com/auth/logging.admin,"
       "https://www.googleapis.com/auth/logging.read";
 
-  // Lists buckets (Beta).
+  // Lists log buckets.
   rpc ListBuckets(ListBucketsRequest) returns (ListBucketsResponse) {
     option (google.api.http) = {
       get: "/v2/{parent=*/*/locations/*}/buckets"
@@ -63,7 +75,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent";
   }
 
-  // Gets a bucket (Beta).
+  // Gets a log bucket.
   rpc GetBucket(GetBucketRequest) returns (LogBucket) {
     option (google.api.http) = {
       get: "/v2/{name=*/*/locations/*/buckets/*}"
@@ -82,17 +94,41 @@ service ConfigServiceV2 {
     };
   }
 
-  // Updates a bucket. This method replaces the following fields in the
+  // Creates a log bucket that can be used to store log entries. After a bucket
+  // has been created, the bucket's location cannot be changed.
+  rpc CreateBucket(CreateBucketRequest) returns (LogBucket) {
+    option (google.api.http) = {
+      post: "/v2/{parent=*/*/locations/*}/buckets"
+      body: "bucket"
+      additional_bindings {
+        post: "/v2/{parent=projects/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=organizations/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=folders/*/locations/*}/buckets"
+        body: "bucket"
+      }
+      additional_bindings {
+        post: "/v2/{parent=billingAccounts/*/locations/*}/buckets"
+        body: "bucket"
+      }
+    };
+  }
+
+  // Updates a log bucket. This method replaces the following fields in the
   // existing bucket with values from the new bucket: `retention_period`
   //
   // If the retention period is decreased and the bucket is locked,
-  // FAILED_PRECONDITION will be returned.
+  // `FAILED_PRECONDITION` will be returned.
   //
-  // If the bucket has a LifecycleState of DELETE_REQUESTED, FAILED_PRECONDITION
-  // will be returned.
+  // If the bucket has a `lifecycle_state` of `DELETE_REQUESTED`, then
+  // `FAILED_PRECONDITION` will be returned.
   //
-  // A buckets region may not be modified after it is created.
-  // This method is in Beta.
+  // After a bucket has been created, the bucket's location cannot be changed.
   rpc UpdateBucket(UpdateBucketRequest) returns (LogBucket) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*/locations/*/buckets/*}"
@@ -112,6 +148,168 @@ service ConfigServiceV2 {
       additional_bindings {
         patch: "/v2/{name=billingAccounts/*/locations/*/buckets/*}"
         body: "bucket"
+      }
+    };
+  }
+
+  // Deletes a log bucket.
+  //
+  // Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
+  // After 7 days, the bucket will be purged and all log entries in the bucket
+  // will be permanently deleted.
+  rpc DeleteBucket(DeleteBucketRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v2/{name=*/*/locations/*/buckets/*}"
+      additional_bindings {
+        delete: "/v2/{name=projects/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=organizations/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=folders/*/locations/*/buckets/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=billingAccounts/*/locations/*/buckets/*}"
+      }
+    };
+  }
+
+  // Undeletes a log bucket. A bucket that has been deleted can be undeleted
+  // within the grace period of 7 days.
+  rpc UndeleteBucket(UndeleteBucketRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v2/{name=*/*/locations/*/buckets/*}:undelete"
+      body: "*"
+      additional_bindings {
+        post: "/v2/{name=projects/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=organizations/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=folders/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v2/{name=billingAccounts/*/locations/*/buckets/*}:undelete"
+        body: "*"
+      }
+    };
+  }
+
+  // Lists views on a log bucket.
+  rpc ListViews(ListViewsRequest) returns (ListViewsResponse) {
+    option (google.api.http) = {
+      get: "/v2/{parent=*/*/locations/*/buckets/*}/views"
+      additional_bindings {
+        get: "/v2/{parent=projects/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=organizations/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=folders/*/locations/*/buckets/*}/views"
+      }
+      additional_bindings {
+        get: "/v2/{parent=billingAccounts/*/locations/*/buckets/*}/views"
+      }
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Gets a view on a log bucket..
+  rpc GetView(GetViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      get: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      additional_bindings {
+        get: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*/buckets/*/views/*}"
+      }
+    };
+  }
+
+  // Creates a view over log entries in a log bucket. A bucket may contain a
+  // maximum of 30 views.
+  rpc CreateView(CreateViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      post: "/v2/{parent=*/*/locations/*/buckets/*}/views"
+      body: "view"
+      additional_bindings {
+        post: "/v2/{parent=projects/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=organizations/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=folders/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+      additional_bindings {
+        post: "/v2/{parent=billingAccounts/*/locations/*/buckets/*}/views"
+        body: "view"
+      }
+    };
+  }
+
+  // Updates a view on a log bucket. This method replaces the following fields
+  // in the existing view with values from the new view: `filter`.
+  // If an `UNAVAILABLE` error is returned, this indicates that system is not in
+  // a state where it can update the view. If this occurs, please try again in a
+  // few minutes.
+  rpc UpdateView(UpdateViewRequest) returns (LogView) {
+    option (google.api.http) = {
+      patch: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      body: "view"
+      additional_bindings {
+        patch: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+      additional_bindings {
+        patch: "/v2/{name=billingAccounts/*/locations/*/buckets/*/views/*}"
+        body: "view"
+      }
+    };
+  }
+
+  // Deletes a view on a log bucket.
+  // If an `UNAVAILABLE` error is returned, this indicates that system is not in
+  // a state where it can delete the view. If this occurs, please try again in a
+  // few minutes.
+  rpc DeleteView(DeleteViewRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v2/{name=*/*/locations/*/buckets/*/views/*}"
+      additional_bindings {
+        delete: "/v2/{name=projects/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=organizations/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=folders/*/locations/*/buckets/*/views/*}"
+      }
+      additional_bindings {
+        delete: "/v2/{name=billingAccounts/*/locations/*/buckets/*/views/*}"
       }
     };
   }
@@ -251,7 +449,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "sink_name";
   }
 
-  // Lists all the exclusions in a parent resource.
+  // Lists all the exclusions on the _Default sink in a parent resource.
   rpc ListExclusions(ListExclusionsRequest) returns (ListExclusionsResponse) {
     option (google.api.http) = {
       get: "/v2/{parent=*/*}/exclusions"
@@ -271,7 +469,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent";
   }
 
-  // Gets the description of an exclusion.
+  // Gets the description of an exclusion in the _Default sink.
   rpc GetExclusion(GetExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       get: "/v2/{name=*/*/exclusions/*}"
@@ -291,9 +489,9 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name";
   }
 
-  // Creates a new exclusion in a specified parent resource.
-  // Only log entries belonging to that resource can be excluded.
-  // You can have up to 10 exclusions in a resource.
+  // Creates a new exclusion in the _Default sink in a specified parent
+  // resource. Only log entries belonging to that resource can be excluded. You
+  // can have up to 10 exclusions in a resource.
   rpc CreateExclusion(CreateExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       post: "/v2/{parent=*/*}/exclusions"
@@ -318,7 +516,8 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "parent,exclusion";
   }
 
-  // Changes one or more properties of an existing exclusion.
+  // Changes one or more properties of an existing exclusion in the _Default
+  // sink.
   rpc UpdateExclusion(UpdateExclusionRequest) returns (LogExclusion) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*/exclusions/*}"
@@ -343,7 +542,7 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name,exclusion,update_mask";
   }
 
-  // Deletes an exclusion.
+  // Deletes an exclusion in the _Default sink.
   rpc DeleteExclusion(DeleteExclusionRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v2/{name=*/*/exclusions/*}"
@@ -363,28 +562,39 @@ service ConfigServiceV2 {
     option (google.api.method_signature) = "name";
   }
 
-  // Gets the Logs Router CMEK settings for the given resource.
+  // Gets the Logging CMEK settings for the given resource.
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  // Note: CMEK for the Log Router can be configured for Google Cloud projects,
+  // folders, organizations and billing accounts. Once configured for an
+  // organization, it applies to all projects and folders in the Google Cloud
+  // organization.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   rpc GetCmekSettings(GetCmekSettingsRequest) returns (CmekSettings) {
     option (google.api.http) = {
       get: "/v2/{name=*/*}/cmekSettings"
       additional_bindings {
+        get: "/v2/{name=projects/*}/cmekSettings"
+      }
+      additional_bindings {
         get: "/v2/{name=organizations/*}/cmekSettings"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*}/cmekSettings"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*}/cmekSettings"
       }
     };
   }
 
-  // Updates the Logs Router CMEK settings for the given resource.
+  // Updates the Log Router CMEK settings for the given resource.
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  // Note: CMEK for the Log Router can currently only be configured for Google
+  // Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
   //
   // [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings]
   // will fail if 1) `kms_key_name` is invalid, or 2) the associated service
@@ -392,8 +602,9 @@ service ConfigServiceV2 {
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
   // 3) access to the key is disabled.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   rpc UpdateCmekSettings(UpdateCmekSettingsRequest) returns (CmekSettings) {
     option (google.api.http) = {
       patch: "/v2/{name=*/*}/cmekSettings"
@@ -404,9 +615,82 @@ service ConfigServiceV2 {
       }
     };
   }
+
+  // Gets the Log Router settings for the given resource.
+  //
+  // Note: Settings for the Log Router can be get for Google Cloud projects,
+  // folders, organizations and billing accounts. Currently it can only be
+  // configured for organizations. Once configured for an organization, it
+  // applies to all projects and folders in the Google Cloud organization.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  rpc GetSettings(GetSettingsRequest) returns (Settings) {
+    option (google.api.http) = {
+      get: "/v2/{name=*/*}/settings"
+      additional_bindings {
+        get: "/v2/{name=projects/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=organizations/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=folders/*}/settings"
+      }
+      additional_bindings {
+        get: "/v2/{name=billingAccounts/*}/settings"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Updates the Log Router settings for the given resource.
+  //
+  // Note: Settings for the Log Router can currently only be configured for
+  // Google Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
+  //
+  // [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings]
+  // will fail if 1) `kms_key_name` is invalid, or 2) the associated service
+  // account does not have the required
+  // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
+  // 3) access to the key is disabled. 4) `location_id` is not supported by
+  // Logging. 5) `location_id` violate OrgPolicy.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  rpc UpdateSettings(UpdateSettingsRequest) returns (Settings) {
+    option (google.api.http) = {
+      patch: "/v2/{name=*/*}/settings"
+      body: "settings"
+      additional_bindings {
+        patch: "/v2/{name=organizations/*}/settings"
+        body: "settings"
+      }
+      additional_bindings {
+        patch: "/v2/{name=folders/*}/settings"
+        body: "settings"
+      }
+    };
+    option (google.api.method_signature) = "settings,update_mask";
+  }
+
+  // Copies a set of log entries from a log bucket to a Cloud Storage bucket.
+  rpc CopyLogEntries(CopyLogEntriesRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v2/entries:copy"
+      body: "*"
+    };
+    option (google.longrunning.operation_info) = {
+      response_type: "CopyLogEntriesResponse"
+      metadata_type: "CopyLogEntriesMetadata"
+    };
+  }
 }
 
-// Describes a repository of logs (Beta).
+// Describes a repository in which log entries are stored.
 message LogBucket {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogBucket"
@@ -416,17 +700,20 @@ message LogBucket {
     pattern: "billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}"
   };
 
-  // The resource name of the bucket.
-  // For example:
-  // "projects/my-project-id/locations/my-location/buckets/my-bucket-id The
-  // supported locations are:
-  //   "global"
-  //   "us-central1"
+  // Output only. The resource name of the bucket.
   //
-  // For the location of `global` it is unspecified where logs are actually
-  // stored.
-  // Once a bucket has been created, the location can not be changed.
-  string name = 1;
+  // For example:
+  //
+  //   `projects/my-project/locations/global/buckets/my-bucket`
+  //
+  // For a list of supported locations, see [Supported
+  // Regions](https://cloud.google.com/logging/docs/region-support)
+  //
+  // For the location of `global` it is unspecified where log entries are
+  // actually stored.
+  //
+  // After a bucket has been created, the location cannot be changed.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Describes this bucket.
   string description = 3;
@@ -439,20 +726,85 @@ message LogBucket {
   google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Logs will be retained by default for this amount of time, after which they
-  // will automatically be deleted. The minimum retention period is 1 day.
-  // If this value is set to zero at bucket creation time, the default time of
-  // 30 days will be used.
+  // will automatically be deleted. The minimum retention period is 1 day. If
+  // this value is set to zero at bucket creation time, the default time of 30
+  // days will be used.
   int32 retention_days = 11;
+
+  // Whether the bucket is locked.
+  //
+  // The retention period on a locked bucket cannot be changed. Locked buckets
+  // may only be deleted if they are empty.
+  bool locked = 9;
 
   // Output only. The bucket lifecycle state.
   LifecycleState lifecycle_state = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Log entry field paths that are denied access in this bucket.
+  //
+  // The following fields and their children are eligible: `textPayload`,
+  // `jsonPayload`, `protoPayload`, `httpRequest`, `labels`, `sourceLocation`.
+  //
+  // Restricting a repeated field will restrict all values. Adding a parent will
+  // block all child fields. (e.g. `foo.bar` will block `foo.bar.baz`)
+  repeated string restricted_fields = 15;
+
+  // The CMEK settings of the log bucket. If present, new log entries written to
+  // this log bucket are encrypted using the CMEK key provided in this
+  // configuration. If a log bucket has CMEK settings, the CMEK settings cannot
+  // be disabled later by updating the log bucket. Changing the KMS key is
+  // allowed.
+  CmekSettings cmek_settings = 19;
+}
+
+// Describes a view over log entries in a bucket.
+message LogView {
+  option (google.api.resource) = {
+    type: "logging.googleapis.com/LogView"
+    pattern: "projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}"
+    pattern: "billingAccounts/{billing_account}/locations/{location}/buckets/{bucket}/views/{view}"
+  };
+
+  // The resource name of the view.
+  //
+  // For example:
+  //
+  //   `projects/my-project/locations/global/buckets/my-bucket/views/my-view`
+  string name = 1;
+
+  // Describes this view.
+  string description = 3;
+
+  // Output only. The creation timestamp of the view.
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The last update timestamp of the view.
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Filter that restricts which log entries in a bucket are visible in this
+  // view.
+  //
+  // Filters are restricted to be a logical AND of ==/!= of any of the
+  // following:
+  //
+  //   - originating project/folder/organization/billing account.
+  //   - resource type
+  //   - log id
+  //
+  // For example:
+  //
+  //   SOURCE("projects/myproject") AND resource.type = "gce_instance"
+  //                                AND LOG_ID("stdout")
+  string filter = 7;
 }
 
 // Describes a sink used to export log entries to one of the following
-// destinations in any project: a Cloud Storage bucket, a BigQuery dataset, or a
-// Cloud Pub/Sub topic. A logs filter controls which log entries are exported.
-// The sink must be created within a project, organization, billing account, or
-// folder.
+// destinations in any project: a Cloud Storage bucket, a BigQuery dataset, a
+// Pub/Sub topic or a Cloud Logging log bucket. A logs filter controls which log
+// entries are exported. The sink must be created within a project,
+// organization, billing account, or folder.
 message LogSink {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogSink"
@@ -462,9 +814,7 @@ message LogSink {
     pattern: "billingAccounts/{billing_account}/sinks/{sink}"
   };
 
-  // Available log entry formats. Log entries can be written to
-  // Logging in either format and can be exported in either format.
-  // Version 2 is the preferred format.
+  // Deprecated. This is unused.
   enum VersionFormat {
     // An unspecified format version that will default to V2.
     VERSION_FORMAT_UNSPECIFIED = 0;
@@ -476,9 +826,10 @@ message LogSink {
     V1 = 2;
   }
 
-  // Required. The client-assigned sink identifier, unique within the project. Example:
-  // `"my-syslog-errors-to-pubsub"`. Sink identifiers are limited to 100
-  // characters and can include only the following characters: upper and
+  // Required. The client-assigned sink identifier, unique within the project.
+  //
+  // For example: `"my-syslog-errors-to-pubsub"`. Sink identifiers are limited
+  // to 100 characters and can include only the following characters: upper and
   // lower-case alphanumeric characters, underscores, hyphens, and periods.
   // First character has to be alphanumeric.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
@@ -489,10 +840,11 @@ message LogSink {
   //     "bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]"
   //     "pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]"
   //
-  // The sink's `writer_identity`, set when the sink is created, must
-  // have permission to write to the destination or else the log
-  // entries are not exported. For more information, see
-  // [Exporting Logs with Sinks](/logging/docs/api/tasks/exporting-logs).
+  // The sink's `writer_identity`, set when the sink is created, must have
+  // permission to write to the destination or else the log entries are not
+  // exported. For more information, see
+  // [Exporting Logs with
+  // Sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
   string destination = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -500,52 +852,70 @@ message LogSink {
     }
   ];
 
-  // Optional. An [advanced logs filter](/logging/docs/view/advanced-queries). The only
-  // exported log entries are those that are in the resource owning the sink and
-  // that match the filter. For example:
+  // Optional. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced-queries). The
+  // only exported log entries are those that are in the resource owning the
+  // sink and that match the filter.
   //
-  //     logName="projects/[PROJECT_ID]/logs/[LOG_ID]" AND severity>=ERROR
+  // For example:
+  //
+  //   `logName="projects/[PROJECT_ID]/logs/[LOG_ID]" AND severity>=ERROR`
   string filter = 5 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. A description of this sink.
+  //
   // The maximum length of the description is 8000 characters.
   string description = 18 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. If set to True, then this sink is disabled and it does not
-  // export any log entries.
+  // Optional. If set to true, then this sink is disabled and it does not export any log
+  // entries.
   bool disabled = 19 [(google.api.field_behavior) = OPTIONAL];
 
-  // Deprecated. The log entry format to use for this sink's exported log
-  // entries. The v2 format is used by default and cannot be changed.
+  // Optional. Log entries that match any of these exclusion filters will not be exported.
+  //
+  // If a log entry is matched by both `filter` and one of `exclusion_filters`
+  // it will not be exported.
+  repeated LogExclusion exclusions = 16 [(google.api.field_behavior) = OPTIONAL];
+
+  // Deprecated. This field is unused.
   VersionFormat output_version_format = 6 [deprecated = true];
 
-  // Output only. An IAM identity–a service account or group&mdash;under which Logging
-  // writes the exported log entries to the sink's destination. This field is
-  // set by [sinks.create][google.logging.v2.ConfigServiceV2.CreateSink] and
+  // Output only. An IAM identity&mdash;a service account or group&mdash;under which Cloud
+  // Logging writes the exported log entries to the sink's destination. This
+  // field is set by
+  // [sinks.create][google.logging.v2.ConfigServiceV2.CreateSink] and
   // [sinks.update][google.logging.v2.ConfigServiceV2.UpdateSink] based on the
   // value of `unique_writer_identity` in those methods.
   //
   // Until you grant this identity write-access to the destination, log entry
-  // exports from this sink will fail. For more information,
-  // see [Granting Access for a
-  // Resource](/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource).
+  // exports from this sink will fail. For more information, see [Granting
+  // Access for a
+  // Resource](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource).
   // Consult the destination service's documentation to determine the
   // appropriate IAM roles to assign to the identity.
+  //
+  // Sinks that have a destination that is a log bucket in the same project as
+  // the sink do not have a writer_identity and no additional permissions are
+  // required.
   string writer_identity = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Optional. This field applies only to sinks owned by organizations and
-  // folders. If the field is false, the default, only the logs owned by the
-  // sink's parent resource are available for export. If the field is true, then
-  // logs from all the projects, folders, and billing accounts contained in the
+  // Optional. This field applies only to sinks owned by organizations and folders. If the
+  // field is false, the default, only the logs owned by the sink's parent
+  // resource are available for export. If the field is true, then log entries
+  // from all the projects, folders, and billing accounts contained in the
   // sink's parent resource are also available for export. Whether a particular
   // log entry from the children is exported depends on the sink's filter
-  // expression. For example, if this field is true, then the filter
-  // `resource.type=gce_instance` would export all Compute Engine VM instance
-  // log entries from all projects in the sink's parent. To only export entries
-  // from certain child projects, filter on the project part of the log name:
+  // expression.
   //
-  //     logName:("projects/test-project1/" OR "projects/test-project2/") AND
-  //     resource.type=gce_instance
+  // For example, if this field is true, then the filter
+  // `resource.type=gce_instance` would export all Compute Engine VM instance
+  // log entries from all projects in the sink's parent.
+  //
+  // To only export entries from certain child projects, filter on the project
+  // part of the log name:
+  //
+  //   logName:("projects/test-project1/" OR "projects/test-project2/") AND
+  //   resource.type=gce_instance
   bool include_children = 9 [(google.api.field_behavior) = OPTIONAL];
 
   // Destination dependent options.
@@ -568,16 +938,18 @@ message LogSink {
 // Options that change functionality of a sink exporting data to BigQuery.
 message BigQueryOptions {
   // Optional. Whether to use [BigQuery's partition
-  // tables](/bigquery/docs/partitioned-tables). By default, Logging
-  // creates dated tables based on the log entries' timestamps, e.g.
-  // syslog_20170523. With partitioned tables the date suffix is no longer
-  // present and [special query
-  // syntax](/bigquery/docs/querying-partitioned-tables) has to be used instead.
-  // In both cases, tables are sharded based on UTC timezone.
+  // tables](https://cloud.google.com/bigquery/docs/partitioned-tables). By
+  // default, Cloud Logging creates dated tables based on the log entries'
+  // timestamps, e.g. syslog_20170523. With partitioned tables the date suffix
+  // is no longer present and [special query
+  // syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+  // has to be used instead. In both cases, tables are sharded based on UTC
+  // timezone.
   bool use_partitioned_tables = 1 [(google.api.field_behavior) = OPTIONAL];
 
-  // Output only. True if new timestamp column based partitioning is in use,
-  // false if legacy ingestion-time partitioning is in use.
+  // Output only. True if new timestamp column based partitioning is in use, false if legacy
+  // ingestion-time partitioning is in use.
+  //
   // All new sinks will have this field set true and will use timestamp column
   // based partitioning. If use_partitioned_tables is false, this value has no
   // meaning and will be false. Legacy sinks using partitioned tables will have
@@ -585,20 +957,7 @@ message BigQueryOptions {
   bool uses_timestamp_column_partitioning = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// LogBucket lifecycle states (Beta).
-enum LifecycleState {
-  // Unspecified state.  This is only used/useful for distinguishing
-  // unset values.
-  LIFECYCLE_STATE_UNSPECIFIED = 0;
-
-  // The normal and active state.
-  ACTIVE = 1;
-
-  // The bucket has been marked for deletion by the user.
-  DELETE_REQUESTED = 2;
-}
-
-// The parameters to `ListBuckets` (Beta).
+// The parameters to `ListBuckets`.
 message ListBucketsRequest {
   // Required. The parent resource whose buckets are to be listed:
   //
@@ -614,21 +973,22 @@ message ListBucketsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       child_type: "logging.googleapis.com/LogBucket"
-    }];
+    }
+  ];
 
-  // Optional. If present, then retrieve the next batch of results from the
-  // preceding call to this method. `pageToken` must be the value of
-  // `nextPageToken` from the previous response. The values of other method
-  // parameters should be identical to those in the previous call.
+  // Optional. If present, then retrieve the next batch of results from the preceding call
+  // to this method. `pageToken` must be the value of `nextPageToken` from the
+  // previous response. The values of other method parameters should be
+  // identical to those in the previous call.
   string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Optional. The maximum number of results to return from this request.
-  // Non-positive values are ignored. The presence of `nextPageToken` in the
-  // response indicates that more results might be available.
+  // Optional. The maximum number of results to return from this request. Non-positive
+  // values are ignored. The presence of `nextPageToken` in the response
+  // indicates that more results might be available.
   int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// The response from ListBuckets (Beta).
+// The response from ListBuckets.
 message ListBucketsResponse {
   // A list of buckets.
   repeated LogBucket buckets = 1;
@@ -639,7 +999,34 @@ message ListBucketsResponse {
   string next_page_token = 2;
 }
 
-// The parameters to `UpdateBucket` (Beta).
+// The parameters to `CreateBucket`.
+message CreateBucketRequest {
+  // Required. The resource in which to create the log bucket:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global"`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+
+  // Required. A client-assigned identifier such as `"my-bucket"`. Identifiers are limited
+  // to 100 characters and can include only letters, digits, underscores,
+  // hyphens, and periods.
+  string bucket_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The new bucket. The region specified in the new bucket must be compliant
+  // with any Location Restriction Org Policy. The name field in the bucket is
+  // ignored.
+  LogBucket bucket = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The parameters to `UpdateBucket`.
 message UpdateBucketRequest {
   // Required. The full resource name of the bucket to update.
   //
@@ -648,10 +1035,9 @@ message UpdateBucketRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //
-  // Example:
-  // `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`. Also
-  // requires permission "resourcemanager.projects.updateLiens" to set the
-  // locked property
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -663,17 +1049,17 @@ message UpdateBucketRequest {
   LogBucket bucket = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Required. Field mask that specifies the fields in `bucket` that need an update. A
-  // bucket field will be overwritten if, and only if, it is in the update
-  // mask. `name` and output only fields cannot be updated.
+  // bucket field will be overwritten if, and only if, it is in the update mask.
+  // `name` and output only fields cannot be updated.
   //
-  // For a detailed `FieldMask` definition, see
+  // For a detailed `FieldMask` definition, see:
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
   //
-  // Example: `updateMask=retention_days`.
+  // For example: `updateMask=retention_days`
   google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// The parameters to `GetBucket` (Beta).
+// The parameters to `GetBucket`.
 message GetBucketRequest {
   // Required. The resource name of the bucket:
   //
@@ -682,12 +1068,161 @@ message GetBucketRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
   //
-  // Example:
-  // `"projects/my-project-id/locations/my-location/buckets/my-bucket-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `DeleteBucket`.
+message DeleteBucketRequest {
+  // Required. The full resource name of the bucket to delete.
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `UndeleteBucket`.
+message UndeleteBucketRequest {
+  // Required. The full resource name of the bucket to undelete.
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "organizations/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //     "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogBucket"
+    }
+  ];
+}
+
+// The parameters to `ListViews`.
+message ListViewsRequest {
+  // Required. The bucket whose views are to be listed:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. If present, then retrieve the next batch of results from the preceding call
+  // to this method. `pageToken` must be the value of `nextPageToken` from the
+  // previous response. The values of other method parameters should be
+  // identical to those in the previous call.
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. The maximum number of results to return from this request.
+  //
+  // Non-positive values are ignored. The presence of `nextPageToken` in the
+  // response indicates that more results might be available.
+  int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The response from ListViews.
+message ListViewsResponse {
+  // A list of views.
+  repeated LogView views = 1;
+
+  // If there might be more results than appear in this response, then
+  // `nextPageToken` is included. To get the next set of results, call the same
+  // method again using the value of `nextPageToken` as `pageToken`.
+  string next_page_token = 2;
+}
+
+// The parameters to `CreateView`.
+message CreateViewRequest {
+  // Required. The bucket in which to create the view
+  //
+  //     `"projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]"`
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket"`
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The id to use for this view.
+  string view_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The new view.
+  LogView view = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The parameters to `UpdateView`.
+message UpdateViewRequest {
+  // Required. The full resource name of the view to update
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The updated view.
+  LogView view = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Field mask that specifies the fields in `view` that need
+  // an update. A field will be overwritten if, and only if, it is
+  // in the update mask. `name` and output only fields cannot be updated.
+  //
+  // For a detailed `FieldMask` definition, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
+  //
+  // For example: `updateMask=filter`
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The parameters to `GetView`.
+message GetViewRequest {
+  // Required. The resource name of the policy:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogView"
+    }
+  ];
+}
+
+// The parameters to `DeleteView`.
+message DeleteViewRequest {
+  // Required. The full resource name of the view to delete:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
+  //
+  // For example:
+  //
+  //    `"projects/my-project/locations/global/buckets/my-bucket/views/my-view"`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/LogView"
     }
   ];
 }
@@ -739,7 +1274,9 @@ message GetSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -757,7 +1294,10 @@ message CreateSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]"
   //     "folders/[FOLDER_ID]"
   //
-  // Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+  // For examples:
+  //
+  //   `"projects/my-project"`
+  //   `"organizations/123456789"`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -772,9 +1312,9 @@ message CreateSinkRequest {
   // Optional. Determines the kind of IAM identity returned as `writer_identity`
   // in the new sink. If this value is omitted or set to false, and if the
   // sink's parent is a project, then the value returned as `writer_identity` is
-  // the same group or service account used by Logging before the addition of
-  // writer identities to this API. The sink's destination must be in the same
-  // project as the sink itself.
+  // the same group or service account used by Cloud Logging before the addition
+  // of writer identities to this API. The sink's destination must be in the
+  // same project as the sink itself.
   //
   // If this field is set to true, or if the sink is owned by a non-project
   // resource such as an organization, then the value of `writer_identity` will
@@ -793,7 +1333,9 @@ message UpdateSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -822,16 +1364,18 @@ message UpdateSinkRequest {
   // an update. A sink field will be overwritten if, and only if, it is
   // in the update mask. `name` and output only fields cannot be updated.
   //
-  // An empty updateMask is temporarily treated as using the following mask
+  // An empty `updateMask` is temporarily treated as using the following mask
   // for backwards compatibility purposes:
-  //   destination,filter,includeChildren
+  //
+  //   `destination,filter,includeChildren`
+  //
   // At some point in the future, behavior will be removed and specifying an
-  // empty updateMask will be an error.
+  // empty `updateMask` will be an error.
   //
   // For a detailed `FieldMask` definition, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
   //
-  // Example: `updateMask=filter`.
+  // For example: `updateMask=filter`
   google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -845,7 +1389,9 @@ message DeleteSinkRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
   //     "folders/[FOLDER_ID]/sinks/[SINK_ID]"
   //
-  // Example: `"projects/my-project-id/sinks/my-sink-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/sinks/my-sink"`
   string sink_name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -854,12 +1400,11 @@ message DeleteSinkRequest {
   ];
 }
 
-// Specifies a set of log entries that are not to be stored in
-// Logging. If your GCP resource receives a large volume of logs, you can
-// use exclusions to reduce your chargeable logs. Exclusions are
-// processed after log sinks, so you can export log entries before they are
-// excluded. Note that organization-level and folder-level exclusions don't
-// apply to child resources, and that you can't exclude audit log entries.
+// Specifies a set of log entries that are filtered out by a sink. If
+// your Google Cloud resource receives a large volume of log entries, you can
+// use exclusions to reduce your chargeable logs. Note that exclusions on
+// organization-level and folder-level sinks don't apply to child resources.
+// Note also that you cannot modify the _Required sink or exclude logs from it.
 message LogExclusion {
   option (google.api.resource) = {
     type: "logging.googleapis.com/LogExclusion"
@@ -878,14 +1423,16 @@ message LogExclusion {
   // Optional. A description of this exclusion.
   string description = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Required. An [advanced logs filter](/logging/docs/view/advanced-queries)
-  // that matches the log entries to be excluded. By using the
-  // [sample function](/logging/docs/view/advanced-queries#sample),
+  // Required. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced-queries) that
+  // matches the log entries to be excluded. By using the [sample
+  // function](https://cloud.google.com/logging/docs/view/advanced-queries#sample),
   // you can exclude less than 100% of the matching log entries.
-  // For example, the following query matches 99% of low-severity log
-  // entries from Google Cloud Storage buckets:
   //
-  // `"resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)"`
+  // For example, the following query matches 99% of low-severity log entries
+  // from Google Cloud Storage buckets:
+  //
+  //   `resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)`
   string filter = 3 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. If set to True, then this exclusion is disabled and it does not
@@ -952,7 +1499,9 @@ message GetExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -970,7 +1519,10 @@ message CreateExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]"
   //     "folders/[FOLDER_ID]"
   //
-  // Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
+  // For examples:
+  //
+  //   `"projects/my-logging-project"`
+  //   `"organizations/123456789"`
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -992,7 +1544,9 @@ message UpdateExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1023,7 +1577,9 @@ message DeleteExclusionRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
   //     "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
   //
-  // Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
+  // For example:
+  //
+  //   `"projects/my-project/exclusions/my-exclusion"`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1035,8 +1591,9 @@ message DeleteExclusionRequest {
 // The parameters to
 // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings].
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message GetCmekSettingsRequest {
   // Required. The resource for which to retrieve CMEK settings.
   //
@@ -1045,11 +1602,14 @@ message GetCmekSettingsRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
   //     "folders/[FOLDER_ID]/cmekSettings"
   //
-  // Example: `"organizations/12345/cmekSettings"`.
+  // For example:
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  //   `"organizations/12345/cmekSettings"`
+  //
+  // Note: CMEK for the Log Router can be configured for Google Cloud projects,
+  // folders, organizations and billing accounts. Once configured for an
+  // organization, it applies to all projects and folders in the Google Cloud
+  // organization.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -1061,8 +1621,9 @@ message GetCmekSettingsRequest {
 // The parameters to
 // [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings].
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message UpdateCmekSettingsRequest {
   // Required. The resource name for the CMEK settings to update.
   //
@@ -1071,17 +1632,20 @@ message UpdateCmekSettingsRequest {
   //     "billingAccounts/[BILLING_ACCOUNT_ID]/cmekSettings"
   //     "folders/[FOLDER_ID]/cmekSettings"
   //
-  // Example: `"organizations/12345/cmekSettings"`.
+  // For example:
   //
-  // Note: CMEK for the Logs Router can currently only be configured for GCP
-  // organizations. Once configured, it applies to all projects and folders in
-  // the GCP organization.
+  //   `"organizations/12345/cmekSettings"`
+  //
+  // Note: CMEK for the Log Router can currently only be configured for Google
+  // Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The CMEK settings to update.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
   CmekSettings cmek_settings = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. Field mask identifying which fields from `cmek_settings` should
@@ -1090,19 +1654,20 @@ message UpdateCmekSettingsRequest {
   //
   // See [FieldMask][google.protobuf.FieldMask] for more information.
   //
-  // Example: `"updateMask=kmsKeyName"`
+  // For example: `"updateMask=kmsKeyName"`
   google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Describes the customer-managed encryption key (CMEK) settings associated with
 // a project, folder, organization, billing account, or flexible resource.
 //
-// Note: CMEK for the Logs Router can currently only be configured for GCP
-// organizations. Once configured, it applies to all projects and folders in the
-// GCP organization.
+// Note: CMEK for the Log Router can currently only be configured for Google
+// Cloud organizations. Once configured, it applies to all projects and folders
+// in the Google Cloud organization.
 //
-// See [Enabling CMEK for Logs Router](/logging/docs/routing/managed-encryption)
-// for more information.
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
 message CmekSettings {
   option (google.api.resource) = {
     type: "logging.googleapis.com/CmekSettings"
@@ -1118,14 +1683,142 @@ message CmekSettings {
   // The resource name for the configured Cloud KMS key.
   //
   // KMS key name format:
+  //
   //     "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]"
   //
   // For example:
-  //     `"projects/my-project-id/locations/my-region/keyRings/key-ring-name/cryptoKeys/key-name"`
+  //
+  //   `"projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"`
   //
   //
   //
-  // To enable CMEK for the Logs Router, set this field to a valid
+  // To enable CMEK for the Log Router, set this field to a valid
+  // `kms_key_name` for which the associated service account has the required
+  // cloudkms.cryptoKeyEncrypterDecrypter roles assigned for the key.
+  //
+  // The Cloud KMS key used by the Log Router can be updated by changing the
+  // `kms_key_name` to a new valid key name or disabled by setting the key name
+  // to an empty string. Encryption operations that are in progress will be
+  // completed with the key that was in use when they started. Decryption
+  // operations will be completed using the key that was used at the time of
+  // encryption unless access to that key has been revoked.
+  //
+  // To disable CMEK for the Log Router, set this field to an empty string.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_key_name = 2;
+
+  // Output only. The service account that will be used by the Log Router to access your
+  // Cloud KMS key.
+  //
+  // Before enabling CMEK for Log Router, you must first assign the
+  // cloudkms.cryptoKeyEncrypterDecrypter role to the service account that
+  // the Log Router will use to access your Cloud KMS key. Use
+  // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings] to
+  // obtain the service account ID.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// The parameters to
+// [GetSettings][google.logging.v2.ConfigServiceV2.GetSettings].
+//
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
+message GetSettingsRequest {
+  // Required. The resource for which to retrieve settings.
+  //
+  //     "projects/[PROJECT_ID]/settings"
+  //     "organizations/[ORGANIZATION_ID]/settings"
+  //     "billingAccounts/[BILLING_ACCOUNT_ID]/settings"
+  //     "folders/[FOLDER_ID]/settings"
+  //
+  // For example:
+  //
+  //   `"organizations/12345/settings"`
+  //
+  // Note: Settings for the Log Router can be get for Google Cloud projects,
+  // folders, organizations and billing accounts. Currently it can only be
+  // configured for organizations. Once configured for an organization, it
+  // applies to all projects and folders in the Google Cloud organization.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "logging.googleapis.com/Settings"
+    }
+  ];
+}
+
+// The parameters to
+// [UpdateSettings][google.logging.v2.ConfigServiceV2.UpdateSettings].
+//
+// See [Enabling CMEK for Log
+// Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for
+// more information.
+message UpdateSettingsRequest {
+  // Required. The resource name for the settings to update.
+  //
+  //     "organizations/[ORGANIZATION_ID]/settings"
+  //
+  // For example:
+  //
+  //   `"organizations/12345/settings"`
+  //
+  // Note: Settings for the Log Router can currently only be configured for
+  // Google Cloud organizations. Once configured, it applies to all projects and
+  // folders in the Google Cloud organization.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The settings to update.
+  //
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  Settings settings = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. Field mask identifying which fields from `settings` should
+  // be updated. A field will be overwritten if and only if it is in the update
+  // mask. Output only fields cannot be updated.
+  //
+  // See [FieldMask][google.protobuf.FieldMask] for more information.
+  //
+  // For example: `"updateMask=kmsKeyName"`
+  google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Describes the settings associated with a project, folder, organization,
+// billing account, or flexible resource.
+message Settings {
+  option (google.api.resource) = {
+    type: "logging.googleapis.com/Settings"
+    pattern: "projects/{project}/settings"
+    pattern: "organizations/{organization}/settings"
+    pattern: "folders/{folder}/settings"
+    pattern: "billingAccounts/{billing_account}/settings"
+  };
+
+  // Output only. The resource name of the settings.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Optional. The resource name for the configured Cloud KMS key.
+  //
+  // KMS key name format:
+  //
+  //     "projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]"
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"`
+  //
+  //
+  //
+  // To enable CMEK for the Log Router, set this field to a valid
   // `kms_key_name` for which the associated service account has the required
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key.
   //
@@ -1135,22 +1828,130 @@ message CmekSettings {
   // Decryption operations will be completed using the key that was used at the
   // time of encryption unless access to that key has been revoked.
   //
-  // To disable CMEK for the Logs Router, set this field to an empty string.
+  // To disable CMEK for the Log Router, set this field to an empty string.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
-  string kms_key_name = 2;
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_key_name = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Output only. The service account that will be used by the Logs Router to access your
+  // Output only. The service account that will be used by the Log Router to access your
   // Cloud KMS key.
   //
-  // Before enabling CMEK for Logs Router, you must first assign the role
+  // Before enabling CMEK for Log Router, you must first assign the role
   // `roles/cloudkms.cryptoKeyEncrypterDecrypter` to the service account that
-  // the Logs Router will use to access your Cloud KMS key. Use
-  // [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings] to
+  // the Log Router will use to access your Cloud KMS key. Use
+  // [GetSettings][google.logging.v2.ConfigServiceV2.GetSettings] to
   // obtain the service account ID.
   //
-  // See [Enabling CMEK for Logs
-  // Router](/logging/docs/routing/managed-encryption) for more information.
-  string service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // See [Enabling CMEK for Log
+  // Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
+  // for more information.
+  string kms_service_account_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Optional. The Cloud region that will be used for _Default and _Required log buckets
+  // for newly created projects and folders. For example `europe-west1`.
+  // This setting does not affect the location of custom log buckets.
+  string storage_location = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Optional. If set to true, the _Default sink in newly created projects and folders
+  // will created in a disabled state. This can be used to automatically disable
+  // log ingestion if there is already an aggregated sink configured in the
+  // hierarchy. The _Default sink can be re-enabled manually if needed.
+  bool disable_default_sink = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// The parameters to CopyLogEntries.
+message CopyLogEntriesRequest {
+  // Required. Log bucket from which to copy log entries.
+  //
+  // For example:
+  //
+  //   `"projects/my-project/locations/global/buckets/my-source-bucket"`
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. A filter specifying which log entries to copy. The filter must be no more
+  // than 20k characters. An empty filter matches all log entries.
+  string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Required. Destination to which to copy log entries.
+  string destination = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Metadata for CopyLogEntries long running operations.
+message CopyLogEntriesMetadata {
+  // The create time of an operation.
+  google.protobuf.Timestamp start_time = 1;
+
+  // The end time of an operation.
+  google.protobuf.Timestamp end_time = 2;
+
+  // State of an operation.
+  OperationState state = 3;
+
+  // Identifies whether the user has requested cancellation of the operation.
+  bool cancellation_requested = 4;
+
+  // CopyLogEntries RPC request.
+  CopyLogEntriesRequest request = 5;
+
+  // Estimated progress of the operation (0 - 100%).
+  int32 progress = 6;
+
+  // The IAM identity of a service account that must be granted access to the
+  // destination.
+  //
+  // If the service account is not granted permission to the destination within
+  // an hour, the operation will be cancelled.
+  //
+  // For example: `"serviceAccount:foo@bar.com"`
+  string writer_identity = 7;
+}
+
+// Response type for CopyLogEntries long running operations.
+message CopyLogEntriesResponse {
+  // Number of log entries copied.
+  int64 log_entries_copied_count = 1;
+}
+
+// LogBucket lifecycle states.
+enum LifecycleState {
+  // Unspecified state. This is only used/useful for distinguishing unset
+  // values.
+  LIFECYCLE_STATE_UNSPECIFIED = 0;
+
+  // The normal and active state.
+  ACTIVE = 1;
+
+  // The resource has been marked for deletion by the user. For some resources
+  // (e.g. buckets), this can be reversed by an un-delete operation.
+  DELETE_REQUESTED = 2;
+}
+
+// List of different operation states.
+// High level state of the operation. This is used to report the job's
+// current state to the user. Once a long running operation is created,
+// the current state of the operation can be queried even before the
+// operation is finished and the final result is available.
+enum OperationState {
+  // Should not be used.
+  OPERATION_STATE_UNSPECIFIED = 0;
+
+  // The operation is scheduled.
+  OPERATION_STATE_SCHEDULED = 1;
+
+  // Waiting for necessary permissions.
+  OPERATION_STATE_WAITING_FOR_PERMISSIONS = 2;
+
+  // The operation is running.
+  OPERATION_STATE_RUNNING = 3;
+
+  // The operation was completed successfully.
+  OPERATION_STATE_SUCCEEDED = 4;
+
+  // The operation failed.
+  OPERATION_STATE_FAILED = 5;
+
+  // The operation was cancelled by the user.
+  OPERATION_STATE_CANCELLED = 6;
 }

--- a/test-fixtures/protos/google/logging/v2/logging_gapic.yaml
+++ b/test-fixtures/protos/google/logging/v2/logging_gapic.yaml
@@ -3,30 +3,23 @@ config_schema_version: 2.0.0
 language_settings:
   java:
     package_name: com.google.cloud.logging.v2
-  python:
-    package_name: google.cloud.logging_v2.gapic
-  go:
-    package_name: cloud.google.com/go/logging/apiv2
-    domain_layer_location: cloud.google.com/go/logging
-  csharp:
-    package_name: Google.Cloud.Logging.V2
-    release_level: GA
-  ruby:
-    package_name: Google::Cloud::Logging::V2
-  php:
-    package_name: Google\Cloud\Logging\V2
-  nodejs:
-    package_name: logging.v2
-    domain_layer_location: google-cloud
-interfaces: 
+    interface_names:
+      google.logging.v2.ConfigServiceV2: Config
+      google.logging.v2.LoggingServiceV2: Logging
+      google.logging.v2.MetricsServiceV2: Metrics
+interfaces:
 - name: google.logging.v2.LoggingServiceV2
-  methods: 
+  methods:
   - name: WriteLogEntries
+    retry_codes_name: idempotent
     batching:
       thresholds:
         element_count_threshold: 1000
-        request_byte_threshold: 1048576  # 1 MiB
+        request_byte_threshold: 1048576
         delay_threshold_millis: 50
+        flow_control_element_limit: 100000
+        flow_control_byte_limit: 10485760
+        flow_control_limit_exceeded_behavior: THROW_EXCEPTION
       batch_descriptor:
         batched_field: entries
         discriminator_fields:

--- a/test-fixtures/protos/google/logging/v2/logging_grpc_service_config.json
+++ b/test-fixtures/protos/google/logging/v2/logging_grpc_service_config.json
@@ -1,0 +1,162 @@
+{
+  "methodConfig": [
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.MetricsServiceV2",
+          "method": "CreateLogMetric"
+        }
+      ],
+      "timeout": "60s"
+    },
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "DeleteLog"
+        },
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "WriteLogEntries"
+        },
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "ListLogEntries"
+        },
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "ListMonitoredResourceDescriptors"
+        },
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "ListLogs"
+        }
+      ],
+      "timeout": "60s",
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
+        ]
+      }
+    },
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.LoggingServiceV2",
+          "method": "TailLogEntries"
+        }
+      ],
+      "timeout": "3600s",
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
+        ]
+      }
+    },
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "ListSinks"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "GetSink"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "UpdateSink"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "DeleteSink"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "ListExclusions"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "GetExclusion"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "DeleteExclusion"
+        }
+      ],
+      "timeout": "60s",
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
+        ]
+      }
+    },
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "CreateSink"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "CreateExclusion"
+        },
+        {
+          "service": "google.logging.v2.ConfigServiceV2",
+          "method": "UpdateExclusion"
+        }
+      ],
+      "timeout": "120s"
+    },
+    {
+      "name": [
+        {
+          "service": "google.logging.v2.MetricsServiceV2",
+          "method": "ListLogMetrics"
+        },
+        {
+          "service": "google.logging.v2.MetricsServiceV2",
+          "method": "GetLogMetric"
+        },
+        {
+          "service": "google.logging.v2.MetricsServiceV2",
+          "method": "UpdateLogMetric"
+        },
+        {
+          "service": "google.logging.v2.MetricsServiceV2",
+          "method": "DeleteLogMetric"
+        }
+      ],
+      "timeout": "60s",
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.100s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 1.3,
+        "retryableStatusCodes": [
+          "DEADLINE_EXCEEDED",
+          "INTERNAL",
+          "UNAVAILABLE"
+        ]
+      }
+    }
+  ]
+}

--- a/test-fixtures/protos/google/logging/v2/logging_metrics.proto
+++ b/test-fixtures/protos/google/logging/v2/logging_metrics.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,22 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.logging.v2;
 
+import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/distribution.proto";
 import "google/api/field_behavior.proto";
 import "google/api/metric.proto";
 import "google/api/resource.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
-import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Logging.V2";
@@ -35,6 +32,7 @@ option java_multiple_files = true;
 option java_outer_classname = "LoggingMetricsProto";
 option java_package = "com.google.logging.v2";
 option php_namespace = "Google\\Cloud\\Logging\\V2";
+option ruby_package = "Google::Cloud::Logging::V2";
 
 // Service for configuring logs-based metrics.
 service MetricsServiceV2 {
@@ -92,8 +90,8 @@ service MetricsServiceV2 {
 // Describes a logs-based metric. The value of the metric is the number of log
 // entries that match a logs filter in a given time interval.
 //
-// Logs-based metric can also be used to extract values from logs and create a
-// a distribution of the values. The distribution records the statistics of the
+// Logs-based metrics can also be used to extract values from logs and create a
+// distribution of the values. The distribution records the statistics of the
 // extracted values along with an optional histogram of the values as specified
 // by the bucket options.
 message LogMetric {
@@ -119,25 +117,29 @@ message LogMetric {
   // `_-.,+!*',()%/`. The forward-slash character (`/`) denotes a hierarchy of
   // name pieces, and it cannot be the first character of the name.
   //
-  // The metric identifier in this field must not be
-  // [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
-  // However, when the metric identifier appears as the `[METRIC_ID]` part of a
-  // `metric_name` API parameter, then the metric identifier must be
-  // URL-encoded. Example: `"projects/my-project/metrics/nginx%2Frequests"`.
+  // This field is the `[METRIC_ID]` part of a metric resource name in the
+  // format "projects/[PROJECT_ID]/metrics/[METRIC_ID]". Example: If the
+  // resource name of a metric is
+  // `"projects/my-project/metrics/nginx%2Frequests"`, this field's value is
+  // `"nginx/requests"`.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Optional. A description of this metric, which is used in documentation.
   // The maximum length of the description is 8000 characters.
   string description = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Required. An [advanced logs filter](/logging/docs/view/advanced_filters) which is
-  // used to match log entries.
-  // Example:
+  // Required. An [advanced logs
+  // filter](https://cloud.google.com/logging/docs/view/advanced_filters) which
+  // is used to match log entries. Example:
   //
   //     "resource.type=gae_app AND severity>=ERROR"
   //
   // The maximum length of the filter is 20000 characters.
   string filter = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional. If set to True, then this metric is disabled and it does not
+  // generate any points.
+  bool disabled = 12 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. The metric descriptor associated with the logs-based metric.
   // If unspecified, it uses a default metric descriptor with a DELTA metric

--- a/typescript/test/unit/baselines.ts
+++ b/typescript/test/unit/baselines.ts
@@ -115,6 +115,7 @@ describe('Baseline tests', () => {
     useCommonProto: true,
     bundleConfig: 'google/logging/v2/logging_gapic.yaml',
     mainServiceName: 'LoggingService',
+    grpcServiceConfig: 'google/logging/v2/logging_grpc_service_config.json',
   });
 
   runBaselineTest({

--- a/typescript/test/unit/baselines.ts
+++ b/typescript/test/unit/baselines.ts
@@ -111,7 +111,7 @@ describe('Baseline tests', () => {
   runBaselineTest({
     baselineName: 'logging',
     outputDir: '.test-out-logging',
-    protoPath: 'google/logging/v2/*.proto',
+    protoPath: 'google/logging/v2/*.proto;google/logging/type/*.proto',
     useCommonProto: true,
     bundleConfig: 'google/logging/v2/logging_gapic.yaml',
     mainServiceName: 'LoggingService',


### PR DESCRIPTION
We now import `google-gax` as `import type`, so we must use an instance when accessing its functions.

Also, add `nodejs-logging` library to the test executed in CI to make sure it actually compiles.