### PR TITLE
fix: preserve default values in x-goog-request-params

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -421,7 +421,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.batchGetAssetsHistory(request, options, callback);
@@ -506,7 +506,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createFeed(request, options, callback);
@@ -580,7 +580,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getFeed(request, options, callback);
@@ -653,7 +653,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listFeeds(request, options, callback);
@@ -732,7 +732,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'feed.name': request.feed!.name || '',
+      'feed.name': request.feed!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateFeed(request, options, callback);
@@ -806,7 +806,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteFeed(request, options, callback);
@@ -904,7 +904,7 @@ export class AssetServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.exportAssets(request, options, callback);

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as assetserviceModule from '../src';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -159,8 +171,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -183,8 +197,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -218,8 +234,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -241,7 +259,9 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.batchGetAssetsHistory(request), expectedError);
@@ -256,8 +276,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -280,8 +302,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -315,8 +339,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -338,7 +364,9 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createFeed(request), expectedError);
@@ -353,8 +381,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -377,8 +407,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -412,8 +444,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -435,7 +469,9 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetFeedRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getFeed(request), expectedError);
@@ -450,8 +486,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -474,8 +512,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -509,8 +549,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -532,7 +574,9 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.listFeeds(request), expectedError);
@@ -547,9 +591,11 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
-            request.feed = {};
-            request.feed.name = '';
-            const expectedHeaderRequestParams = "feed.name=";
+            request.feed ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+            request.feed.name = defaultValue1;
+            const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -572,9 +618,11 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
-            request.feed = {};
-            request.feed.name = '';
-            const expectedHeaderRequestParams = "feed.name=";
+            request.feed ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+            request.feed.name = defaultValue1;
+            const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -608,9 +656,11 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
-            request.feed = {};
-            request.feed.name = '';
-            const expectedHeaderRequestParams = "feed.name=";
+            request.feed ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+            request.feed.name = defaultValue1;
+            const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -632,8 +682,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
-            request.feed = {};
-            request.feed.name = '';
+            request.feed ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+            request.feed.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateFeed(request), expectedError);
@@ -648,8 +700,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -672,8 +726,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -707,8 +763,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -730,7 +788,9 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteFeed(request), expectedError);
@@ -745,8 +805,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -770,8 +832,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -808,8 +872,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -831,8 +897,10 @@ describe('v1.AssetServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {

--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -170,24 +171,25 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse()
+            );
             client.innerApiCalls.batchGetAssetsHistory = stubSimpleCall(expectedResponse);
             const [response] = await client.batchGetAssetsHistory(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchGetAssetsHistory as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchGetAssetsHistory without error using callback', async () => {
@@ -196,19 +198,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse()
+            );
             client.innerApiCalls.batchGetAssetsHistory = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.batchGetAssetsHistory(
@@ -223,8 +222,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchGetAssetsHistory as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchGetAssetsHistory with error', async () => {
@@ -233,23 +236,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.batchGetAssetsHistory = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.batchGetAssetsHistory(request), expectedError);
-            assert((client.innerApiCalls.batchGetAssetsHistory as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchGetAssetsHistory as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchGetAssetsHistory with closed client', async () => {
@@ -258,7 +260,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
@@ -275,24 +279,25 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.CreateFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.createFeed = stubSimpleCall(expectedResponse);
             const [response] = await client.createFeed(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createFeed without error using callback', async () => {
@@ -301,19 +306,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.CreateFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.createFeed = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createFeed(
@@ -328,8 +330,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createFeed with error', async () => {
@@ -338,23 +344,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.CreateFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createFeed = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createFeed(request), expectedError);
-            assert((client.innerApiCalls.createFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createFeed with closed client', async () => {
@@ -363,7 +368,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.CreateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.CreateFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
@@ -380,24 +387,25 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.GetFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.getFeed = stubSimpleCall(expectedResponse);
             const [response] = await client.getFeed(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getFeed without error using callback', async () => {
@@ -406,19 +414,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.GetFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.getFeed = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getFeed(
@@ -433,8 +438,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getFeed with error', async () => {
@@ -443,23 +452,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.GetFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getFeed = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getFeed(request), expectedError);
-            assert((client.innerApiCalls.getFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getFeed with closed client', async () => {
@@ -468,7 +476,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.GetFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.GetFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetFeedRequest', ['name']);
             request.name = defaultValue1;
@@ -485,24 +495,25 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsResponse()
+            );
             client.innerApiCalls.listFeeds = stubSimpleCall(expectedResponse);
             const [response] = await client.listFeeds(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listFeeds as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listFeeds without error using callback', async () => {
@@ -511,19 +522,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsResponse()
+            );
             client.innerApiCalls.listFeeds = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.listFeeds(
@@ -538,8 +546,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listFeeds as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listFeeds with error', async () => {
@@ -548,23 +560,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listFeeds = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listFeeds(request), expectedError);
-            assert((client.innerApiCalls.listFeeds as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listFeeds as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listFeeds with closed client', async () => {
@@ -573,7 +584,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ListFeedsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ListFeedsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -590,25 +603,26 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.UpdateFeedRequest()
+            );
             request.feed ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.updateFeed = stubSimpleCall(expectedResponse);
             const [response] = await client.updateFeed(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateFeed without error using callback', async () => {
@@ -617,20 +631,17 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.UpdateFeedRequest()
+            );
             request.feed ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.asset.v1.Feed());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.asset.v1.Feed()
+            );
             client.innerApiCalls.updateFeed = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateFeed(
@@ -645,8 +656,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateFeed with error', async () => {
@@ -655,24 +670,23 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.UpdateFeedRequest()
+            );
             request.feed ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateFeed = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateFeed(request), expectedError);
-            assert((client.innerApiCalls.updateFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateFeed with closed client', async () => {
@@ -681,7 +695,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.UpdateFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.UpdateFeedRequest()
+            );
             request.feed ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
@@ -699,24 +715,25 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.DeleteFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteFeed = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteFeed(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteFeed without error using callback', async () => {
@@ -725,19 +742,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.DeleteFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteFeed = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteFeed(
@@ -752,8 +766,12 @@ describe('v1.AssetServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteFeed with error', async () => {
@@ -762,23 +780,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.DeleteFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteFeed = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteFeed(request), expectedError);
-            assert((client.innerApiCalls.deleteFeed as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteFeed as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteFeed with closed client', async () => {
@@ -787,7 +804,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.DeleteFeedRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.DeleteFeedRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
@@ -804,25 +823,26 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ExportAssetsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.exportAssets = stubLongRunningCall(expectedResponse);
             const [operation] = await client.exportAssets(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.exportAssets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportAssets without error using callback', async () => {
@@ -831,19 +851,16 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ExportAssetsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.exportAssets = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.exportAssets(
@@ -861,8 +878,12 @@ describe('v1.AssetServiceClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.asset.v1.IExportAssetsResponse, protos.google.cloud.asset.v1.IExportAssetsRequest>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.exportAssets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportAssets with call error', async () => {
@@ -871,23 +892,22 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ExportAssetsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.exportAssets = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.exportAssets(request), expectedError);
-            assert((client.innerApiCalls.exportAssets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportAssets with LRO error', async () => {
@@ -896,24 +916,23 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.asset.v1.ExportAssetsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.asset.v1.ExportAssetsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.exportAssets = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.exportAssets(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.exportAssets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportAssets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkExportAssetsProgress without error', async () => {
@@ -922,7 +941,9 @@ describe('v1.AssetServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -413,8 +413,8 @@ export class BigQueryStorageClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'table_reference.project_id': request.tableReference!.projectId || '',
-      'table_reference.dataset_id': request.tableReference!.datasetId || '',
+      'table_reference.project_id': request.tableReference!.projectId ?? '',
+      'table_reference.dataset_id': request.tableReference!.datasetId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createReadSession(request, options, callback);
@@ -492,7 +492,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'session.name': request.session!.name || '',
+      'session.name': request.session!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.batchCreateReadSessionStreams(request, options, callback);
@@ -576,7 +576,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'stream.name': request.stream!.name || '',
+      'stream.name': request.stream!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.finalizeStream(request, options, callback);
@@ -667,7 +667,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'original_stream.name': request.originalStream!.name || '',
+      'original_stream.name': request.originalStream!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.splitReadStream(request, options, callback);
@@ -711,7 +711,7 @@ export class BigQueryStorageClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'read_position.stream.name': request.readPosition!.stream!.name || '',
+      'read_position.stream.name': request.readPosition!.stream!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.readRows(request, options);

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -157,11 +169,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
-            request.tableReference = {};
-            request.tableReference.projectId = '';
-            request.tableReference = {};
-            request.tableReference.datasetId = '';
-            const expectedHeaderRequestParams = "table_reference.project_id=&table_reference.dataset_id=";
+            request.tableReference ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+            request.tableReference.projectId = defaultValue1;
+            request.tableReference ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+            request.tableReference.datasetId = defaultValue2;
+            const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -184,11 +200,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
-            request.tableReference = {};
-            request.tableReference.projectId = '';
-            request.tableReference = {};
-            request.tableReference.datasetId = '';
-            const expectedHeaderRequestParams = "table_reference.project_id=&table_reference.dataset_id=";
+            request.tableReference ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+            request.tableReference.projectId = defaultValue1;
+            request.tableReference ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+            request.tableReference.datasetId = defaultValue2;
+            const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -222,11 +242,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
-            request.tableReference = {};
-            request.tableReference.projectId = '';
-            request.tableReference = {};
-            request.tableReference.datasetId = '';
-            const expectedHeaderRequestParams = "table_reference.project_id=&table_reference.dataset_id=";
+            request.tableReference ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+            request.tableReference.projectId = defaultValue1;
+            request.tableReference ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+            request.tableReference.datasetId = defaultValue2;
+            const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -248,10 +272,14 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
-            request.tableReference = {};
-            request.tableReference.projectId = '';
-            request.tableReference = {};
-            request.tableReference.datasetId = '';
+            request.tableReference ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+            request.tableReference.projectId = defaultValue1;
+            request.tableReference ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+            request.tableReference.datasetId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createReadSession(request), expectedError);
@@ -266,9 +294,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
-            request.session = {};
-            request.session.name = '';
-            const expectedHeaderRequestParams = "session.name=";
+            request.session ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+            request.session.name = defaultValue1;
+            const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -291,9 +321,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
-            request.session = {};
-            request.session.name = '';
-            const expectedHeaderRequestParams = "session.name=";
+            request.session ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+            request.session.name = defaultValue1;
+            const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -327,9 +359,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
-            request.session = {};
-            request.session.name = '';
-            const expectedHeaderRequestParams = "session.name=";
+            request.session ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+            request.session.name = defaultValue1;
+            const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -351,8 +385,10 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
-            request.session = {};
-            request.session.name = '';
+            request.session ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+            request.session.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.batchCreateReadSessionStreams(request), expectedError);
@@ -367,9 +403,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
-            request.stream = {};
-            request.stream.name = '';
-            const expectedHeaderRequestParams = "stream.name=";
+            request.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+            request.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -392,9 +430,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
-            request.stream = {};
-            request.stream.name = '';
-            const expectedHeaderRequestParams = "stream.name=";
+            request.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+            request.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -428,9 +468,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
-            request.stream = {};
-            request.stream.name = '';
-            const expectedHeaderRequestParams = "stream.name=";
+            request.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+            request.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -452,8 +494,10 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
-            request.stream = {};
-            request.stream.name = '';
+            request.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+            request.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.finalizeStream(request), expectedError);
@@ -468,9 +512,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
-            request.originalStream = {};
-            request.originalStream.name = '';
-            const expectedHeaderRequestParams = "original_stream.name=";
+            request.originalStream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+            request.originalStream.name = defaultValue1;
+            const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -493,9 +539,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
-            request.originalStream = {};
-            request.originalStream.name = '';
-            const expectedHeaderRequestParams = "original_stream.name=";
+            request.originalStream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+            request.originalStream.name = defaultValue1;
+            const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -529,9 +577,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
-            request.originalStream = {};
-            request.originalStream.name = '';
-            const expectedHeaderRequestParams = "original_stream.name=";
+            request.originalStream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+            request.originalStream.name = defaultValue1;
+            const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -553,8 +603,10 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
-            request.originalStream = {};
-            request.originalStream.name = '';
+            request.originalStream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+            request.originalStream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.splitReadStream(request), expectedError);
@@ -569,10 +621,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
-            request.readPosition = {};
-            request.readPosition.stream = {};
-            request.readPosition.stream.name = '';
-            const expectedHeaderRequestParams = "read_position.stream.name=";
+            request.readPosition ??= {};
+            request.readPosition.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+            request.readPosition.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -604,10 +658,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
-            request.readPosition = {};
-            request.readPosition.stream = {};
-            request.readPosition.stream.name = '';
-            const expectedHeaderRequestParams = "read_position.stream.name=";
+            request.readPosition ??= {};
+            request.readPosition.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+            request.readPosition.stream.name = defaultValue1;
+            const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -638,9 +694,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
-            request.readPosition = {};
-            request.readPosition.stream = {};
-            request.readPosition.stream.name = '';
+            request.readPosition ??= {};
+            request.readPosition.stream ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+            request.readPosition.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.readRows(request);

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -168,7 +169,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest()
+            );
             request.tableReference ??= {};
             const defaultValue1 =
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
@@ -178,19 +181,18 @@ describe('v1beta1.BigQueryStorageClient', () => {
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadSession());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadSession()
+            );
             client.innerApiCalls.createReadSession = stubSimpleCall(expectedResponse);
             const [response] = await client.createReadSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createReadSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createReadSession without error using callback', async () => {
@@ -199,7 +201,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest()
+            );
             request.tableReference ??= {};
             const defaultValue1 =
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
@@ -209,14 +213,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadSession());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadSession()
+            );
             client.innerApiCalls.createReadSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createReadSession(
@@ -231,8 +230,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createReadSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createReadSession with error', async () => {
@@ -241,7 +244,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest()
+            );
             request.tableReference ??= {};
             const defaultValue1 =
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
@@ -251,18 +256,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createReadSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createReadSession(request), expectedError);
-            assert((client.innerApiCalls.createReadSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createReadSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createReadSession with closed client', async () => {
@@ -271,7 +273,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest()
+            );
             request.tableReference ??= {};
             const defaultValue1 =
               getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
@@ -293,25 +297,26 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest()
+            );
             request.session ??= {};
             const defaultValue1 =
               getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse()
+            );
             client.innerApiCalls.batchCreateReadSessionStreams = stubSimpleCall(expectedResponse);
             const [response] = await client.batchCreateReadSessionStreams(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchCreateReadSessionStreams without error using callback', async () => {
@@ -320,20 +325,17 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest()
+            );
             request.session ??= {};
             const defaultValue1 =
               getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse()
+            );
             client.innerApiCalls.batchCreateReadSessionStreams = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.batchCreateReadSessionStreams(
@@ -348,8 +350,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchCreateReadSessionStreams with error', async () => {
@@ -358,24 +364,23 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest()
+            );
             request.session ??= {};
             const defaultValue1 =
               getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.batchCreateReadSessionStreams = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.batchCreateReadSessionStreams(request), expectedError);
-            assert((client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchCreateReadSessionStreams as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchCreateReadSessionStreams with closed client', async () => {
@@ -384,7 +389,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest()
+            );
             request.session ??= {};
             const defaultValue1 =
               getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
@@ -402,25 +409,26 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest()
+            );
             request.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.finalizeStream = stubSimpleCall(expectedResponse);
             const [response] = await client.finalizeStream(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.finalizeStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes finalizeStream without error using callback', async () => {
@@ -429,20 +437,17 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest()
+            );
             request.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.finalizeStream = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.finalizeStream(
@@ -457,8 +462,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.finalizeStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes finalizeStream with error', async () => {
@@ -467,24 +476,23 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest()
+            );
             request.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.finalizeStream = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.finalizeStream(request), expectedError);
-            assert((client.innerApiCalls.finalizeStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.finalizeStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes finalizeStream with closed client', async () => {
@@ -493,7 +501,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest()
+            );
             request.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
@@ -511,25 +521,26 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest()
+            );
             request.originalStream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse()
+            );
             client.innerApiCalls.splitReadStream = stubSimpleCall(expectedResponse);
             const [response] = await client.splitReadStream(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.splitReadStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes splitReadStream without error using callback', async () => {
@@ -538,20 +549,17 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest()
+            );
             request.originalStream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse()
+            );
             client.innerApiCalls.splitReadStream = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.splitReadStream(
@@ -566,8 +574,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.splitReadStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes splitReadStream with error', async () => {
@@ -576,24 +588,23 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest()
+            );
             request.originalStream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.splitReadStream = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.splitReadStream(request), expectedError);
-            assert((client.innerApiCalls.splitReadStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.splitReadStream as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes splitReadStream with closed client', async () => {
@@ -602,7 +613,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest()
+            );
             request.originalStream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
@@ -620,21 +633,18 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest()
+            );
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
             request.readPosition.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse()
+            );
             client.innerApiCalls.readRows = stubServerStreamingCall(expectedResponse);
             const stream = client.readRows(request);
             const promise = new Promise((resolve, reject) => {
@@ -647,8 +657,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.readRows as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes readRows with error', async () => {
@@ -657,20 +671,15 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest()
+            );
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =
               getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
             request.readPosition.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.readRows = stubServerStreamingCall(undefined, expectedError);
             const stream = client.readRows(request);
@@ -683,8 +692,12 @@ describe('v1beta1.BigQueryStorageClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.readRows as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.readRows as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes readRows with closed client', async () => {
@@ -693,7 +706,9 @@ describe('v1beta1.BigQueryStorageClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest()
+            );
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -383,9 +383,9 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
-      'address': request.address || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
+      'address': request.address ?? '',
     });
     this.initialize();
     return this.innerApiCalls.delete(request, options, callback)
@@ -478,8 +478,8 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
     });
     this.initialize();
     return this.innerApiCalls.insert(request, options, callback)
@@ -545,7 +545,7 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
+      'project': request.project ?? '',
     });
     const defaultCallSettings = this._defaults['aggregatedList'];
     const callSettings = defaultCallSettings.merge(options);
@@ -647,8 +647,8 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
     });
     this.initialize();
     return this.innerApiCalls.list(request, options, callback);
@@ -703,8 +703,8 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
     });
     const defaultCallSettings = this._defaults['list'];
     const callSettings = defaultCallSettings.merge(options);
@@ -768,8 +768,8 @@ export class AddressesClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
     });
     const defaultCallSettings = this._defaults['list'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -359,9 +359,9 @@ export class RegionOperationsClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
-      'operation': request.operation || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
+      'operation': request.operation ?? '',
     });
     this.initialize();
     return this.innerApiCalls.get(request, options, callback);
@@ -440,9 +440,9 @@ export class RegionOperationsClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'project': request.project || '',
-      'region': request.region || '',
-      'operation': request.operation || '',
+      'project': request.project ?? '',
+      'region': request.region ?? '',
+      'operation': request.operation ?? '',
     });
     this.initialize();
     return this.innerApiCalls.wait(request, options, callback);

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {GoogleAuth, protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -201,10 +213,16 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
-            request.project = '';
-            request.region = '';
-            request.address = '';
-            const expectedHeaderRequestParams = "project=&region=&address=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+            request.address = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -227,10 +245,16 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
-            request.project = '';
-            request.region = '';
-            request.address = '';
-            const expectedHeaderRequestParams = "project=&region=&address=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+            request.address = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -264,10 +288,16 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
-            request.project = '';
-            request.region = '';
-            request.address = '';
-            const expectedHeaderRequestParams = "project=&region=&address=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+            request.address = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -289,9 +319,15 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
-            request.project = '';
-            request.region = '';
-            request.address = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+            request.address = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.delete(request), expectedError);
@@ -306,9 +342,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('InsertAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InsertAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -331,9 +371,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('InsertAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InsertAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -367,9 +411,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('InsertAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InsertAddressRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -391,8 +439,12 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
-            request.project = '';
-            request.region = '';
+            const defaultValue1 =
+              getTypeDefaultValue('InsertAddressRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InsertAddressRequest', ['region']);
+            request.region = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.insert(request), expectedError);
@@ -408,8 +460,10 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.AggregatedListAddressesRequest());
-            request.project = '';
-            const expectedHeaderRequestParams = "project=";
+            const defaultValue1 =
+              getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const expectedHeaderRequestParams = `project=${defaultValue1}`;
             const expectedResponse = [
               ['tuple_key_1', generateSampleMessage(new protos.google.cloud.compute.v1.AddressesScopedList())],
               ['tuple_key_2', generateSampleMessage(new protos.google.cloud.compute.v1.AddressesScopedList())],
@@ -439,8 +493,10 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.AggregatedListAddressesRequest());
-            request.project = '';
-            const expectedHeaderRequestParams = "project=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const expectedHeaderRequestParams = `project=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.aggregatedList.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.aggregatedListAsync(request);
             await assert.rejects(async () => {
@@ -468,9 +524,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -497,9 +557,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -537,9 +601,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -561,9 +629,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -601,9 +673,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.list.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listStream(request);
@@ -636,9 +712,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -668,9 +748,13 @@ describe('v1.AddressesClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
-            request.project = '';
-            request.region = '';
-            const expectedHeaderRequestParams = "project=&region=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListAddressesRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListAddressesRequest', ['region']);
+            request.region = defaultValue2;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.list.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listAsync(request);
             await assert.rejects(async () => {

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -31,6 +31,7 @@ import {GoogleAuth, protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -212,7 +213,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.DeleteAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -223,19 +226,18 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.delete = stubSimpleCall(expectedResponse);
             const [response] = await client.delete(request);
             assert.deepStrictEqual(response.latestResponse, expectedResponse);
-            assert((client.innerApiCalls.delete as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes delete without error using callback', async () => {
@@ -244,7 +246,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.DeleteAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -255,14 +259,9 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.delete = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.delete(
@@ -277,8 +276,12 @@ describe('v1.AddressesClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.delete as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes delete with error', async () => {
@@ -287,7 +290,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.DeleteAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -298,18 +303,15 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.delete = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.delete(request), expectedError);
-            assert((client.innerApiCalls.delete as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.delete as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes delete with closed client', async () => {
@@ -318,7 +320,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.DeleteAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.DeleteAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -341,7 +345,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.InsertAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InsertAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -349,19 +355,18 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.insert = stubSimpleCall(expectedResponse);
             const [response] = await client.insert(request);
             assert.deepStrictEqual(response.latestResponse, expectedResponse);
-            assert((client.innerApiCalls.insert as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes insert without error using callback', async () => {
@@ -370,7 +375,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.InsertAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InsertAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -378,14 +385,9 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.insert = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.insert(
@@ -400,8 +402,12 @@ describe('v1.AddressesClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.insert as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes insert with error', async () => {
@@ -410,7 +416,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.InsertAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InsertAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -418,18 +426,15 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.insert = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.insert(request), expectedError);
-            assert((client.innerApiCalls.insert as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.insert as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes insert with closed client', async () => {
@@ -438,7 +443,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.InsertAddressRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.InsertAddressRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InsertAddressRequest', ['project']);
             request.project = defaultValue1;
@@ -459,7 +466,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.AggregatedListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.AggregatedListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
             request.project = defaultValue1;
@@ -479,10 +488,11 @@ describe('v1.AddressesClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.aggregatedList.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.aggregatedList.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -492,11 +502,14 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.AggregatedListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.AggregatedListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
             request.project = defaultValue1;
-            const expectedHeaderRequestParams = `project=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `project=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.aggregatedList.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.aggregatedListAsync(request);
             await assert.rejects(async () => {
@@ -508,10 +521,11 @@ describe('v1.AddressesClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.aggregatedList.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.aggregatedList.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -523,22 +537,16 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListAddressesRequest', ['region']);
             request.region = defaultValue2;
-            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -546,8 +554,12 @@ describe('v1.AddressesClient', () => {
             client.innerApiCalls.list = stubSimpleCall(expectedResponse);
             const [response] = await client.list(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.list as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes list without error using callback', async () => {
@@ -556,22 +568,16 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListAddressesRequest', ['region']);
             request.region = defaultValue2;
-            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -590,8 +596,12 @@ describe('v1.AddressesClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.list as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes list with error', async () => {
@@ -600,7 +610,9 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
@@ -608,18 +620,15 @@ describe('v1.AddressesClient', () => {
               getTypeDefaultValue('ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.list = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.list(request), expectedError);
-            assert((client.innerApiCalls.list as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.list as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listStream without error', async () => {
@@ -628,7 +637,9 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
@@ -659,10 +670,11 @@ describe('v1.AddressesClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.list.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.list, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.list.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -672,7 +684,9 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
@@ -698,10 +712,11 @@ describe('v1.AddressesClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.list.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.list, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.list.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -711,7 +726,9 @@ describe('v1.AddressesClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
@@ -734,10 +751,11 @@ describe('v1.AddressesClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.list.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.list.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -747,14 +765,17 @@ describe('v1.AddressesClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.ListAddressesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.ListAddressesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListAddressesRequest', ['region']);
             request.region = defaultValue2;
-            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.list.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listAsync(request);
             await assert.rejects(async () => {
@@ -766,10 +787,11 @@ describe('v1.AddressesClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.list.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.list.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -29,6 +29,7 @@ import {GoogleAuth, protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -165,7 +166,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.GetRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -176,19 +179,18 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.get = stubSimpleCall(expectedResponse);
             const [response] = await client.get(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.get as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes get without error using callback', async () => {
@@ -197,7 +199,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.GetRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -208,14 +212,9 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.get = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.get(
@@ -230,8 +229,12 @@ describe('v1.RegionOperationsClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.get as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes get with error', async () => {
@@ -240,7 +243,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.GetRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -251,18 +256,15 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.get = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.get(request), expectedError);
-            assert((client.innerApiCalls.get as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.get as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes get with closed client', async () => {
@@ -271,7 +273,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.GetRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -294,7 +298,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -305,19 +311,18 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.wait = stubSimpleCall(expectedResponse);
             const [response] = await client.wait(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes wait without error using callback', async () => {
@@ -326,7 +331,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -337,14 +344,9 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.compute.v1.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.compute.v1.Operation()
+            );
             client.innerApiCalls.wait = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.wait(
@@ -359,8 +361,12 @@ describe('v1.RegionOperationsClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes wait with error', async () => {
@@ -369,7 +375,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
@@ -380,18 +388,15 @@ describe('v1.RegionOperationsClient', () => {
               getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.wait(request), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.wait as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes wait with closed client', async () => {
@@ -400,7 +405,9 @@ describe('v1.RegionOperationsClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as regionoperationsModule from '../src';
 
 import {GoogleAuth, protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -154,10 +166,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -180,10 +198,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -217,10 +241,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -242,9 +272,15 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.GetRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.get(request), expectedError);
@@ -259,10 +295,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -285,10 +327,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -322,10 +370,16 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
-            const expectedHeaderRequestParams = "project=&region=&operation=";
+            const defaultValue1 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
+            const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -347,9 +401,15 @@ describe('v1.RegionOperationsClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.compute.v1.WaitRegionOperationRequest());
-            request.project = '';
-            request.region = '';
-            request.operation = '';
+            const defaultValue1 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+            request.project = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+            request.region = defaultValue2;
+            const defaultValue3 =
+              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+            request.operation = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.wait(request), expectedError);

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -154,14 +155,15 @@ describe('v1.DeprecatedServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.fastFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.fastFibonacci(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes fastFibonacci without error using callback', async () => {
@@ -170,9 +172,12 @@ describe('v1.DeprecatedServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.fastFibonacci = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.fastFibonacci(
@@ -187,8 +192,6 @@ describe('v1.DeprecatedServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes fastFibonacci with error', async () => {
@@ -197,13 +200,12 @@ describe('v1.DeprecatedServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.fastFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.fastFibonacci(request), expectedError);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes fastFibonacci with closed client', async () => {
@@ -212,7 +214,9 @@ describe('v1.DeprecatedServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.fastFibonacci(request), expectedError);
@@ -227,15 +231,16 @@ describe('v1.DeprecatedServiceClient', () => {
             });
             const stub = sinon.stub(client, 'warn');
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.slowFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.slowFibonacci(request);
             assert(stub.calledOnce);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes slowFibonacci without error using callback', async () => {
@@ -245,9 +250,12 @@ describe('v1.DeprecatedServiceClient', () => {
             });
             const stub = sinon.stub(client, 'warn');
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.slowFibonacci = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.slowFibonacci(
@@ -263,8 +271,6 @@ describe('v1.DeprecatedServiceClient', () => {
             const response = await promise;
             assert(stub.calledOnce);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes slowFibonacci with error', async () => {
@@ -274,14 +280,13 @@ describe('v1.DeprecatedServiceClient', () => {
             });
             const stub = sinon.stub(client, 'warn');
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.slowFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.slowFibonacci(request), expectedError);
             assert(stub.calledOnce);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes slowFibonacci with closed client', async () => {
@@ -291,7 +296,9 @@ describe('v1.DeprecatedServiceClient', () => {
             });
             const stub = sinon.stub(client, 'warn');
             client.initialize();
-            const request = generateSampleMessage(new protos.google.deprecatedtest.v1.FibonacciRequest());
+            const request = generateSampleMessage(
+              new protos.google.deprecatedtest.v1.FibonacciRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.slowFibonacci(request), expectedError);

--- a/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
+++ b/baselines/deprecatedtest/test/gapic_deprecated_service_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as deprecatedserviceModule from '../src';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -646,11 +646,11 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_int32': request.info!.fInt32 || '',
-      'info.f_double': request.info!.fDouble || '',
-      'info.f_bool': request.info!.fBool || '',
-      'info.f_kingdom': request.info!.fKingdom || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_int32': request.info!.fInt32 ?? '',
+      'info.f_double': request.info!.fDouble ?? '',
+      'info.f_bool': request.info!.fBool ?? '',
+      'info.f_kingdom': request.info!.fKingdom ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataSimplePath(request, options, callback);
@@ -734,9 +734,9 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_child.f_string': request.info!.fChild!.fString || '',
-      'info.f_bool': request.info!.fBool || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_child.f_string': request.info!.fChild!.fString ?? '',
+      'info.f_bool': request.info!.fBool ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataPathResource(request, options, callback);
@@ -820,8 +820,8 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_child.f_string': request.info!.fChild!.fString || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_child.f_string': request.info!.fChild!.fString ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataPathTrailingResource(request, options, callback);

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -463,7 +463,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getUser(request, options, callback);
@@ -537,7 +537,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'user.name': request.user!.name || '',
+      'user.name': request.user!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateUser(request, options, callback);
@@ -608,7 +608,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteUser(request, options, callback);

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -511,7 +511,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getRoom(request, options, callback);
@@ -585,7 +585,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'room.name': request.room!.name || '',
+      'room.name': request.room!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateRoom(request, options, callback);
@@ -656,7 +656,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteRoom(request, options, callback);
@@ -732,7 +732,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createBlurb(request, options, callback);
@@ -803,7 +803,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getBlurb(request, options, callback);
@@ -877,7 +877,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'blurb.name': request.blurb!.name || '',
+      'blurb.name': request.blurb!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateBlurb(request, options, callback);
@@ -948,7 +948,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteBlurb(request, options, callback);
@@ -985,7 +985,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.streamBlurbs(request, options);
@@ -1145,7 +1145,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.searchBlurbs(request, options, callback);
@@ -1409,7 +1409,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listBlurbs(request, options, callback);
@@ -1452,7 +1452,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1504,7 +1504,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -451,7 +451,7 @@ export class SequenceServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSequenceReport(request, options, callback);
@@ -521,7 +521,7 @@ export class SequenceServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.attemptSequence(request, options, callback);

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -468,7 +468,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSession(request, options, callback);
@@ -539,7 +539,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteSession(request, options, callback);
@@ -612,7 +612,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.reportSession(request, options, callback);
@@ -688,7 +688,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteTest(request, options, callback);
@@ -766,7 +766,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.verifyTest(request, options, callback);
@@ -999,7 +999,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listTests(request, options, callback);
@@ -1038,7 +1038,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTests'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1086,7 +1086,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTests'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -25,6 +25,18 @@ import * as complianceModule from '../src';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -359,17 +371,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -392,17 +414,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -436,17 +468,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -468,16 +510,26 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataSimplePath(request), expectedError);
@@ -492,14 +544,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -522,14 +580,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -563,14 +627,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -592,13 +662,19 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataPathResource(request), expectedError);
@@ -613,12 +689,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -641,12 +721,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -680,12 +764,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -707,11 +795,15 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataPathTrailingResource(request), expectedError);

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -154,14 +155,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBody = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBody(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBody without error using callback', async () => {
@@ -170,9 +172,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBody = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBody(
@@ -187,8 +192,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBody with error', async () => {
@@ -197,13 +200,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBody = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBody(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBody with closed client', async () => {
@@ -212,7 +214,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBody(request), expectedError);
@@ -226,14 +230,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyInfo(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyInfo without error using callback', async () => {
@@ -242,9 +247,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyInfo(
@@ -259,8 +267,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyInfo with error', async () => {
@@ -269,13 +275,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyInfo(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyInfo with closed client', async () => {
@@ -284,7 +289,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyInfo(request), expectedError);
@@ -298,14 +305,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataQuery = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataQuery(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataQuery without error using callback', async () => {
@@ -314,9 +322,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataQuery = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataQuery(
@@ -331,8 +342,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataQuery with error', async () => {
@@ -341,13 +350,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataQuery = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataQuery(request), expectedError);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataQuery with closed client', async () => {
@@ -356,7 +364,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataQuery(request), expectedError);
@@ -370,7 +380,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -392,19 +404,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataSimplePath(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath without error using callback', async () => {
@@ -413,7 +424,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -435,14 +448,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataSimplePath(
@@ -457,8 +465,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath with error', async () => {
@@ -467,7 +479,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -489,18 +503,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataSimplePath(request), expectedError);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath with closed client', async () => {
@@ -509,7 +520,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -543,7 +556,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -558,19 +573,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathResource = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataPathResource(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource without error using callback', async () => {
@@ -579,7 +593,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -594,14 +610,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathResource = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataPathResource(
@@ -616,8 +627,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource with error', async () => {
@@ -626,7 +641,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -641,18 +658,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataPathResource = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataPathResource(request), expectedError);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource with closed client', async () => {
@@ -661,7 +675,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -688,7 +704,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -699,19 +717,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataPathTrailingResource(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource without error using callback', async () => {
@@ -720,7 +737,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -731,14 +750,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataPathTrailingResource(
@@ -753,8 +767,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource with error', async () => {
@@ -763,7 +781,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -774,18 +794,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataPathTrailingResource(request), expectedError);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource with closed client', async () => {
@@ -794,7 +811,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -817,14 +836,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyPut(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPut without error using callback', async () => {
@@ -833,9 +853,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyPut(
@@ -850,8 +873,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyPut with error', async () => {
@@ -860,13 +881,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyPut(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPut with closed client', async () => {
@@ -875,7 +895,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyPut(request), expectedError);
@@ -889,14 +911,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyPatch(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPatch without error using callback', async () => {
@@ -905,9 +928,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyPatch(
@@ -922,8 +948,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyPatch with error', async () => {
@@ -932,13 +956,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyPatch(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPatch with closed client', async () => {
@@ -947,7 +970,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyPatch(request), expectedError);
@@ -961,14 +986,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.getEnum = stubSimpleCall(expectedResponse);
             const [response] = await client.getEnum(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getEnum without error using callback', async () => {
@@ -977,9 +1003,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.getEnum = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getEnum(
@@ -994,8 +1023,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes getEnum with error', async () => {
@@ -1004,13 +1031,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.getEnum = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getEnum(request), expectedError);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getEnum with closed client', async () => {
@@ -1019,7 +1045,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getEnum(request), expectedError);
@@ -1033,14 +1061,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.verifyEnum = stubSimpleCall(expectedResponse);
             const [response] = await client.verifyEnum(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes verifyEnum without error using callback', async () => {
@@ -1049,9 +1078,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.verifyEnum = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.verifyEnum(
@@ -1066,8 +1098,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes verifyEnum with error', async () => {
@@ -1076,13 +1106,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.verifyEnum = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.verifyEnum(request), expectedError);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes verifyEnum with closed client', async () => {
@@ -1091,7 +1120,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.verifyEnum(request), expectedError);

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -256,7 +256,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -282,7 +282,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -319,7 +319,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -250,46 +251,24 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCall(expectedResponse);
             const [response] = await client.echo(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo without error using callback', async () => {
@@ -298,41 +277,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.echo(
@@ -347,8 +300,12 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with error', async () => {
@@ -357,45 +314,21 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with closed client', async () => {
@@ -404,21 +337,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            // path template is empty
-            request.header = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
             const expectedError = new Error('The client has already been closed.');
@@ -434,14 +355,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpandLegacy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy without error using callback', async () => {
@@ -450,9 +372,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.pagedExpandLegacy(
@@ -467,8 +392,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpandLegacy with error', async () => {
@@ -477,13 +400,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy with closed client', async () => {
@@ -492,7 +414,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
@@ -506,14 +430,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCall(expectedResponse);
             const [response] = await client.block(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block without error using callback', async () => {
@@ -522,9 +447,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.block(
@@ -539,8 +467,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes block with error', async () => {
@@ -549,13 +475,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.block = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.block(request), expectedError);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block with closed client', async () => {
@@ -564,7 +489,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.block(request), expectedError);
@@ -578,15 +505,16 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCall(expectedResponse);
             const [operation] = await client.wait(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait without error using callback', async () => {
@@ -595,9 +523,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.wait(
@@ -615,8 +546,6 @@ describe('v1beta1.EchoClient', () => {
             const operation = await promise as LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes wait with call error', async () => {
@@ -625,13 +554,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.wait(request), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait with LRO error', async () => {
@@ -640,14 +568,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.wait(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkWaitProgress without error', async () => {
@@ -656,7 +583,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -690,9 +619,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
             const stream = client.expand(request);
             const promise = new Promise((resolve, reject) => {
@@ -705,8 +637,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with error', async () => {
@@ -715,8 +645,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.expand = stubServerStreamingCall(undefined, expectedError);
             const stream = client.expand(request);
@@ -729,8 +660,6 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with closed client', async () => {
@@ -739,7 +668,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.expand(request);
@@ -762,8 +693,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.chat = stubBidiStreamingCall(expectedResponse);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {
@@ -790,7 +726,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
@@ -819,8 +757,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.collect = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
@@ -848,7 +791,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.collect = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -877,9 +822,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -887,8 +832,6 @@ describe('v1beta1.EchoClient', () => {
             client.innerApiCalls.pagedExpand = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpand(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpand without error using callback', async () => {
@@ -897,9 +840,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -918,8 +861,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpand with error', async () => {
@@ -928,13 +869,12 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpand = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpand(request), expectedError);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandStream without error', async () => {
@@ -943,7 +883,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -975,7 +917,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.pagedExpandStream(request);
@@ -1002,7 +946,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -1026,7 +972,10 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.pagedExpandAsync(request);
             await assert.rejects(async () => {

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -262,8 +274,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -286,8 +300,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -321,8 +337,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -344,7 +362,9 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getUser(request), expectedError);
@@ -359,9 +379,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -384,9 +406,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -420,9 +444,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -444,8 +470,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateUser(request), expectedError);
@@ -460,8 +488,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -484,8 +514,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -519,8 +551,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -542,7 +576,9 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteUser(request), expectedError);

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,14 +202,15 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.createUser = stubSimpleCall(expectedResponse);
             const [response] = await client.createUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createUser without error using callback', async () => {
@@ -217,9 +219,12 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.createUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createUser(
@@ -234,8 +239,6 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createUser with error', async () => {
@@ -244,13 +247,12 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createUser(request), expectedError);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createUser with closed client', async () => {
@@ -259,7 +261,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createUser(request), expectedError);
@@ -273,24 +277,25 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.getUser = stubSimpleCall(expectedResponse);
             const [response] = await client.getUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser without error using callback', async () => {
@@ -299,19 +304,16 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.getUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getUser(
@@ -326,8 +328,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser with error', async () => {
@@ -336,23 +342,22 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getUser(request), expectedError);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser with closed client', async () => {
@@ -361,7 +366,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
@@ -378,25 +385,26 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.updateUser = stubSimpleCall(expectedResponse);
             const [response] = await client.updateUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser without error using callback', async () => {
@@ -405,20 +413,17 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.updateUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateUser(
@@ -433,8 +438,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser with error', async () => {
@@ -443,24 +452,23 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateUser(request), expectedError);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser with closed client', async () => {
@@ -469,7 +477,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
@@ -487,24 +497,25 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUser = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser without error using callback', async () => {
@@ -513,19 +524,16 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteUser(
@@ -540,8 +548,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser with error', async () => {
@@ -550,23 +562,22 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteUser(request), expectedError);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser with closed client', async () => {
@@ -575,7 +586,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
@@ -592,9 +605,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -602,8 +615,6 @@ describe('v1beta1.IdentityClient', () => {
             client.innerApiCalls.listUsers = stubSimpleCall(expectedResponse);
             const [response] = await client.listUsers(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUsers without error using callback', async () => {
@@ -612,9 +623,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -633,8 +644,6 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listUsers with error', async () => {
@@ -643,13 +652,12 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listUsers = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listUsers(request), expectedError);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUsersStream without error', async () => {
@@ -658,7 +666,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -690,7 +700,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listUsers.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listUsersStream(request);
@@ -717,7 +729,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -741,7 +755,10 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listUsersAsync(request);
             await assert.rejects(async () => {

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -311,8 +323,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -335,8 +349,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -370,8 +386,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -393,7 +411,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getRoom(request), expectedError);
@@ -408,9 +428,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -433,9 +455,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,9 +493,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -493,8 +519,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateRoom(request), expectedError);
@@ -509,8 +537,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -533,8 +563,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -568,8 +600,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -591,7 +625,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteRoom(request), expectedError);
@@ -606,8 +642,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -630,8 +668,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -665,8 +705,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -688,7 +730,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createBlurb(request), expectedError);
@@ -703,8 +747,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -727,8 +773,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -762,8 +810,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -785,7 +835,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getBlurb(request), expectedError);
@@ -800,9 +852,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -825,9 +879,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -861,9 +917,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -885,8 +943,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateBlurb(request), expectedError);
@@ -901,8 +961,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -925,8 +987,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -960,8 +1024,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -983,7 +1049,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteBlurb(request), expectedError);
@@ -998,8 +1066,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1023,8 +1093,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1061,8 +1133,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1084,8 +1158,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1142,8 +1218,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1175,8 +1253,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1207,7 +1287,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.streamBlurbs(request);
@@ -1517,8 +1599,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1545,8 +1629,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1584,8 +1670,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1607,8 +1695,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1646,8 +1736,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listBlurbsStream(request);
@@ -1680,8 +1772,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1711,8 +1805,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBlurbsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -250,14 +251,15 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.createRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.createRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createRoom without error using callback', async () => {
@@ -266,9 +268,12 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.createRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createRoom(
@@ -283,8 +288,6 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createRoom with error', async () => {
@@ -293,13 +296,12 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createRoom(request), expectedError);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createRoom with closed client', async () => {
@@ -308,7 +310,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createRoom(request), expectedError);
@@ -322,24 +326,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.getRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.getRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom without error using callback', async () => {
@@ -348,19 +353,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.getRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getRoom(
@@ -375,8 +377,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom with error', async () => {
@@ -385,23 +391,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getRoom(request), expectedError);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom with closed client', async () => {
@@ -410,7 +415,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
@@ -427,25 +434,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.updateRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.updateRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom without error using callback', async () => {
@@ -454,20 +462,17 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.updateRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateRoom(
@@ -482,8 +487,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom with error', async () => {
@@ -492,24 +501,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateRoom(request), expectedError);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom with closed client', async () => {
@@ -518,7 +526,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
@@ -536,24 +546,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom without error using callback', async () => {
@@ -562,19 +573,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteRoom(
@@ -589,8 +597,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom with error', async () => {
@@ -599,23 +611,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteRoom(request), expectedError);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom with closed client', async () => {
@@ -624,7 +635,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
@@ -641,24 +654,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.createBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.createBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb without error using callback', async () => {
@@ -667,19 +681,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.createBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createBlurb(
@@ -694,8 +705,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb with error', async () => {
@@ -704,23 +719,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createBlurb(request), expectedError);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb with closed client', async () => {
@@ -729,7 +743,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
@@ -746,24 +762,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.getBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.getBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb without error using callback', async () => {
@@ -772,19 +789,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.getBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getBlurb(
@@ -799,8 +813,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb with error', async () => {
@@ -809,23 +827,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getBlurb(request), expectedError);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb with closed client', async () => {
@@ -834,7 +851,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
@@ -851,25 +870,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.updateBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.updateBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb without error using callback', async () => {
@@ -878,20 +898,17 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.updateBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateBlurb(
@@ -906,8 +923,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb with error', async () => {
@@ -916,24 +937,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateBlurb(request), expectedError);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb with closed client', async () => {
@@ -942,7 +962,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
@@ -960,24 +982,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb without error using callback', async () => {
@@ -986,19 +1009,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteBlurb(
@@ -1013,8 +1033,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb with error', async () => {
@@ -1023,23 +1047,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteBlurb(request), expectedError);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb with closed client', async () => {
@@ -1048,7 +1071,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
@@ -1065,25 +1090,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(expectedResponse);
             const [operation] = await client.searchBlurbs(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs without error using callback', async () => {
@@ -1092,19 +1118,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.searchBlurbs = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.searchBlurbs(
@@ -1122,8 +1145,12 @@ describe('v1beta1.MessagingClient', () => {
             const operation = await promise as LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs with call error', async () => {
@@ -1132,23 +1159,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.searchBlurbs(request), expectedError);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs with LRO error', async () => {
@@ -1157,24 +1183,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.searchBlurbs(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkSearchBlurbsProgress without error', async () => {
@@ -1183,7 +1208,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1217,19 +1244,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
             client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
             const stream = client.streamBlurbs(request);
             const promise = new Promise((resolve, reject) => {
@@ -1242,8 +1266,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.streamBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes streamBlurbs with error', async () => {
@@ -1252,18 +1280,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.streamBlurbs = stubServerStreamingCall(undefined, expectedError);
             const stream = client.streamBlurbs(request);
@@ -1276,8 +1299,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.streamBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes streamBlurbs with closed client', async () => {
@@ -1286,7 +1313,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
@@ -1312,8 +1341,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ConnectRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
             client.innerApiCalls.connect = stubBidiStreamingCall(expectedResponse);
             const stream = client.connect();
             const promise = new Promise((resolve, reject) => {
@@ -1340,7 +1374,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ConnectRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.connect();
@@ -1369,8 +1405,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SendBlurbsResponse()
+            );
             client.innerApiCalls.sendBlurbs = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
@@ -1398,7 +1439,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.sendBlurbs = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -1427,9 +1470,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1437,8 +1480,6 @@ describe('v1beta1.MessagingClient', () => {
             client.innerApiCalls.listRooms = stubSimpleCall(expectedResponse);
             const [response] = await client.listRooms(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listRooms without error using callback', async () => {
@@ -1447,9 +1488,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1468,8 +1509,6 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listRooms with error', async () => {
@@ -1478,13 +1517,12 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listRooms = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listRooms(request), expectedError);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listRoomsStream without error', async () => {
@@ -1493,7 +1531,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1525,7 +1565,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listRooms.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listRoomsStream(request);
@@ -1552,7 +1594,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1576,7 +1620,10 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listRoomsAsync(request);
             await assert.rejects(async () => {
@@ -1598,19 +1645,13 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1618,8 +1659,12 @@ describe('v1beta1.MessagingClient', () => {
             client.innerApiCalls.listBlurbs = stubSimpleCall(expectedResponse);
             const [response] = await client.listBlurbs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbs without error using callback', async () => {
@@ -1628,19 +1673,13 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1659,8 +1698,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbs with error', async () => {
@@ -1669,23 +1712,22 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listBlurbs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listBlurbs(request), expectedError);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbsStream without error', async () => {
@@ -1694,7 +1736,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1722,10 +1766,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listBlurbs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBlurbs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1735,7 +1780,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1758,10 +1805,11 @@ describe('v1beta1.MessagingClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listBlurbs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBlurbs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1771,7 +1819,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1791,10 +1841,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1804,11 +1855,14 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBlurbsAsync(request);
             await assert.rejects(async () => {
@@ -1820,10 +1874,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -154,14 +155,15 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Sequence());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Sequence()
+            );
             client.innerApiCalls.createSequence = stubSimpleCall(expectedResponse);
             const [response] = await client.createSequence(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSequence without error using callback', async () => {
@@ -170,9 +172,12 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Sequence());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Sequence()
+            );
             client.innerApiCalls.createSequence = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createSequence(
@@ -187,8 +192,6 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createSequence with error', async () => {
@@ -197,13 +200,12 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createSequence = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createSequence(request), expectedError);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSequence with closed client', async () => {
@@ -212,7 +214,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createSequence(request), expectedError);
@@ -226,24 +230,25 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SequenceReport());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SequenceReport()
+            );
             client.innerApiCalls.getSequenceReport = stubSimpleCall(expectedResponse);
             const [response] = await client.getSequenceReport(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport without error using callback', async () => {
@@ -252,19 +257,16 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SequenceReport());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SequenceReport()
+            );
             client.innerApiCalls.getSequenceReport = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSequenceReport(
@@ -279,8 +281,12 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport with error', async () => {
@@ -289,23 +295,22 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSequenceReport = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSequenceReport(request), expectedError);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport with closed client', async () => {
@@ -314,7 +319,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
@@ -331,24 +338,25 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.attemptSequence = stubSimpleCall(expectedResponse);
             const [response] = await client.attemptSequence(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence without error using callback', async () => {
@@ -357,19 +365,16 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.attemptSequence = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.attemptSequence(
@@ -384,8 +389,12 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence with error', async () => {
@@ -394,23 +403,22 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.attemptSequence = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.attemptSequence(request), expectedError);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence with closed client', async () => {
@@ -419,7 +427,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -25,6 +25,18 @@ import * as sequenceserviceModule from '../src';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -215,8 +227,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -239,8 +253,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -274,8 +290,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -297,7 +315,9 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSequenceReport(request), expectedError);
@@ -312,8 +332,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -336,8 +358,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -371,8 +395,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -394,7 +420,9 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.attemptSequence(request), expectedError);

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,14 +202,15 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.createSession = stubSimpleCall(expectedResponse);
             const [response] = await client.createSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSession without error using callback', async () => {
@@ -217,9 +219,12 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.createSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createSession(
@@ -234,8 +239,6 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createSession with error', async () => {
@@ -244,13 +247,12 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createSession(request), expectedError);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSession with closed client', async () => {
@@ -259,7 +261,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createSession(request), expectedError);
@@ -273,24 +277,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.getSession = stubSimpleCall(expectedResponse);
             const [response] = await client.getSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession without error using callback', async () => {
@@ -299,19 +304,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.getSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSession(
@@ -326,8 +328,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession with error', async () => {
@@ -336,23 +342,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSession(request), expectedError);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession with closed client', async () => {
@@ -361,7 +366,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -378,24 +385,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSession = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession without error using callback', async () => {
@@ -404,19 +412,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteSession(
@@ -431,8 +436,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession with error', async () => {
@@ -441,23 +450,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteSession(request), expectedError);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession with closed client', async () => {
@@ -466,7 +474,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -483,24 +493,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionResponse()
+            );
             client.innerApiCalls.reportSession = stubSimpleCall(expectedResponse);
             const [response] = await client.reportSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession without error using callback', async () => {
@@ -509,19 +520,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionResponse()
+            );
             client.innerApiCalls.reportSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.reportSession(
@@ -536,8 +544,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession with error', async () => {
@@ -546,23 +558,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.reportSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.reportSession(request), expectedError);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession with closed client', async () => {
@@ -571,7 +582,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -588,24 +601,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTest = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteTest(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest without error using callback', async () => {
@@ -614,19 +628,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTest = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteTest(
@@ -641,8 +652,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest with error', async () => {
@@ -651,23 +666,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteTest = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteTest(request), expectedError);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest with closed client', async () => {
@@ -676,7 +690,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
@@ -693,24 +709,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestResponse()
+            );
             client.innerApiCalls.verifyTest = stubSimpleCall(expectedResponse);
             const [response] = await client.verifyTest(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest without error using callback', async () => {
@@ -719,19 +736,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestResponse()
+            );
             client.innerApiCalls.verifyTest = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.verifyTest(
@@ -746,8 +760,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest with error', async () => {
@@ -756,23 +774,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.verifyTest = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.verifyTest(request), expectedError);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest with closed client', async () => {
@@ -781,7 +798,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
@@ -798,9 +817,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -808,8 +827,6 @@ describe('v1beta1.TestingClient', () => {
             client.innerApiCalls.listSessions = stubSimpleCall(expectedResponse);
             const [response] = await client.listSessions(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listSessions without error using callback', async () => {
@@ -818,9 +835,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -839,8 +856,6 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listSessions with error', async () => {
@@ -849,13 +864,12 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listSessions = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listSessions(request), expectedError);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listSessionsStream without error', async () => {
@@ -864,7 +878,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -896,7 +912,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listSessions.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listSessionsStream(request);
@@ -923,7 +941,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -947,7 +967,10 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listSessionsAsync(request);
             await assert.rejects(async () => {
@@ -969,19 +992,13 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -989,8 +1006,12 @@ describe('v1beta1.TestingClient', () => {
             client.innerApiCalls.listTests = stubSimpleCall(expectedResponse);
             const [response] = await client.listTests(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTests without error using callback', async () => {
@@ -999,19 +1020,13 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1030,8 +1045,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTests with error', async () => {
@@ -1040,23 +1059,22 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listTests = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listTests(request), expectedError);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTestsStream without error', async () => {
@@ -1065,7 +1083,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1093,10 +1113,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listTests.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTests, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1106,7 +1127,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1129,10 +1152,11 @@ describe('v1beta1.TestingClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listTests.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTests, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1142,7 +1166,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1162,10 +1188,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1175,11 +1202,14 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listTests.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTestsAsync(request);
             await assert.rejects(async () => {
@@ -1191,10 +1221,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -262,8 +274,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -286,8 +300,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -321,8 +337,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -344,7 +362,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSession(request), expectedError);
@@ -359,8 +379,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -383,8 +405,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -418,8 +442,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -441,7 +467,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteSession(request), expectedError);
@@ -456,8 +484,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -480,8 +510,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -515,8 +547,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -538,7 +572,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.reportSession(request), expectedError);
@@ -553,8 +589,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -577,8 +615,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -612,8 +652,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -635,7 +677,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteTest(request), expectedError);
@@ -650,8 +694,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -674,8 +720,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -709,8 +757,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -732,7 +782,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.verifyTest(request), expectedError);
@@ -918,8 +970,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -946,8 +1000,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -985,8 +1041,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1008,8 +1066,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1047,8 +1107,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listTests.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listTestsStream(request);
@@ -1081,8 +1143,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1112,8 +1176,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listTests.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTestsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -434,8 +434,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.inspectContent(request, options, callback);
@@ -525,8 +525,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.redactImage(request, options, callback);
@@ -629,8 +629,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deidentifyContent(request, options, callback);
@@ -735,8 +735,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.reidentifyContent(request, options, callback);
@@ -817,7 +817,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'location_id': request.locationId || '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listInfoTypes(request, options, callback);
@@ -901,8 +901,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createInspectTemplate(request, options, callback);
@@ -980,7 +980,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateInspectTemplate(request, options, callback);
@@ -1054,7 +1054,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getInspectTemplate(request, options, callback);
@@ -1128,7 +1128,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteInspectTemplate(request, options, callback);
@@ -1213,8 +1213,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createDeidentifyTemplate(request, options, callback);
@@ -1293,7 +1293,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateDeidentifyTemplate(request, options, callback);
@@ -1368,7 +1368,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getDeidentifyTemplate(request, options, callback);
@@ -1443,7 +1443,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteDeidentifyTemplate(request, options, callback);
@@ -1526,8 +1526,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createJobTrigger(request, options, callback);
@@ -1604,7 +1604,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateJobTrigger(request, options, callback);
@@ -1677,7 +1677,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getJobTrigger(request, options, callback);
@@ -1750,7 +1750,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteJobTrigger(request, options, callback);
@@ -1823,7 +1823,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.activateJobTrigger(request, options, callback);
@@ -1912,8 +1912,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createDlpJob(request, options, callback);
@@ -1986,7 +1986,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getDlpJob(request, options, callback);
@@ -2061,7 +2061,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteDlpJob(request, options, callback);
@@ -2136,7 +2136,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.cancelDlpJob(request, options, callback);
@@ -2220,8 +2220,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createStoredInfoType(request, options, callback);
@@ -2303,7 +2303,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateStoredInfoType(request, options, callback);
@@ -2378,7 +2378,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getStoredInfoType(request, options, callback);
@@ -2453,7 +2453,7 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteStoredInfoType(request, options, callback);
@@ -2555,8 +2555,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listInspectTemplates(request, options, callback);
@@ -2615,8 +2615,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listInspectTemplates'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2684,8 +2684,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listInspectTemplates'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2793,8 +2793,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listDeidentifyTemplates(request, options, callback);
@@ -2853,8 +2853,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listDeidentifyTemplates'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2922,8 +2922,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listDeidentifyTemplates'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3056,8 +3056,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listJobTriggers(request, options, callback);
@@ -3142,8 +3142,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listJobTriggers'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3237,8 +3237,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listJobTriggers'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3374,8 +3374,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listDlpJobs(request, options, callback);
@@ -3462,8 +3462,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listDlpJobs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3559,8 +3559,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listDlpJobs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3669,8 +3669,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listStoredInfoTypes(request, options, callback);
@@ -3730,8 +3730,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listStoredInfoTypes'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3800,8 +3800,8 @@ export class DlpServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
-      'location_id': request.locationId || '',
+      'parent': request.parent ?? '',
+      'location_id': request.locationId ?? '',
     });
     const defaultCallSettings = this._defaults['listStoredInfoTypes'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,9 +202,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('InspectContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -215,9 +231,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('InspectContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -251,9 +271,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('InspectContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -275,8 +299,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('InspectContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.inspectContent(request), expectedError);
@@ -291,9 +319,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('RedactImageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -316,9 +348,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('RedactImageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -352,9 +388,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('RedactImageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -376,8 +416,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('RedactImageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.redactImage(request), expectedError);
@@ -392,9 +436,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -417,9 +465,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -453,9 +505,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -477,8 +533,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deidentifyContent(request), expectedError);
@@ -493,9 +553,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -518,9 +582,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -554,9 +622,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -578,8 +650,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.reidentifyContent(request), expectedError);
@@ -594,8 +670,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
-            request.locationId = '';
-            const expectedHeaderRequestParams = "location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue1;
+            const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -618,8 +696,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
-            request.locationId = '';
-            const expectedHeaderRequestParams = "location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue1;
+            const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -653,8 +733,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
-            request.locationId = '';
-            const expectedHeaderRequestParams = "location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue1;
+            const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -676,7 +758,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.listInfoTypes(request), expectedError);
@@ -691,9 +775,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -716,9 +804,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -752,9 +844,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -776,8 +872,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createInspectTemplate(request), expectedError);
@@ -792,8 +892,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -816,8 +918,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -851,8 +955,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -874,7 +980,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateInspectTemplate(request), expectedError);
@@ -889,8 +997,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -913,8 +1023,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -948,8 +1060,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -971,7 +1085,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getInspectTemplate(request), expectedError);
@@ -986,8 +1102,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1010,8 +1128,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1045,8 +1165,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1068,7 +1190,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteInspectTemplate(request), expectedError);
@@ -1083,9 +1207,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1108,9 +1236,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1144,9 +1276,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1168,8 +1304,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createDeidentifyTemplate(request), expectedError);
@@ -1184,8 +1324,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1208,8 +1350,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1243,8 +1387,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1266,7 +1412,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateDeidentifyTemplate(request), expectedError);
@@ -1281,8 +1429,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1305,8 +1455,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1340,8 +1492,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1363,7 +1517,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getDeidentifyTemplate(request), expectedError);
@@ -1378,8 +1534,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1402,8 +1560,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1437,8 +1597,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1460,7 +1622,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteDeidentifyTemplate(request), expectedError);
@@ -1475,9 +1639,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1500,9 +1668,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1536,9 +1708,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1560,8 +1736,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createJobTrigger(request), expectedError);
@@ -1576,8 +1756,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1600,8 +1782,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1635,8 +1819,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1658,7 +1844,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateJobTrigger(request), expectedError);
@@ -1673,8 +1861,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1697,8 +1887,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1732,8 +1924,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1755,7 +1949,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getJobTrigger(request), expectedError);
@@ -1770,8 +1966,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1794,8 +1992,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1829,8 +2029,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1852,7 +2054,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteJobTrigger(request), expectedError);
@@ -1867,8 +2071,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1891,8 +2097,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1926,8 +2134,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1949,7 +2159,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.activateJobTrigger(request), expectedError);
@@ -1964,9 +2176,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1989,9 +2205,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2025,9 +2245,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2049,8 +2273,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createDlpJob(request), expectedError);
@@ -2065,8 +2293,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2089,8 +2319,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2124,8 +2356,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2147,7 +2381,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getDlpJob(request), expectedError);
@@ -2162,8 +2398,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2186,8 +2424,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2221,8 +2461,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2244,7 +2486,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteDlpJob(request), expectedError);
@@ -2259,8 +2503,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2283,8 +2529,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2318,8 +2566,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2341,7 +2591,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.cancelDlpJob(request), expectedError);
@@ -2356,9 +2608,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2381,9 +2637,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2417,9 +2677,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2441,8 +2705,12 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
-            request.parent = '';
-            request.locationId = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+            request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createStoredInfoType(request), expectedError);
@@ -2457,8 +2725,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2481,8 +2751,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2516,8 +2788,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2539,7 +2813,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateStoredInfoType(request), expectedError);
@@ -2554,8 +2830,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2578,8 +2856,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2613,8 +2893,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2636,7 +2918,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getStoredInfoType(request), expectedError);
@@ -2651,8 +2935,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2675,8 +2961,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2710,8 +2998,10 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2733,7 +3023,9 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteStoredInfoType(request), expectedError);
@@ -2748,9 +3040,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2777,9 +3073,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2817,9 +3117,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2841,9 +3145,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -2881,9 +3189,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listInspectTemplates.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listInspectTemplatesStream(request);
@@ -2916,9 +3228,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -2948,9 +3264,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.listInspectTemplates.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listInspectTemplatesAsync(request);
             await assert.rejects(async () => {
@@ -2978,9 +3298,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3007,9 +3331,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3047,9 +3375,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3071,9 +3403,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3111,9 +3447,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listDeidentifyTemplates.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listDeidentifyTemplatesStream(request);
@@ -3146,9 +3486,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3178,9 +3522,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.listDeidentifyTemplates.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listDeidentifyTemplatesAsync(request);
             await assert.rejects(async () => {
@@ -3208,9 +3556,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3237,9 +3589,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3277,9 +3633,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3301,9 +3661,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3341,9 +3705,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listJobTriggers.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listJobTriggersStream(request);
@@ -3376,9 +3744,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3408,9 +3780,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.listJobTriggers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listJobTriggersAsync(request);
             await assert.rejects(async () => {
@@ -3438,9 +3814,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3467,9 +3847,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3507,9 +3891,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3531,9 +3919,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3571,9 +3963,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listDlpJobs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listDlpJobsStream(request);
@@ -3606,9 +4002,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3638,9 +4038,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.listDlpJobs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listDlpJobsAsync(request);
             await assert.rejects(async () => {
@@ -3668,9 +4072,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3697,9 +4105,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3737,9 +4149,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3761,9 +4177,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -3801,9 +4221,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listStoredInfoTypes.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listStoredInfoTypesStream(request);
@@ -3836,9 +4260,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -3868,9 +4296,13 @@ describe('v2.DlpServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
-            request.parent = '';
-            request.locationId = '';
-            const expectedHeaderRequestParams = "parent=&location_id=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const defaultValue2 =
+              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+            request.locationId = defaultValue2;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
             client.descriptors.page.listStoredInfoTypes.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listStoredInfoTypesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,7 +202,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -209,19 +212,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentResponse()
+            );
             client.innerApiCalls.inspectContent = stubSimpleCall(expectedResponse);
             const [response] = await client.inspectContent(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.inspectContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes inspectContent without error using callback', async () => {
@@ -230,7 +232,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -238,14 +242,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentResponse()
+            );
             client.innerApiCalls.inspectContent = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.inspectContent(
@@ -260,8 +259,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.inspectContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes inspectContent with error', async () => {
@@ -270,7 +273,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -278,18 +283,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.inspectContent = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.inspectContent(request), expectedError);
-            assert((client.innerApiCalls.inspectContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.inspectContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes inspectContent with closed client', async () => {
@@ -298,7 +300,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -318,7 +322,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
@@ -326,19 +332,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageResponse()
+            );
             client.innerApiCalls.redactImage = stubSimpleCall(expectedResponse);
             const [response] = await client.redactImage(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.redactImage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes redactImage without error using callback', async () => {
@@ -347,7 +352,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
@@ -355,14 +362,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageResponse()
+            );
             client.innerApiCalls.redactImage = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.redactImage(
@@ -377,8 +379,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.redactImage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes redactImage with error', async () => {
@@ -387,7 +393,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
@@ -395,18 +403,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.redactImage = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.redactImage(request), expectedError);
-            assert((client.innerApiCalls.redactImage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.redactImage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes redactImage with closed client', async () => {
@@ -415,7 +420,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.RedactImageRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.RedactImageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
@@ -435,7 +442,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -443,19 +452,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentResponse()
+            );
             client.innerApiCalls.deidentifyContent = stubSimpleCall(expectedResponse);
             const [response] = await client.deidentifyContent(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deidentifyContent without error using callback', async () => {
@@ -464,7 +472,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -472,14 +482,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentResponse()
+            );
             client.innerApiCalls.deidentifyContent = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deidentifyContent(
@@ -494,8 +499,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deidentifyContent with error', async () => {
@@ -504,7 +513,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -512,18 +523,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deidentifyContent = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deidentifyContent(request), expectedError);
-            assert((client.innerApiCalls.deidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deidentifyContent with closed client', async () => {
@@ -532,7 +540,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -552,7 +562,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -560,19 +572,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentResponse()
+            );
             client.innerApiCalls.reidentifyContent = stubSimpleCall(expectedResponse);
             const [response] = await client.reidentifyContent(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reidentifyContent without error using callback', async () => {
@@ -581,7 +592,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -589,14 +602,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentResponse()
+            );
             client.innerApiCalls.reidentifyContent = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.reidentifyContent(
@@ -611,8 +619,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reidentifyContent with error', async () => {
@@ -621,7 +633,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -629,18 +643,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.reidentifyContent = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.reidentifyContent(request), expectedError);
-            assert((client.innerApiCalls.reidentifyContent as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reidentifyContent as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reidentifyContent with closed client', async () => {
@@ -649,7 +660,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ReidentifyContentRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
@@ -669,24 +682,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesResponse()
+            );
             client.innerApiCalls.listInfoTypes = stubSimpleCall(expectedResponse);
             const [response] = await client.listInfoTypes(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInfoTypes without error using callback', async () => {
@@ -695,19 +709,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesResponse()
+            );
             client.innerApiCalls.listInfoTypes = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.listInfoTypes(
@@ -722,8 +733,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInfoTypes with error', async () => {
@@ -732,23 +747,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listInfoTypes = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listInfoTypes(request), expectedError);
-            assert((client.innerApiCalls.listInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInfoTypes with closed client', async () => {
@@ -757,7 +771,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
@@ -774,7 +790,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -782,19 +800,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.createInspectTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.createInspectTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInspectTemplate without error using callback', async () => {
@@ -803,7 +820,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -811,14 +830,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.createInspectTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createInspectTemplate(
@@ -833,8 +847,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInspectTemplate with error', async () => {
@@ -843,7 +861,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -851,18 +871,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createInspectTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createInspectTemplate(request), expectedError);
-            assert((client.innerApiCalls.createInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInspectTemplate with closed client', async () => {
@@ -871,7 +888,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -891,24 +910,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.updateInspectTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.updateInspectTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInspectTemplate without error using callback', async () => {
@@ -917,19 +937,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.updateInspectTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateInspectTemplate(
@@ -944,8 +961,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInspectTemplate with error', async () => {
@@ -954,23 +975,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateInspectTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateInspectTemplate(request), expectedError);
-            assert((client.innerApiCalls.updateInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInspectTemplate with closed client', async () => {
@@ -979,7 +999,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -996,24 +1018,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.getInspectTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.getInspectTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInspectTemplate without error using callback', async () => {
@@ -1022,19 +1045,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.InspectTemplate()
+            );
             client.innerApiCalls.getInspectTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getInspectTemplate(
@@ -1049,8 +1069,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInspectTemplate with error', async () => {
@@ -1059,23 +1083,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getInspectTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getInspectTemplate(request), expectedError);
-            assert((client.innerApiCalls.getInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInspectTemplate with closed client', async () => {
@@ -1084,7 +1107,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -1101,24 +1126,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteInspectTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteInspectTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInspectTemplate without error using callback', async () => {
@@ -1127,19 +1153,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteInspectTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteInspectTemplate(
@@ -1154,8 +1177,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInspectTemplate with error', async () => {
@@ -1164,23 +1191,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteInspectTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteInspectTemplate(request), expectedError);
-            assert((client.innerApiCalls.deleteInspectTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInspectTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInspectTemplate with closed client', async () => {
@@ -1189,7 +1215,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -1206,7 +1234,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1214,19 +1244,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.createDeidentifyTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.createDeidentifyTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDeidentifyTemplate without error using callback', async () => {
@@ -1235,7 +1264,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1243,14 +1274,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.createDeidentifyTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createDeidentifyTemplate(
@@ -1265,8 +1291,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDeidentifyTemplate with error', async () => {
@@ -1275,7 +1305,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1283,18 +1315,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createDeidentifyTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createDeidentifyTemplate(request), expectedError);
-            assert((client.innerApiCalls.createDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDeidentifyTemplate with closed client', async () => {
@@ -1303,7 +1332,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1323,24 +1354,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.updateDeidentifyTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.updateDeidentifyTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateDeidentifyTemplate without error using callback', async () => {
@@ -1349,19 +1381,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.updateDeidentifyTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateDeidentifyTemplate(
@@ -1376,8 +1405,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateDeidentifyTemplate with error', async () => {
@@ -1386,23 +1419,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateDeidentifyTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateDeidentifyTemplate(request), expectedError);
-            assert((client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateDeidentifyTemplate with closed client', async () => {
@@ -1411,7 +1443,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -1428,24 +1462,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.getDeidentifyTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.getDeidentifyTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDeidentifyTemplate without error using callback', async () => {
@@ -1454,19 +1489,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeidentifyTemplate()
+            );
             client.innerApiCalls.getDeidentifyTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getDeidentifyTemplate(
@@ -1481,8 +1513,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDeidentifyTemplate with error', async () => {
@@ -1491,23 +1527,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getDeidentifyTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getDeidentifyTemplate(request), expectedError);
-            assert((client.innerApiCalls.getDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDeidentifyTemplate with closed client', async () => {
@@ -1516,7 +1551,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -1533,24 +1570,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteDeidentifyTemplate = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteDeidentifyTemplate(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDeidentifyTemplate without error using callback', async () => {
@@ -1559,19 +1597,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteDeidentifyTemplate = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteDeidentifyTemplate(
@@ -1586,8 +1621,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDeidentifyTemplate with error', async () => {
@@ -1596,23 +1635,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteDeidentifyTemplate = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteDeidentifyTemplate(request), expectedError);
-            assert((client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDeidentifyTemplate as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDeidentifyTemplate with closed client', async () => {
@@ -1621,7 +1659,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
@@ -1638,7 +1678,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1646,19 +1688,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.createJobTrigger = stubSimpleCall(expectedResponse);
             const [response] = await client.createJobTrigger(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createJobTrigger without error using callback', async () => {
@@ -1667,7 +1708,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1675,14 +1718,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.createJobTrigger = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createJobTrigger(
@@ -1697,8 +1735,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createJobTrigger with error', async () => {
@@ -1707,7 +1749,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1715,18 +1759,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createJobTrigger = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createJobTrigger(request), expectedError);
-            assert((client.innerApiCalls.createJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createJobTrigger with closed client', async () => {
@@ -1735,7 +1776,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1755,24 +1798,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.updateJobTrigger = stubSimpleCall(expectedResponse);
             const [response] = await client.updateJobTrigger(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateJobTrigger without error using callback', async () => {
@@ -1781,19 +1825,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.updateJobTrigger = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateJobTrigger(
@@ -1808,8 +1849,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateJobTrigger with error', async () => {
@@ -1818,23 +1863,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateJobTrigger = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateJobTrigger(request), expectedError);
-            assert((client.innerApiCalls.updateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateJobTrigger with closed client', async () => {
@@ -1843,7 +1887,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
@@ -1860,24 +1906,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.getJobTrigger = stubSimpleCall(expectedResponse);
             const [response] = await client.getJobTrigger(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getJobTrigger without error using callback', async () => {
@@ -1886,19 +1933,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.JobTrigger()
+            );
             client.innerApiCalls.getJobTrigger = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getJobTrigger(
@@ -1913,8 +1957,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getJobTrigger with error', async () => {
@@ -1923,23 +1971,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getJobTrigger = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getJobTrigger(request), expectedError);
-            assert((client.innerApiCalls.getJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getJobTrigger with closed client', async () => {
@@ -1948,7 +1995,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
@@ -1965,24 +2014,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteJobTrigger = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteJobTrigger(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteJobTrigger without error using callback', async () => {
@@ -1991,19 +2041,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteJobTrigger = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteJobTrigger(
@@ -2018,8 +2065,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteJobTrigger with error', async () => {
@@ -2028,23 +2079,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteJobTrigger = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteJobTrigger(request), expectedError);
-            assert((client.innerApiCalls.deleteJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteJobTrigger with closed client', async () => {
@@ -2053,7 +2103,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
@@ -2070,24 +2122,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.activateJobTrigger = stubSimpleCall(expectedResponse);
             const [response] = await client.activateJobTrigger(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.activateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes activateJobTrigger without error using callback', async () => {
@@ -2096,19 +2149,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.activateJobTrigger = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.activateJobTrigger(
@@ -2123,8 +2173,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.activateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes activateJobTrigger with error', async () => {
@@ -2133,23 +2187,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.activateJobTrigger = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.activateJobTrigger(request), expectedError);
-            assert((client.innerApiCalls.activateJobTrigger as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.activateJobTrigger as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes activateJobTrigger with closed client', async () => {
@@ -2158,7 +2211,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
@@ -2175,7 +2230,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2183,19 +2240,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.createDlpJob = stubSimpleCall(expectedResponse);
             const [response] = await client.createDlpJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDlpJob without error using callback', async () => {
@@ -2204,7 +2260,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2212,14 +2270,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.createDlpJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createDlpJob(
@@ -2234,8 +2287,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDlpJob with error', async () => {
@@ -2244,7 +2301,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2252,18 +2311,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createDlpJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createDlpJob(request), expectedError);
-            assert((client.innerApiCalls.createDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createDlpJob with closed client', async () => {
@@ -2272,7 +2328,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2292,24 +2350,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.getDlpJob = stubSimpleCall(expectedResponse);
             const [response] = await client.getDlpJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDlpJob without error using callback', async () => {
@@ -2318,19 +2377,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DlpJob()
+            );
             client.innerApiCalls.getDlpJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getDlpJob(
@@ -2345,8 +2401,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDlpJob with error', async () => {
@@ -2355,23 +2415,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getDlpJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getDlpJob(request), expectedError);
-            assert((client.innerApiCalls.getDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getDlpJob with closed client', async () => {
@@ -2380,7 +2439,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
@@ -2397,24 +2458,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteDlpJob = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteDlpJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDlpJob without error using callback', async () => {
@@ -2423,19 +2485,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteDlpJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteDlpJob(
@@ -2450,8 +2509,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDlpJob with error', async () => {
@@ -2460,23 +2523,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteDlpJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteDlpJob(request), expectedError);
-            assert((client.innerApiCalls.deleteDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteDlpJob with closed client', async () => {
@@ -2485,7 +2547,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
@@ -2502,24 +2566,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.cancelDlpJob = stubSimpleCall(expectedResponse);
             const [response] = await client.cancelDlpJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.cancelDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes cancelDlpJob without error using callback', async () => {
@@ -2528,19 +2593,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.cancelDlpJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.cancelDlpJob(
@@ -2555,8 +2617,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.cancelDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes cancelDlpJob with error', async () => {
@@ -2565,23 +2631,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.cancelDlpJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.cancelDlpJob(request), expectedError);
-            assert((client.innerApiCalls.cancelDlpJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.cancelDlpJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes cancelDlpJob with closed client', async () => {
@@ -2590,7 +2655,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CancelDlpJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
@@ -2607,7 +2674,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2615,19 +2684,18 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.createStoredInfoType = stubSimpleCall(expectedResponse);
             const [response] = await client.createStoredInfoType(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createStoredInfoType without error using callback', async () => {
@@ -2636,7 +2704,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2644,14 +2714,9 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.createStoredInfoType = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createStoredInfoType(
@@ -2666,8 +2731,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createStoredInfoType with error', async () => {
@@ -2676,7 +2745,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2684,18 +2755,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createStoredInfoType = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createStoredInfoType(request), expectedError);
-            assert((client.innerApiCalls.createStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createStoredInfoType with closed client', async () => {
@@ -2704,7 +2772,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2724,24 +2794,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.updateStoredInfoType = stubSimpleCall(expectedResponse);
             const [response] = await client.updateStoredInfoType(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateStoredInfoType without error using callback', async () => {
@@ -2750,19 +2821,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.updateStoredInfoType = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateStoredInfoType(
@@ -2777,8 +2845,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateStoredInfoType with error', async () => {
@@ -2787,23 +2859,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateStoredInfoType = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateStoredInfoType(request), expectedError);
-            assert((client.innerApiCalls.updateStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateStoredInfoType with closed client', async () => {
@@ -2812,7 +2883,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
@@ -2829,24 +2902,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.getStoredInfoType = stubSimpleCall(expectedResponse);
             const [response] = await client.getStoredInfoType(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getStoredInfoType without error using callback', async () => {
@@ -2855,19 +2929,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.StoredInfoType()
+            );
             client.innerApiCalls.getStoredInfoType = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getStoredInfoType(
@@ -2882,8 +2953,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getStoredInfoType with error', async () => {
@@ -2892,23 +2967,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getStoredInfoType = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getStoredInfoType(request), expectedError);
-            assert((client.innerApiCalls.getStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getStoredInfoType with closed client', async () => {
@@ -2917,7 +2991,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
@@ -2934,24 +3010,25 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteStoredInfoType = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteStoredInfoType(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteStoredInfoType without error using callback', async () => {
@@ -2960,19 +3037,16 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteStoredInfoType = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteStoredInfoType(
@@ -2987,8 +3061,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteStoredInfoType with error', async () => {
@@ -2997,23 +3075,22 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteStoredInfoType = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteStoredInfoType(request), expectedError);
-            assert((client.innerApiCalls.deleteStoredInfoType as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteStoredInfoType as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteStoredInfoType with closed client', async () => {
@@ -3022,7 +3099,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
@@ -3039,22 +3118,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -3062,8 +3135,12 @@ describe('v2.DlpServiceClient', () => {
             client.innerApiCalls.listInspectTemplates = stubSimpleCall(expectedResponse);
             const [response] = await client.listInspectTemplates(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInspectTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInspectTemplates without error using callback', async () => {
@@ -3072,22 +3149,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -3106,8 +3177,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInspectTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInspectTemplates with error', async () => {
@@ -3116,7 +3191,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3124,18 +3201,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listInspectTemplates = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listInspectTemplates(request), expectedError);
-            assert((client.innerApiCalls.listInspectTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInspectTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInspectTemplatesStream without error', async () => {
@@ -3144,7 +3218,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3175,10 +3251,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listInspectTemplates.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listInspectTemplates, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInspectTemplates.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3188,7 +3265,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3214,10 +3293,11 @@ describe('v2.DlpServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listInspectTemplates.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listInspectTemplates, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInspectTemplates.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3227,7 +3307,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3250,10 +3332,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listInspectTemplates.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInspectTemplates.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3263,14 +3346,17 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listInspectTemplates.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listInspectTemplatesAsync(request);
             await assert.rejects(async () => {
@@ -3282,10 +3368,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listInspectTemplates.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInspectTemplates.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3297,22 +3384,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3320,8 +3401,12 @@ describe('v2.DlpServiceClient', () => {
             client.innerApiCalls.listDeidentifyTemplates = stubSimpleCall(expectedResponse);
             const [response] = await client.listDeidentifyTemplates(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listDeidentifyTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDeidentifyTemplates without error using callback', async () => {
@@ -3330,22 +3415,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3364,8 +3443,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listDeidentifyTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDeidentifyTemplates with error', async () => {
@@ -3374,7 +3457,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3382,18 +3467,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listDeidentifyTemplates = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listDeidentifyTemplates(request), expectedError);
-            assert((client.innerApiCalls.listDeidentifyTemplates as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDeidentifyTemplates as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDeidentifyTemplatesStream without error', async () => {
@@ -3402,7 +3484,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3433,10 +3517,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listDeidentifyTemplates.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listDeidentifyTemplates, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDeidentifyTemplates.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3446,7 +3531,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3472,10 +3559,11 @@ describe('v2.DlpServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listDeidentifyTemplates.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listDeidentifyTemplates, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDeidentifyTemplates.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3485,7 +3573,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3508,10 +3598,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listDeidentifyTemplates.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDeidentifyTemplates.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3521,14 +3612,17 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listDeidentifyTemplates.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listDeidentifyTemplatesAsync(request);
             await assert.rejects(async () => {
@@ -3540,10 +3634,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listDeidentifyTemplates.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDeidentifyTemplates.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3555,22 +3650,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3578,8 +3667,12 @@ describe('v2.DlpServiceClient', () => {
             client.innerApiCalls.listJobTriggers = stubSimpleCall(expectedResponse);
             const [response] = await client.listJobTriggers(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listJobTriggers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listJobTriggers without error using callback', async () => {
@@ -3588,22 +3681,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3622,8 +3709,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listJobTriggers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listJobTriggers with error', async () => {
@@ -3632,7 +3723,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3640,18 +3733,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listJobTriggers = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listJobTriggers(request), expectedError);
-            assert((client.innerApiCalls.listJobTriggers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listJobTriggers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listJobTriggersStream without error', async () => {
@@ -3660,7 +3750,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3691,10 +3783,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listJobTriggers.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listJobTriggers, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listJobTriggers.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3704,7 +3797,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3730,10 +3825,11 @@ describe('v2.DlpServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listJobTriggers.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listJobTriggers, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listJobTriggers.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3743,7 +3839,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3766,10 +3864,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listJobTriggers.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listJobTriggers.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3779,14 +3878,17 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListJobTriggersRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listJobTriggers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listJobTriggersAsync(request);
             await assert.rejects(async () => {
@@ -3798,10 +3900,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listJobTriggers.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listJobTriggers.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3813,22 +3916,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3836,8 +3933,12 @@ describe('v2.DlpServiceClient', () => {
             client.innerApiCalls.listDlpJobs = stubSimpleCall(expectedResponse);
             const [response] = await client.listDlpJobs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listDlpJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDlpJobs without error using callback', async () => {
@@ -3846,22 +3947,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3880,8 +3975,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listDlpJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDlpJobs with error', async () => {
@@ -3890,7 +3989,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3898,18 +3999,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listDlpJobs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listDlpJobs(request), expectedError);
-            assert((client.innerApiCalls.listDlpJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listDlpJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listDlpJobsStream without error', async () => {
@@ -3918,7 +4016,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3949,10 +4049,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listDlpJobs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listDlpJobs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDlpJobs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3962,7 +4063,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3988,10 +4091,11 @@ describe('v2.DlpServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listDlpJobs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listDlpJobs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDlpJobs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -4001,7 +4105,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -4024,10 +4130,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listDlpJobs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDlpJobs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -4037,14 +4144,17 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListDlpJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listDlpJobs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listDlpJobsAsync(request);
             await assert.rejects(async () => {
@@ -4056,10 +4166,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listDlpJobs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listDlpJobs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -4071,22 +4182,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -4094,8 +4199,12 @@ describe('v2.DlpServiceClient', () => {
             client.innerApiCalls.listStoredInfoTypes = stubSimpleCall(expectedResponse);
             const [response] = await client.listStoredInfoTypes(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listStoredInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listStoredInfoTypes without error using callback', async () => {
@@ -4104,22 +4213,16 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -4138,8 +4241,12 @@ describe('v2.DlpServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listStoredInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listStoredInfoTypes with error', async () => {
@@ -4148,7 +4255,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -4156,18 +4265,15 @@ describe('v2.DlpServiceClient', () => {
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listStoredInfoTypes = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listStoredInfoTypes(request), expectedError);
-            assert((client.innerApiCalls.listStoredInfoTypes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listStoredInfoTypes as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listStoredInfoTypesStream without error', async () => {
@@ -4176,7 +4282,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -4207,10 +4315,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listStoredInfoTypes.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listStoredInfoTypes, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listStoredInfoTypes.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -4220,7 +4329,9 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -4246,10 +4357,11 @@ describe('v2.DlpServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listStoredInfoTypes.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listStoredInfoTypes, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listStoredInfoTypes.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -4259,7 +4371,9 @@ describe('v2.DlpServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -4282,10 +4396,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listStoredInfoTypes.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listStoredInfoTypes.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -4295,14 +4410,17 @@ describe('v2.DlpServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest());
+            const request = generateSampleMessage(
+              new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
               getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listStoredInfoTypes.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listStoredInfoTypesAsync(request);
             await assert.rejects(async () => {
@@ -4314,10 +4432,11 @@ describe('v2.DlpServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listStoredInfoTypes.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listStoredInfoTypes.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -379,7 +379,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getKeyRing(request, options, callback);
@@ -451,7 +451,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getCryptoKey(request, options, callback);
@@ -522,7 +522,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getCryptoKeyVersion(request, options, callback);
@@ -597,7 +597,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getPublicKey(request, options, callback);
@@ -668,7 +668,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getImportJob(request, options, callback);
@@ -745,7 +745,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createKeyRing(request, options, callback);
@@ -832,7 +832,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createCryptoKey(request, options, callback);
@@ -910,7 +910,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createCryptoKeyVersion(request, options, callback);
@@ -1013,7 +1013,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.importCryptoKeyVersion(request, options, callback);
@@ -1092,7 +1092,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createImportJob(request, options, callback);
@@ -1165,7 +1165,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'crypto_key.name': request.cryptoKey!.name || '',
+      'crypto_key.name': request.cryptoKey!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateCryptoKey(request, options, callback);
@@ -1244,7 +1244,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'crypto_key_version.name': request.cryptoKeyVersion!.name || '',
+      'crypto_key_version.name': request.cryptoKeyVersion!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateCryptoKeyVersion(request, options, callback);
@@ -1340,7 +1340,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.encrypt(request, options, callback);
@@ -1419,7 +1419,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.decrypt(request, options, callback);
@@ -1496,7 +1496,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.asymmetricSign(request, options, callback);
@@ -1573,7 +1573,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.asymmetricDecrypt(request, options, callback);
@@ -1648,7 +1648,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateCryptoKeyPrimaryVersion(request, options, callback);
@@ -1730,7 +1730,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.destroyCryptoKeyVersion(request, options, callback);
@@ -1807,7 +1807,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.restoreCryptoKeyVersion(request, options, callback);
@@ -1898,7 +1898,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listKeyRings(request, options, callback);
@@ -1947,7 +1947,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listKeyRings'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2005,7 +2005,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listKeyRings'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2103,7 +2103,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listCryptoKeys(request, options, callback);
@@ -2154,7 +2154,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeys'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2214,7 +2214,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeys'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2313,7 +2313,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listCryptoKeyVersions(request, options, callback);
@@ -2365,7 +2365,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeyVersions'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2426,7 +2426,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listCryptoKeyVersions'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2522,7 +2522,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listImportJobs(request, options, callback);
@@ -2571,7 +2571,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listImportJobs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2629,7 +2629,7 @@ export class KeyManagementServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listImportJobs'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, IamProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.KeyRing()
+            );
             client.innerApiCalls.getKeyRing = stubSimpleCall(expectedResponse);
             const [response] = await client.getKeyRing(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getKeyRing without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.KeyRing()
+            );
             client.innerApiCalls.getKeyRing = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getKeyRing(
@@ -254,8 +253,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getKeyRing with error', async () => {
@@ -264,23 +267,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getKeyRing = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getKeyRing(request), expectedError);
-            assert((client.innerApiCalls.getKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getKeyRing with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.getCryptoKey = stubSimpleCall(expectedResponse);
             const [response] = await client.getCryptoKey(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKey without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.getCryptoKey = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getCryptoKey(
@@ -359,8 +361,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKey with error', async () => {
@@ -369,23 +375,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getCryptoKey = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getCryptoKey(request), expectedError);
-            assert((client.innerApiCalls.getCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKey with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
@@ -411,24 +418,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.getCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.getCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKeyVersion without error using callback', async () => {
@@ -437,19 +445,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.getCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getCryptoKeyVersion(
@@ -464,8 +469,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKeyVersion with error', async () => {
@@ -474,23 +483,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.getCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCryptoKeyVersion with closed client', async () => {
@@ -499,7 +507,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
@@ -516,24 +526,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetPublicKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.PublicKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.PublicKey()
+            );
             client.innerApiCalls.getPublicKey = stubSimpleCall(expectedResponse);
             const [response] = await client.getPublicKey(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getPublicKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getPublicKey without error using callback', async () => {
@@ -542,19 +553,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetPublicKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.PublicKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.PublicKey()
+            );
             client.innerApiCalls.getPublicKey = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getPublicKey(
@@ -569,8 +577,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getPublicKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getPublicKey with error', async () => {
@@ -579,23 +591,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetPublicKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getPublicKey = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getPublicKey(request), expectedError);
-            assert((client.innerApiCalls.getPublicKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getPublicKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getPublicKey with closed client', async () => {
@@ -604,7 +615,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetPublicKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
@@ -621,24 +634,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportJob()
+            );
             client.innerApiCalls.getImportJob = stubSimpleCall(expectedResponse);
             const [response] = await client.getImportJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getImportJob without error using callback', async () => {
@@ -647,19 +661,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportJob()
+            );
             client.innerApiCalls.getImportJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getImportJob(
@@ -674,8 +685,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getImportJob with error', async () => {
@@ -684,23 +699,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getImportJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getImportJob(request), expectedError);
-            assert((client.innerApiCalls.getImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getImportJob with closed client', async () => {
@@ -709,7 +723,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.GetImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetImportJobRequest', ['name']);
             request.name = defaultValue1;
@@ -726,24 +742,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.KeyRing()
+            );
             client.innerApiCalls.createKeyRing = stubSimpleCall(expectedResponse);
             const [response] = await client.createKeyRing(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createKeyRing without error using callback', async () => {
@@ -752,19 +769,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.KeyRing()
+            );
             client.innerApiCalls.createKeyRing = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createKeyRing(
@@ -779,8 +793,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createKeyRing with error', async () => {
@@ -789,23 +807,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createKeyRing = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createKeyRing(request), expectedError);
-            assert((client.innerApiCalls.createKeyRing as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createKeyRing as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createKeyRing with closed client', async () => {
@@ -814,7 +831,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateKeyRingRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
@@ -831,24 +850,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.createCryptoKey = stubSimpleCall(expectedResponse);
             const [response] = await client.createCryptoKey(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKey without error using callback', async () => {
@@ -857,19 +877,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.createCryptoKey = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createCryptoKey(
@@ -884,8 +901,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKey with error', async () => {
@@ -894,23 +915,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createCryptoKey = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createCryptoKey(request), expectedError);
-            assert((client.innerApiCalls.createCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKey with closed client', async () => {
@@ -919,7 +939,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
@@ -936,24 +958,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.createCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.createCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKeyVersion without error using callback', async () => {
@@ -962,19 +985,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.createCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createCryptoKeyVersion(
@@ -989,8 +1009,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKeyVersion with error', async () => {
@@ -999,23 +1023,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.createCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createCryptoKeyVersion with closed client', async () => {
@@ -1024,7 +1047,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1041,24 +1066,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.importCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.importCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.importCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importCryptoKeyVersion without error using callback', async () => {
@@ -1067,19 +1093,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.importCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.importCryptoKeyVersion(
@@ -1094,8 +1117,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.importCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importCryptoKeyVersion with error', async () => {
@@ -1104,23 +1131,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.importCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.importCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.importCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importCryptoKeyVersion with closed client', async () => {
@@ -1129,7 +1155,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1146,24 +1174,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportJob()
+            );
             client.innerApiCalls.createImportJob = stubSimpleCall(expectedResponse);
             const [response] = await client.createImportJob(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createImportJob without error using callback', async () => {
@@ -1172,19 +1201,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ImportJob()
+            );
             client.innerApiCalls.createImportJob = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createImportJob(
@@ -1199,8 +1225,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createImportJob with error', async () => {
@@ -1209,23 +1239,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createImportJob = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createImportJob(request), expectedError);
-            assert((client.innerApiCalls.createImportJob as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createImportJob as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createImportJob with closed client', async () => {
@@ -1234,7 +1263,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CreateImportJobRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1251,25 +1282,26 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest()
+            );
             request.cryptoKey ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.updateCryptoKey = stubSimpleCall(expectedResponse);
             const [response] = await client.updateCryptoKey(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKey without error using callback', async () => {
@@ -1278,20 +1310,17 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest()
+            );
             request.cryptoKey ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.updateCryptoKey = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateCryptoKey(
@@ -1306,8 +1335,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKey with error', async () => {
@@ -1316,24 +1349,23 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest()
+            );
             request.cryptoKey ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateCryptoKey = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateCryptoKey(request), expectedError);
-            assert((client.innerApiCalls.updateCryptoKey as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKey as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKey with closed client', async () => {
@@ -1342,7 +1374,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest()
+            );
             request.cryptoKey ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
@@ -1360,25 +1394,26 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest()
+            );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.updateCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.updateCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyVersion without error using callback', async () => {
@@ -1387,20 +1422,17 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest()
+            );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.updateCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateCryptoKeyVersion(
@@ -1415,8 +1447,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyVersion with error', async () => {
@@ -1425,24 +1461,23 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest()
+            );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyVersion with closed client', async () => {
@@ -1451,7 +1486,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest()
+            );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
@@ -1469,24 +1506,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptResponse()
+            );
             client.innerApiCalls.encrypt = stubSimpleCall(expectedResponse);
             const [response] = await client.encrypt(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.encrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes encrypt without error using callback', async () => {
@@ -1495,19 +1533,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptResponse()
+            );
             client.innerApiCalls.encrypt = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.encrypt(
@@ -1522,8 +1557,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.encrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes encrypt with error', async () => {
@@ -1532,23 +1571,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.encrypt = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.encrypt(request), expectedError);
-            assert((client.innerApiCalls.encrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.encrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes encrypt with closed client', async () => {
@@ -1557,7 +1595,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.EncryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('EncryptRequest', ['name']);
             request.name = defaultValue1;
@@ -1574,24 +1614,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptResponse()
+            );
             client.innerApiCalls.decrypt = stubSimpleCall(expectedResponse);
             const [response] = await client.decrypt(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.decrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes decrypt without error using callback', async () => {
@@ -1600,19 +1641,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptResponse()
+            );
             client.innerApiCalls.decrypt = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.decrypt(
@@ -1627,8 +1665,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.decrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes decrypt with error', async () => {
@@ -1637,23 +1679,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.decrypt = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.decrypt(request), expectedError);
-            assert((client.innerApiCalls.decrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.decrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes decrypt with closed client', async () => {
@@ -1662,7 +1703,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DecryptRequest', ['name']);
             request.name = defaultValue1;
@@ -1679,24 +1722,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignResponse()
+            );
             client.innerApiCalls.asymmetricSign = stubSimpleCall(expectedResponse);
             const [response] = await client.asymmetricSign(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.asymmetricSign as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricSign without error using callback', async () => {
@@ -1705,19 +1749,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignResponse()
+            );
             client.innerApiCalls.asymmetricSign = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.asymmetricSign(
@@ -1732,8 +1773,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.asymmetricSign as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricSign with error', async () => {
@@ -1742,23 +1787,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.asymmetricSign = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.asymmetricSign(request), expectedError);
-            assert((client.innerApiCalls.asymmetricSign as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricSign as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricSign with closed client', async () => {
@@ -1767,7 +1811,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricSignRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
@@ -1784,24 +1830,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptResponse()
+            );
             client.innerApiCalls.asymmetricDecrypt = stubSimpleCall(expectedResponse);
             const [response] = await client.asymmetricDecrypt(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.asymmetricDecrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricDecrypt without error using callback', async () => {
@@ -1810,19 +1857,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptResponse()
+            );
             client.innerApiCalls.asymmetricDecrypt = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.asymmetricDecrypt(
@@ -1837,8 +1881,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.asymmetricDecrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricDecrypt with error', async () => {
@@ -1847,23 +1895,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.asymmetricDecrypt = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.asymmetricDecrypt(request), expectedError);
-            assert((client.innerApiCalls.asymmetricDecrypt as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.asymmetricDecrypt as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes asymmetricDecrypt with closed client', async () => {
@@ -1872,7 +1919,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
@@ -1889,24 +1938,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.updateCryptoKeyPrimaryVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.updateCryptoKeyPrimaryVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyPrimaryVersion without error using callback', async () => {
@@ -1915,19 +1965,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKey()
+            );
             client.innerApiCalls.updateCryptoKeyPrimaryVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateCryptoKeyPrimaryVersion(
@@ -1942,8 +1989,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyPrimaryVersion with error', async () => {
@@ -1952,23 +2003,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateCryptoKeyPrimaryVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateCryptoKeyPrimaryVersion(request), expectedError);
-            assert((client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCryptoKeyPrimaryVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCryptoKeyPrimaryVersion with closed client', async () => {
@@ -1977,7 +2027,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
@@ -1994,24 +2046,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.destroyCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.destroyCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes destroyCryptoKeyVersion without error using callback', async () => {
@@ -2020,19 +2073,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.destroyCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.destroyCryptoKeyVersion(
@@ -2047,8 +2097,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes destroyCryptoKeyVersion with error', async () => {
@@ -2057,23 +2111,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.destroyCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.destroyCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.destroyCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes destroyCryptoKeyVersion with closed client', async () => {
@@ -2082,7 +2135,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
@@ -2099,24 +2154,25 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.restoreCryptoKeyVersion = stubSimpleCall(expectedResponse);
             const [response] = await client.restoreCryptoKeyVersion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes restoreCryptoKeyVersion without error using callback', async () => {
@@ -2125,19 +2181,16 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.kms.v1.CryptoKeyVersion()
+            );
             client.innerApiCalls.restoreCryptoKeyVersion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.restoreCryptoKeyVersion(
@@ -2152,8 +2205,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes restoreCryptoKeyVersion with error', async () => {
@@ -2162,23 +2219,22 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.restoreCryptoKeyVersion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.restoreCryptoKeyVersion(request), expectedError);
-            assert((client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.restoreCryptoKeyVersion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes restoreCryptoKeyVersion with closed client', async () => {
@@ -2187,7 +2243,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
@@ -2204,19 +2262,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2224,8 +2276,12 @@ describe('v1.KeyManagementServiceClient', () => {
             client.innerApiCalls.listKeyRings = stubSimpleCall(expectedResponse);
             const [response] = await client.listKeyRings(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listKeyRings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listKeyRings without error using callback', async () => {
@@ -2234,19 +2290,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2265,8 +2315,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listKeyRings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listKeyRings with error', async () => {
@@ -2275,23 +2329,22 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listKeyRings = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listKeyRings(request), expectedError);
-            assert((client.innerApiCalls.listKeyRings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listKeyRings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listKeyRingsStream without error', async () => {
@@ -2300,7 +2353,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2328,10 +2383,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listKeyRings.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listKeyRings, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listKeyRings.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2341,7 +2397,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2364,10 +2422,11 @@ describe('v1.KeyManagementServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listKeyRings.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listKeyRings, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listKeyRings.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2377,7 +2436,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2397,10 +2458,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listKeyRings.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listKeyRings.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2410,11 +2472,14 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListKeyRingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listKeyRings.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listKeyRingsAsync(request);
             await assert.rejects(async () => {
@@ -2426,10 +2491,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listKeyRings.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listKeyRings.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -2441,19 +2507,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2461,8 +2521,12 @@ describe('v1.KeyManagementServiceClient', () => {
             client.innerApiCalls.listCryptoKeys = stubSimpleCall(expectedResponse);
             const [response] = await client.listCryptoKeys(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listCryptoKeys as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeys without error using callback', async () => {
@@ -2471,19 +2535,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2502,8 +2560,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listCryptoKeys as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeys with error', async () => {
@@ -2512,23 +2574,22 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listCryptoKeys = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listCryptoKeys(request), expectedError);
-            assert((client.innerApiCalls.listCryptoKeys as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeys as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeysStream without error', async () => {
@@ -2537,7 +2598,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2565,10 +2628,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listCryptoKeys.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listCryptoKeys, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeys.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2578,7 +2642,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2601,10 +2667,11 @@ describe('v1.KeyManagementServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listCryptoKeys.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listCryptoKeys, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeys.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2614,7 +2681,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2634,10 +2703,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listCryptoKeys.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeys.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2647,11 +2717,14 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeys.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listCryptoKeysAsync(request);
             await assert.rejects(async () => {
@@ -2663,10 +2736,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listCryptoKeys.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeys.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -2678,19 +2752,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2698,8 +2766,12 @@ describe('v1.KeyManagementServiceClient', () => {
             client.innerApiCalls.listCryptoKeyVersions = stubSimpleCall(expectedResponse);
             const [response] = await client.listCryptoKeyVersions(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listCryptoKeyVersions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeyVersions without error using callback', async () => {
@@ -2708,19 +2780,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2739,8 +2805,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listCryptoKeyVersions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeyVersions with error', async () => {
@@ -2749,23 +2819,22 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listCryptoKeyVersions = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listCryptoKeyVersions(request), expectedError);
-            assert((client.innerApiCalls.listCryptoKeyVersions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listCryptoKeyVersions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listCryptoKeyVersionsStream without error', async () => {
@@ -2774,7 +2843,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2802,10 +2873,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listCryptoKeyVersions.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listCryptoKeyVersions, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeyVersions.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2815,7 +2887,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2838,10 +2912,11 @@ describe('v1.KeyManagementServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listCryptoKeyVersions.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listCryptoKeyVersions, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeyVersions.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2851,7 +2926,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2871,10 +2948,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listCryptoKeyVersions.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeyVersions.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2884,11 +2962,14 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeyVersions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listCryptoKeyVersionsAsync(request);
             await assert.rejects(async () => {
@@ -2900,10 +2981,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listCryptoKeyVersions.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listCryptoKeyVersions.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -2915,19 +2997,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -2935,8 +3011,12 @@ describe('v1.KeyManagementServiceClient', () => {
             client.innerApiCalls.listImportJobs = stubSimpleCall(expectedResponse);
             const [response] = await client.listImportJobs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listImportJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listImportJobs without error using callback', async () => {
@@ -2945,19 +3025,13 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -2976,8 +3050,12 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listImportJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listImportJobs with error', async () => {
@@ -2986,23 +3064,22 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listImportJobs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listImportJobs(request), expectedError);
-            assert((client.innerApiCalls.listImportJobs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listImportJobs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listImportJobsStream without error', async () => {
@@ -3011,7 +3088,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3039,10 +3118,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listImportJobs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listImportJobs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listImportJobs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3052,7 +3132,9 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3075,10 +3157,11 @@ describe('v1.KeyManagementServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listImportJobs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listImportJobs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listImportJobs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3088,7 +3171,9 @@ describe('v1.KeyManagementServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3108,10 +3193,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listImportJobs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listImportJobs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3121,11 +3207,14 @@ describe('v1.KeyManagementServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.kms.v1.ListImportJobsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listImportJobs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listImportJobsAsync(request);
             await assert.rejects(async () => {
@@ -3137,10 +3226,11 @@ describe('v1.KeyManagementServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listImportJobs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listImportJobs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3152,7 +3242,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3164,7 +3254,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -3179,7 +3269,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3191,7 +3281,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -3218,7 +3308,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3244,7 +3334,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3256,7 +3346,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -3271,7 +3361,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3283,7 +3373,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -3310,7 +3400,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3336,7 +3426,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3348,7 +3438,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -3363,7 +3453,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -3375,7 +3465,7 @@ describe('v1.KeyManagementServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -3402,7 +3492,7 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, IamProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetKeyRingRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getKeyRing(request), expectedError);
@@ -287,8 +307,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getCryptoKey(request), expectedError);
@@ -384,8 +412,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -408,8 +438,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -443,8 +475,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -466,7 +500,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getCryptoKeyVersion(request), expectedError);
@@ -481,8 +517,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -505,8 +543,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -540,8 +580,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -563,7 +605,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetPublicKeyRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getPublicKey(request), expectedError);
@@ -578,8 +622,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetImportJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -602,8 +648,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetImportJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -637,8 +685,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetImportJobRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -660,7 +710,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.GetImportJobRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetImportJobRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getImportJob(request), expectedError);
@@ -675,8 +727,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -699,8 +753,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -734,8 +790,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -757,7 +815,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateKeyRingRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createKeyRing(request), expectedError);
@@ -772,8 +832,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -796,8 +858,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -831,8 +895,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -854,7 +920,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createCryptoKey(request), expectedError);
@@ -869,8 +937,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -893,8 +963,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -928,8 +1000,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -951,7 +1025,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createCryptoKeyVersion(request), expectedError);
@@ -966,8 +1042,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -990,8 +1068,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1025,8 +1105,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1048,7 +1130,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.importCryptoKeyVersion(request), expectedError);
@@ -1063,8 +1147,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1087,8 +1173,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1122,8 +1210,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1145,7 +1235,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.CreateImportJobRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createImportJob(request), expectedError);
@@ -1160,9 +1252,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
-            request.cryptoKey = {};
-            request.cryptoKey.name = '';
-            const expectedHeaderRequestParams = "crypto_key.name=";
+            request.cryptoKey ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+            request.cryptoKey.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1185,9 +1279,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
-            request.cryptoKey = {};
-            request.cryptoKey.name = '';
-            const expectedHeaderRequestParams = "crypto_key.name=";
+            request.cryptoKey ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+            request.cryptoKey.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1221,9 +1317,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
-            request.cryptoKey = {};
-            request.cryptoKey.name = '';
-            const expectedHeaderRequestParams = "crypto_key.name=";
+            request.cryptoKey ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+            request.cryptoKey.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1245,8 +1343,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyRequest());
-            request.cryptoKey = {};
-            request.cryptoKey.name = '';
+            request.cryptoKey ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+            request.cryptoKey.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateCryptoKey(request), expectedError);
@@ -1261,9 +1361,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
-            request.cryptoKeyVersion = {};
-            request.cryptoKeyVersion.name = '';
-            const expectedHeaderRequestParams = "crypto_key_version.name=";
+            request.cryptoKeyVersion ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+            request.cryptoKeyVersion.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1286,9 +1388,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
-            request.cryptoKeyVersion = {};
-            request.cryptoKeyVersion.name = '';
-            const expectedHeaderRequestParams = "crypto_key_version.name=";
+            request.cryptoKeyVersion ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+            request.cryptoKeyVersion.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1322,9 +1426,11 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
-            request.cryptoKeyVersion = {};
-            request.cryptoKeyVersion.name = '';
-            const expectedHeaderRequestParams = "crypto_key_version.name=";
+            request.cryptoKeyVersion ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+            request.cryptoKeyVersion.name = defaultValue1;
+            const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1346,8 +1452,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest());
-            request.cryptoKeyVersion = {};
-            request.cryptoKeyVersion.name = '';
+            request.cryptoKeyVersion ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+            request.cryptoKeyVersion.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateCryptoKeyVersion(request), expectedError);
@@ -1362,8 +1470,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('EncryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1386,8 +1496,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('EncryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1421,8 +1533,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('EncryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1444,7 +1558,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.EncryptRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('EncryptRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.encrypt(request), expectedError);
@@ -1459,8 +1575,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1483,8 +1601,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1518,8 +1638,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1541,7 +1663,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DecryptRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DecryptRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.decrypt(request), expectedError);
@@ -1556,8 +1680,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1580,8 +1706,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1615,8 +1743,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1638,7 +1768,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricSignRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.asymmetricSign(request), expectedError);
@@ -1653,8 +1785,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1677,8 +1811,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1712,8 +1848,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1735,7 +1873,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.AsymmetricDecryptRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.asymmetricDecrypt(request), expectedError);
@@ -1750,8 +1890,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1774,8 +1916,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1809,8 +1953,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1832,7 +1978,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateCryptoKeyPrimaryVersion(request), expectedError);
@@ -1847,8 +1995,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1871,8 +2021,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1906,8 +2058,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1929,7 +2083,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.destroyCryptoKeyVersion(request), expectedError);
@@ -1944,8 +2100,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1968,8 +2126,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2003,8 +2163,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2026,7 +2188,9 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.restoreCryptoKeyVersion(request), expectedError);
@@ -2041,8 +2205,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2069,8 +2235,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2108,8 +2276,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2131,8 +2301,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2170,8 +2342,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listKeyRings.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listKeyRingsStream(request);
@@ -2204,8 +2378,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2235,8 +2411,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListKeyRingsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listKeyRings.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listKeyRingsAsync(request);
             await assert.rejects(async () => {
@@ -2264,8 +2442,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2292,8 +2472,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2331,8 +2513,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2354,8 +2538,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2393,8 +2579,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeys.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listCryptoKeysStream(request);
@@ -2427,8 +2615,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2458,8 +2648,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeysRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeys.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listCryptoKeysAsync(request);
             await assert.rejects(async () => {
@@ -2487,8 +2679,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2515,8 +2709,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2554,8 +2750,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2577,8 +2775,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2616,8 +2816,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeyVersions.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listCryptoKeyVersionsStream(request);
@@ -2650,8 +2852,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2681,8 +2885,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listCryptoKeyVersions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listCryptoKeyVersionsAsync(request);
             await assert.rejects(async () => {
@@ -2710,8 +2916,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2738,8 +2946,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2777,8 +2987,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2800,8 +3012,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -2839,8 +3053,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listImportJobs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listImportJobsStream(request);
@@ -2873,8 +3089,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -2904,8 +3122,10 @@ describe('v1.KeyManagementServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.kms.v1.ListImportJobsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listImportJobs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listImportJobsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -504,7 +504,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getBucket(request, options, callback);
@@ -590,7 +590,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createBucket(request, options, callback);
@@ -690,7 +690,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateBucket(request, options, callback);
@@ -774,7 +774,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteBucket(request, options, callback);
@@ -855,7 +855,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.undeleteBucket(request, options, callback);
@@ -932,7 +932,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getView(request, options, callback);
@@ -1014,7 +1014,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createView(request, options, callback);
@@ -1106,7 +1106,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateView(request, options, callback);
@@ -1186,7 +1186,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteView(request, options, callback);
@@ -1266,7 +1266,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'sink_name': request.sinkName || '',
+      'sink_name': request.sinkName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSink(request, options, callback);
@@ -1365,7 +1365,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createSink(request, options, callback);
@@ -1482,7 +1482,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'sink_name': request.sinkName || '',
+      'sink_name': request.sinkName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateSink(request, options, callback);
@@ -1564,7 +1564,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'sink_name': request.sinkName || '',
+      'sink_name': request.sinkName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteSink(request, options, callback);
@@ -1644,7 +1644,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getExclusion(request, options, callback);
@@ -1730,7 +1730,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createExclusion(request, options, callback);
@@ -1822,7 +1822,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateExclusion(request, options, callback);
@@ -1902,7 +1902,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteExclusion(request, options, callback);
@@ -1996,7 +1996,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getCmekSettings(request, options, callback);
@@ -2108,7 +2108,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateCmekSettings(request, options, callback);
@@ -2202,7 +2202,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSettings(request, options, callback);
@@ -2312,7 +2312,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateSettings(request, options, callback);
@@ -2502,7 +2502,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listBuckets(request, options, callback);
@@ -2555,7 +2555,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBuckets'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2617,7 +2617,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBuckets'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2711,7 +2711,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listViews(request, options, callback);
@@ -2758,7 +2758,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listViews'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2814,7 +2814,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listViews'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2910,7 +2910,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listSinks(request, options, callback);
@@ -2959,7 +2959,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listSinks'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3017,7 +3017,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listSinks'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3113,7 +3113,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listExclusions(request, options, callback);
@@ -3162,7 +3162,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listExclusions'];
     const callSettings = defaultCallSettings.merge(options);
@@ -3220,7 +3220,7 @@ export class ConfigServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listExclusions'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -510,7 +510,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'log_name': request.logName || '',
+      'log_name': request.logName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteLog(request, options, callback);
@@ -1212,7 +1212,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listLogs(request, options, callback);
@@ -1275,7 +1275,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listLogs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1347,7 +1347,7 @@ export class LoggingServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listLogs'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -462,7 +462,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'metric_name': request.metricName || '',
+      'metric_name': request.metricName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getLogMetric(request, options, callback);
@@ -540,7 +540,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createLogMetric(request, options, callback);
@@ -619,7 +619,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'metric_name': request.metricName || '',
+      'metric_name': request.metricName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateLogMetric(request, options, callback);
@@ -692,7 +692,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'metric_name': request.metricName || '',
+      'metric_name': request.metricName ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteLogMetric(request, options, callback);
@@ -780,7 +780,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listLogMetrics(request, options, callback);
@@ -826,7 +826,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listLogMetrics'];
     const callSettings = defaultCallSettings.merge(options);
@@ -881,7 +881,7 @@ export class MetricsServiceV2Client {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listLogMetrics'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -206,8 +218,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -230,8 +244,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -265,8 +281,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -288,7 +306,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetBucketRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getBucket(request), expectedError);
@@ -303,8 +323,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -327,8 +349,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -362,8 +386,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -385,7 +411,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createBucket(request), expectedError);
@@ -400,8 +428,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -424,8 +454,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -459,8 +491,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -482,7 +516,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateBucket(request), expectedError);
@@ -497,8 +533,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -521,8 +559,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -556,8 +596,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -579,7 +621,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteBucket(request), expectedError);
@@ -594,8 +638,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -618,8 +664,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -653,8 +701,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -676,7 +726,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.undeleteBucket(request), expectedError);
@@ -691,8 +743,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -715,8 +769,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -750,8 +806,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -773,7 +831,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetViewRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getView(request), expectedError);
@@ -788,8 +848,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateViewRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -812,8 +874,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateViewRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -847,8 +911,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateViewRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -870,7 +936,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateViewRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createView(request), expectedError);
@@ -885,8 +953,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -909,8 +979,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -944,8 +1016,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -967,7 +1041,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateViewRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateView(request), expectedError);
@@ -982,8 +1058,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1006,8 +1084,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1041,8 +1121,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteViewRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1064,7 +1146,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteViewRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteView(request), expectedError);
@@ -1079,8 +1163,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1103,8 +1189,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1138,8 +1226,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1161,7 +1251,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
-            request.sinkName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSink(request), expectedError);
@@ -1176,8 +1268,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1200,8 +1294,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1235,8 +1331,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1258,7 +1356,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createSink(request), expectedError);
@@ -1273,8 +1373,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1297,8 +1399,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1332,8 +1436,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1355,7 +1461,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
-            request.sinkName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateSink(request), expectedError);
@@ -1370,8 +1478,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1394,8 +1504,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1429,8 +1541,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
-            request.sinkName = '';
-            const expectedHeaderRequestParams = "sink_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
+            const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1452,7 +1566,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
-            request.sinkName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+            request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteSink(request), expectedError);
@@ -1467,8 +1583,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1491,8 +1609,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1526,8 +1646,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1549,7 +1671,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetExclusionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getExclusion(request), expectedError);
@@ -1564,8 +1688,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1588,8 +1714,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1623,8 +1751,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1646,7 +1776,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createExclusion(request), expectedError);
@@ -1661,8 +1793,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1685,8 +1819,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1720,8 +1856,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1743,7 +1881,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateExclusion(request), expectedError);
@@ -1758,8 +1898,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1782,8 +1924,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1817,8 +1961,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1840,7 +1986,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteExclusion(request), expectedError);
@@ -1855,8 +2003,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1879,8 +2029,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1914,8 +2066,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1937,7 +2091,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getCmekSettings(request), expectedError);
@@ -1952,8 +2108,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1976,8 +2134,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2011,8 +2171,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2034,7 +2196,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateCmekSettings(request), expectedError);
@@ -2049,8 +2213,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2073,8 +2239,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2108,8 +2276,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2131,7 +2301,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSettingsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSettings(request), expectedError);
@@ -2146,8 +2318,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2170,8 +2344,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2205,8 +2381,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2228,7 +2406,9 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateSettings(request), expectedError);
@@ -2355,8 +2535,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2383,8 +2565,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2422,8 +2606,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2445,8 +2631,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2484,8 +2672,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listBuckets.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listBucketsStream(request);
@@ -2518,8 +2708,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2549,8 +2741,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listBuckets.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBucketsAsync(request);
             await assert.rejects(async () => {
@@ -2578,8 +2772,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2606,8 +2802,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2645,8 +2843,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2668,8 +2868,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2707,8 +2909,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listViews.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listViewsStream(request);
@@ -2741,8 +2945,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2772,8 +2978,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListViewsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listViews.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listViewsAsync(request);
             await assert.rejects(async () => {
@@ -2801,8 +3009,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2829,8 +3039,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2868,8 +3080,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -2891,8 +3105,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -2930,8 +3146,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listSinks.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listSinksStream(request);
@@ -2964,8 +3182,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -2995,8 +3215,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListSinksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listSinks.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listSinksAsync(request);
             await assert.rejects(async () => {
@@ -3024,8 +3246,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3052,8 +3276,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3091,8 +3317,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -3114,8 +3342,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3153,8 +3383,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listExclusions.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listExclusionsStream(request);
@@ -3187,8 +3419,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3218,8 +3452,10 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listExclusions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listExclusionsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -217,24 +218,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.getBucket = stubSimpleCall(expectedResponse);
             const [response] = await client.getBucket(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBucket without error using callback', async () => {
@@ -243,19 +245,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.getBucket = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getBucket(
@@ -270,8 +269,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBucket with error', async () => {
@@ -280,23 +283,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getBucket = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getBucket(request), expectedError);
-            assert((client.innerApiCalls.getBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBucket with closed client', async () => {
@@ -305,7 +307,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBucketRequest', ['name']);
             request.name = defaultValue1;
@@ -322,24 +326,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.createBucket = stubSimpleCall(expectedResponse);
             const [response] = await client.createBucket(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBucket without error using callback', async () => {
@@ -348,19 +353,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.createBucket = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createBucket(
@@ -375,8 +377,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBucket with error', async () => {
@@ -385,23 +391,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createBucket = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createBucket(request), expectedError);
-            assert((client.innerApiCalls.createBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBucket with closed client', async () => {
@@ -410,7 +415,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
@@ -427,24 +434,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.updateBucket = stubSimpleCall(expectedResponse);
             const [response] = await client.updateBucket(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBucket without error using callback', async () => {
@@ -453,19 +461,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogBucket());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogBucket()
+            );
             client.innerApiCalls.updateBucket = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateBucket(
@@ -480,8 +485,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBucket with error', async () => {
@@ -490,23 +499,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateBucket = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateBucket(request), expectedError);
-            assert((client.innerApiCalls.updateBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBucket with closed client', async () => {
@@ -515,7 +523,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
@@ -532,24 +542,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBucket = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteBucket(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBucket without error using callback', async () => {
@@ -558,19 +569,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBucket = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteBucket(
@@ -585,8 +593,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBucket with error', async () => {
@@ -595,23 +607,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteBucket = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteBucket(request), expectedError);
-            assert((client.innerApiCalls.deleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBucket with closed client', async () => {
@@ -620,7 +631,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
@@ -637,24 +650,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UndeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.undeleteBucket = stubSimpleCall(expectedResponse);
             const [response] = await client.undeleteBucket(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.undeleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes undeleteBucket without error using callback', async () => {
@@ -663,19 +677,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UndeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.undeleteBucket = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.undeleteBucket(
@@ -690,8 +701,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.undeleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes undeleteBucket with error', async () => {
@@ -700,23 +715,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UndeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.undeleteBucket = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.undeleteBucket(request), expectedError);
-            assert((client.innerApiCalls.undeleteBucket as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.undeleteBucket as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes undeleteBucket with closed client', async () => {
@@ -725,7 +739,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UndeleteBucketRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UndeleteBucketRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
@@ -742,24 +758,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.getView = stubSimpleCall(expectedResponse);
             const [response] = await client.getView(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getView without error using callback', async () => {
@@ -768,19 +785,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.getView = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getView(
@@ -795,8 +809,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getView with error', async () => {
@@ -805,23 +823,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getView = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getView(request), expectedError);
-            assert((client.innerApiCalls.getView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getView with closed client', async () => {
@@ -830,7 +847,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetViewRequest', ['name']);
             request.name = defaultValue1;
@@ -847,24 +866,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.createView = stubSimpleCall(expectedResponse);
             const [response] = await client.createView(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createView without error using callback', async () => {
@@ -873,19 +893,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.createView = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createView(
@@ -900,8 +917,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createView with error', async () => {
@@ -910,23 +931,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createView = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createView(request), expectedError);
-            assert((client.innerApiCalls.createView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createView with closed client', async () => {
@@ -935,7 +955,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
@@ -952,24 +974,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.updateView = stubSimpleCall(expectedResponse);
             const [response] = await client.updateView(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateView without error using callback', async () => {
@@ -978,19 +1001,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogView());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogView()
+            );
             client.innerApiCalls.updateView = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateView(
@@ -1005,8 +1025,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateView with error', async () => {
@@ -1015,23 +1039,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateView = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateView(request), expectedError);
-            assert((client.innerApiCalls.updateView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateView with closed client', async () => {
@@ -1040,7 +1063,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateViewRequest', ['name']);
             request.name = defaultValue1;
@@ -1057,24 +1082,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteView = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteView(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteView without error using callback', async () => {
@@ -1083,19 +1109,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteView = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteView(
@@ -1110,8 +1133,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteView with error', async () => {
@@ -1120,23 +1147,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteView = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteView(request), expectedError);
-            assert((client.innerApiCalls.deleteView as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteView as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteView with closed client', async () => {
@@ -1145,7 +1171,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteViewRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteViewRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteViewRequest', ['name']);
             request.name = defaultValue1;
@@ -1162,24 +1190,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.getSink = stubSimpleCall(expectedResponse);
             const [response] = await client.getSink(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSink without error using callback', async () => {
@@ -1188,19 +1217,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.getSink = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSink(
@@ -1215,8 +1241,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSink with error', async () => {
@@ -1225,23 +1255,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSink = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSink(request), expectedError);
-            assert((client.innerApiCalls.getSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSink with closed client', async () => {
@@ -1250,7 +1279,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
@@ -1267,24 +1298,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.createSink = stubSimpleCall(expectedResponse);
             const [response] = await client.createSink(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createSink without error using callback', async () => {
@@ -1293,19 +1325,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.createSink = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createSink(
@@ -1320,8 +1349,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createSink with error', async () => {
@@ -1330,23 +1363,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createSink = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createSink(request), expectedError);
-            assert((client.innerApiCalls.createSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createSink with closed client', async () => {
@@ -1355,7 +1387,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1372,24 +1406,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.updateSink = stubSimpleCall(expectedResponse);
             const [response] = await client.updateSink(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSink without error using callback', async () => {
@@ -1398,19 +1433,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogSink());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogSink()
+            );
             client.innerApiCalls.updateSink = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateSink(
@@ -1425,8 +1457,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSink with error', async () => {
@@ -1435,23 +1471,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateSink = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateSink(request), expectedError);
-            assert((client.innerApiCalls.updateSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSink with closed client', async () => {
@@ -1460,7 +1495,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
@@ -1477,24 +1514,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSink = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteSink(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSink without error using callback', async () => {
@@ -1503,19 +1541,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSink = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteSink(
@@ -1530,8 +1565,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSink with error', async () => {
@@ -1540,23 +1579,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteSink = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteSink(request), expectedError);
-            assert((client.innerApiCalls.deleteSink as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSink as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSink with closed client', async () => {
@@ -1565,7 +1603,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteSinkRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteSinkRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
@@ -1582,24 +1622,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.getExclusion = stubSimpleCall(expectedResponse);
             const [response] = await client.getExclusion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getExclusion without error using callback', async () => {
@@ -1608,19 +1649,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.getExclusion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getExclusion(
@@ -1635,8 +1673,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getExclusion with error', async () => {
@@ -1645,23 +1687,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getExclusion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getExclusion(request), expectedError);
-            assert((client.innerApiCalls.getExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getExclusion with closed client', async () => {
@@ -1670,7 +1711,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetExclusionRequest', ['name']);
             request.name = defaultValue1;
@@ -1687,24 +1730,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.createExclusion = stubSimpleCall(expectedResponse);
             const [response] = await client.createExclusion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createExclusion without error using callback', async () => {
@@ -1713,19 +1757,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.createExclusion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createExclusion(
@@ -1740,8 +1781,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createExclusion with error', async () => {
@@ -1750,23 +1795,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createExclusion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createExclusion(request), expectedError);
-            assert((client.innerApiCalls.createExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createExclusion with closed client', async () => {
@@ -1775,7 +1819,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1792,24 +1838,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.updateExclusion = stubSimpleCall(expectedResponse);
             const [response] = await client.updateExclusion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateExclusion without error using callback', async () => {
@@ -1818,19 +1865,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogExclusion());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogExclusion()
+            );
             client.innerApiCalls.updateExclusion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateExclusion(
@@ -1845,8 +1889,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateExclusion with error', async () => {
@@ -1855,23 +1903,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateExclusion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateExclusion(request), expectedError);
-            assert((client.innerApiCalls.updateExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateExclusion with closed client', async () => {
@@ -1880,7 +1927,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
@@ -1897,24 +1946,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteExclusion = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteExclusion(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteExclusion without error using callback', async () => {
@@ -1923,19 +1973,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteExclusion = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteExclusion(
@@ -1950,8 +1997,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteExclusion with error', async () => {
@@ -1960,23 +2011,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteExclusion = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteExclusion(request), expectedError);
-            assert((client.innerApiCalls.deleteExclusion as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteExclusion as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteExclusion with closed client', async () => {
@@ -1985,7 +2035,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteExclusionRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteExclusionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
@@ -2002,24 +2054,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.CmekSettings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.CmekSettings()
+            );
             client.innerApiCalls.getCmekSettings = stubSimpleCall(expectedResponse);
             const [response] = await client.getCmekSettings(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCmekSettings without error using callback', async () => {
@@ -2028,19 +2081,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.CmekSettings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.CmekSettings()
+            );
             client.innerApiCalls.getCmekSettings = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getCmekSettings(
@@ -2055,8 +2105,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCmekSettings with error', async () => {
@@ -2065,23 +2119,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getCmekSettings = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getCmekSettings(request), expectedError);
-            assert((client.innerApiCalls.getCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getCmekSettings with closed client', async () => {
@@ -2090,7 +2143,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
@@ -2107,24 +2162,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.CmekSettings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.CmekSettings()
+            );
             client.innerApiCalls.updateCmekSettings = stubSimpleCall(expectedResponse);
             const [response] = await client.updateCmekSettings(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCmekSettings without error using callback', async () => {
@@ -2133,19 +2189,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.CmekSettings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.CmekSettings()
+            );
             client.innerApiCalls.updateCmekSettings = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateCmekSettings(
@@ -2160,8 +2213,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCmekSettings with error', async () => {
@@ -2170,23 +2227,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateCmekSettings = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateCmekSettings(request), expectedError);
-            assert((client.innerApiCalls.updateCmekSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateCmekSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateCmekSettings with closed client', async () => {
@@ -2195,7 +2251,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateCmekSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateCmekSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
@@ -2212,24 +2270,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.Settings()
+            );
             client.innerApiCalls.getSettings = stubSimpleCall(expectedResponse);
             const [response] = await client.getSettings(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSettings without error using callback', async () => {
@@ -2238,19 +2297,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.Settings()
+            );
             client.innerApiCalls.getSettings = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSettings(
@@ -2265,8 +2321,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSettings with error', async () => {
@@ -2275,23 +2335,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSettings = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSettings(request), expectedError);
-            assert((client.innerApiCalls.getSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSettings with closed client', async () => {
@@ -2300,7 +2359,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSettingsRequest', ['name']);
             request.name = defaultValue1;
@@ -2317,24 +2378,25 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.Settings()
+            );
             client.innerApiCalls.updateSettings = stubSimpleCall(expectedResponse);
             const [response] = await client.updateSettings(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSettings without error using callback', async () => {
@@ -2343,19 +2405,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.Settings());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.Settings()
+            );
             client.innerApiCalls.updateSettings = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateSettings(
@@ -2370,8 +2429,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSettings with error', async () => {
@@ -2380,23 +2443,22 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateSettings = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateSettings(request), expectedError);
-            assert((client.innerApiCalls.updateSettings as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateSettings as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateSettings with closed client', async () => {
@@ -2405,7 +2467,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateSettingsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateSettingsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
@@ -2422,15 +2486,16 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CopyLogEntriesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.copyLogEntries = stubLongRunningCall(expectedResponse);
             const [operation] = await client.copyLogEntries(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.copyLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes copyLogEntries without error using callback', async () => {
@@ -2439,9 +2504,12 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CopyLogEntriesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.copyLogEntries = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.copyLogEntries(
@@ -2459,8 +2527,6 @@ describe('v2.ConfigServiceV2Client', () => {
             const operation = await promise as LROperation<protos.google.logging.v2.ICopyLogEntriesResponse, protos.google.logging.v2.ICopyLogEntriesMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.copyLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes copyLogEntries with call error', async () => {
@@ -2469,13 +2535,12 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CopyLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.copyLogEntries = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.copyLogEntries(request), expectedError);
-            assert((client.innerApiCalls.copyLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes copyLogEntries with LRO error', async () => {
@@ -2484,14 +2549,13 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CopyLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CopyLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.copyLogEntries = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.copyLogEntries(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.copyLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkCopyLogEntriesProgress without error', async () => {
@@ -2500,7 +2564,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -2534,19 +2600,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2554,8 +2614,12 @@ describe('v2.ConfigServiceV2Client', () => {
             client.innerApiCalls.listBuckets = stubSimpleCall(expectedResponse);
             const [response] = await client.listBuckets(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBuckets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBuckets without error using callback', async () => {
@@ -2564,19 +2628,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2595,8 +2653,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBuckets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBuckets with error', async () => {
@@ -2605,23 +2667,22 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listBuckets = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listBuckets(request), expectedError);
-            assert((client.innerApiCalls.listBuckets as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBuckets as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBucketsStream without error', async () => {
@@ -2630,7 +2691,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2658,10 +2721,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listBuckets.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBuckets, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBuckets.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2671,7 +2735,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2694,10 +2760,11 @@ describe('v2.ConfigServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listBuckets.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBuckets, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBuckets.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2707,7 +2774,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2727,10 +2796,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2740,11 +2810,14 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListBucketsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListBucketsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listBuckets.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBucketsAsync(request);
             await assert.rejects(async () => {
@@ -2756,10 +2829,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBuckets.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -2771,19 +2845,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2791,8 +2859,12 @@ describe('v2.ConfigServiceV2Client', () => {
             client.innerApiCalls.listViews = stubSimpleCall(expectedResponse);
             const [response] = await client.listViews(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listViews as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listViews without error using callback', async () => {
@@ -2801,19 +2873,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2832,8 +2898,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listViews as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listViews with error', async () => {
@@ -2842,23 +2912,22 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listViews = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listViews(request), expectedError);
-            assert((client.innerApiCalls.listViews as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listViews as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listViewsStream without error', async () => {
@@ -2867,7 +2936,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2895,10 +2966,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listViews.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listViews, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listViews.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2908,7 +2980,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2931,10 +3005,11 @@ describe('v2.ConfigServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listViews.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listViews, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listViews.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2944,7 +3019,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2964,10 +3041,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listViews.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listViews.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2977,11 +3055,14 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListViewsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListViewsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listViews.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listViewsAsync(request);
             await assert.rejects(async () => {
@@ -2993,10 +3074,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listViews.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listViews.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3008,19 +3090,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -3028,8 +3104,12 @@ describe('v2.ConfigServiceV2Client', () => {
             client.innerApiCalls.listSinks = stubSimpleCall(expectedResponse);
             const [response] = await client.listSinks(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSinks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listSinks without error using callback', async () => {
@@ -3038,19 +3118,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -3069,8 +3143,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSinks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listSinks with error', async () => {
@@ -3079,23 +3157,22 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listSinks = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listSinks(request), expectedError);
-            assert((client.innerApiCalls.listSinks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listSinks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listSinksStream without error', async () => {
@@ -3104,7 +3181,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3132,10 +3211,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listSinks.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listSinks, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listSinks.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3145,7 +3225,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3168,10 +3250,11 @@ describe('v2.ConfigServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listSinks.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listSinks, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listSinks.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3181,7 +3264,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3201,10 +3286,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listSinks.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listSinks.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3214,11 +3300,14 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListSinksRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListSinksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listSinks.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listSinksAsync(request);
             await assert.rejects(async () => {
@@ -3230,10 +3319,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listSinks.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listSinks.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -3245,19 +3335,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3265,8 +3349,12 @@ describe('v2.ConfigServiceV2Client', () => {
             client.innerApiCalls.listExclusions = stubSimpleCall(expectedResponse);
             const [response] = await client.listExclusions(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listExclusions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listExclusions without error using callback', async () => {
@@ -3275,19 +3363,13 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3306,8 +3388,12 @@ describe('v2.ConfigServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listExclusions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listExclusions with error', async () => {
@@ -3316,23 +3402,22 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listExclusions = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listExclusions(request), expectedError);
-            assert((client.innerApiCalls.listExclusions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listExclusions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listExclusionsStream without error', async () => {
@@ -3341,7 +3426,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3369,10 +3456,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listExclusions.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listExclusions, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listExclusions.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3382,7 +3470,9 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3405,10 +3495,11 @@ describe('v2.ConfigServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listExclusions.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listExclusions, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listExclusions.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -3418,7 +3509,9 @@ describe('v2.ConfigServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -3438,10 +3531,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -3451,11 +3545,14 @@ describe('v2.ConfigServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListExclusionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListExclusionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listExclusions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listExclusionsAsync(request);
             await assert.rejects(async () => {
@@ -3467,10 +3564,11 @@ describe('v2.ConfigServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listExclusions.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -210,24 +211,25 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteLog = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteLog(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteLog as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLog without error using callback', async () => {
@@ -236,19 +238,16 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteLog = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteLog(
@@ -263,8 +262,12 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteLog as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLog with error', async () => {
@@ -273,23 +276,22 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteLog = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteLog(request), expectedError);
-            assert((client.innerApiCalls.deleteLog as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLog as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLog with closed client', async () => {
@@ -298,7 +300,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
@@ -315,14 +319,15 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesResponse());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesResponse()
+            );
             client.innerApiCalls.writeLogEntries = stubSimpleCall(expectedResponse);
             const [response] = await client.writeLogEntries(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.writeLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes writeLogEntries without error using callback', async () => {
@@ -331,9 +336,12 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesResponse());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesResponse()
+            );
             client.innerApiCalls.writeLogEntries = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.writeLogEntries(
@@ -348,8 +356,6 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.writeLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes writeLogEntries with error', async () => {
@@ -358,13 +364,12 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.writeLogEntries = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.writeLogEntries(request), expectedError);
-            assert((client.innerApiCalls.writeLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes writeLogEntries with closed client', async () => {
@@ -373,7 +378,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.WriteLogEntriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.WriteLogEntriesRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.writeLogEntries(request), expectedError);
@@ -387,8 +394,13 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesResponse());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.TailLogEntriesRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.TailLogEntriesResponse()
+            );
             client.innerApiCalls.tailLogEntries = stubBidiStreamingCall(expectedResponse);
             const stream = client.tailLogEntries();
             const promise = new Promise((resolve, reject) => {
@@ -415,7 +427,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.TailLogEntriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.TailLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.tailLogEntries = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.tailLogEntries();
@@ -444,9 +458,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -454,8 +468,6 @@ describe('v2.LoggingServiceV2Client', () => {
             client.innerApiCalls.listLogEntries = stubSimpleCall(expectedResponse);
             const [response] = await client.listLogEntries(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listLogEntries without error using callback', async () => {
@@ -464,9 +476,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -485,8 +497,6 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listLogEntries with error', async () => {
@@ -495,13 +505,12 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listLogEntries = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listLogEntries(request), expectedError);
-            assert((client.innerApiCalls.listLogEntries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listLogEntriesStream without error', async () => {
@@ -510,7 +519,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -542,7 +553,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listLogEntries.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listLogEntriesStream(request);
@@ -569,7 +582,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
               generateSampleMessage(new protos.google.logging.v2.LogEntry()),
@@ -593,7 +608,10 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogEntriesRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogEntriesRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listLogEntries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listLogEntriesAsync(request);
             await assert.rejects(async () => {
@@ -615,9 +633,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -625,8 +643,6 @@ describe('v2.LoggingServiceV2Client', () => {
             client.innerApiCalls.listMonitoredResourceDescriptors = stubSimpleCall(expectedResponse);
             const [response] = await client.listMonitoredResourceDescriptors(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listMonitoredResourceDescriptors without error using callback', async () => {
@@ -635,9 +651,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -656,8 +672,6 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listMonitoredResourceDescriptors with error', async () => {
@@ -666,13 +680,12 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listMonitoredResourceDescriptors = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listMonitoredResourceDescriptors(request), expectedError);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listMonitoredResourceDescriptorsStream without error', async () => {
@@ -681,7 +694,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -713,7 +728,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listMonitoredResourceDescriptorsStream(request);
@@ -740,7 +757,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -764,7 +783,10 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListMonitoredResourceDescriptorsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listMonitoredResourceDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -786,24 +808,22 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [new String(), new String(), new String()];
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCall(expectedResponse);
             const [response] = await client.listLogs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogs without error using callback', async () => {
@@ -812,19 +832,13 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [new String(), new String(), new String()];
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.listLogs(
@@ -839,8 +853,12 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogs with error', async () => {
@@ -849,23 +867,22 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listLogs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listLogs(request), expectedError);
-            assert((client.innerApiCalls.listLogs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogsStream without error', async () => {
@@ -874,7 +891,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -898,10 +917,11 @@ describe('v2.LoggingServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listLogs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listLogs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -911,7 +931,9 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -934,10 +956,11 @@ describe('v2.LoggingServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listLogs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listLogs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -947,7 +970,9 @@ describe('v2.LoggingServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -963,10 +988,11 @@ describe('v2.LoggingServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listLogs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -976,11 +1002,14 @@ describe('v2.LoggingServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listLogs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listLogsAsync(request);
             await assert.rejects(async () => {
@@ -992,10 +1021,11 @@ describe('v2.LoggingServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listLogs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -199,8 +211,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
-            request.logName = '';
-            const expectedHeaderRequestParams = "log_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+            request.logName = defaultValue1;
+            const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -223,8 +237,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
-            request.logName = '';
-            const expectedHeaderRequestParams = "log_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+            request.logName = defaultValue1;
+            const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -258,8 +274,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
-            request.logName = '';
-            const expectedHeaderRequestParams = "log_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+            request.logName = defaultValue1;
+            const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -281,7 +299,9 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogRequest());
-            request.logName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+            request.logName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteLog(request), expectedError);
@@ -767,8 +787,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -791,8 +813,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -826,8 +850,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -849,8 +875,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [new String(), new String(), new String()];
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(expectedResponse);
             const stream = client.listLogsStream(request);
@@ -884,8 +912,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listLogs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listLogsStream(request);
@@ -918,8 +948,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [new String(), new String(), new String()];
             client.descriptors.page.listLogs.asyncIterate = stubAsyncIterationCall(expectedResponse);
             const responses: string[] = [];
@@ -945,8 +977,10 @@ describe('v2.LoggingServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listLogs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listLogsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.getLogMetric = stubSimpleCall(expectedResponse);
             const [response] = await client.getLogMetric(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getLogMetric without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.getLogMetric = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getLogMetric(
@@ -254,8 +253,12 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getLogMetric with error', async () => {
@@ -264,23 +267,22 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getLogMetric = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getLogMetric(request), expectedError);
-            assert((client.innerApiCalls.getLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getLogMetric with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.GetLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
@@ -306,24 +310,25 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.createLogMetric = stubSimpleCall(expectedResponse);
             const [response] = await client.createLogMetric(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createLogMetric without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.createLogMetric = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createLogMetric(
@@ -359,8 +361,12 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createLogMetric with error', async () => {
@@ -369,23 +375,22 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createLogMetric = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createLogMetric(request), expectedError);
-            assert((client.innerApiCalls.createLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createLogMetric with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.CreateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
@@ -411,24 +418,25 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.updateLogMetric = stubSimpleCall(expectedResponse);
             const [response] = await client.updateLogMetric(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateLogMetric without error using callback', async () => {
@@ -437,19 +445,16 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.logging.v2.LogMetric());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.logging.v2.LogMetric()
+            );
             client.innerApiCalls.updateLogMetric = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateLogMetric(
@@ -464,8 +469,12 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateLogMetric with error', async () => {
@@ -474,23 +483,22 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateLogMetric = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateLogMetric(request), expectedError);
-            assert((client.innerApiCalls.updateLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateLogMetric with closed client', async () => {
@@ -499,7 +507,9 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.UpdateLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
@@ -516,24 +526,25 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteLogMetric = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteLogMetric(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLogMetric without error using callback', async () => {
@@ -542,19 +553,16 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteLogMetric = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteLogMetric(
@@ -569,8 +577,12 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLogMetric with error', async () => {
@@ -579,23 +591,22 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteLogMetric = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteLogMetric(request), expectedError);
-            assert((client.innerApiCalls.deleteLogMetric as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteLogMetric as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteLogMetric with closed client', async () => {
@@ -604,7 +615,9 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.DeleteLogMetricRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
@@ -621,19 +634,13 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -641,8 +648,12 @@ describe('v2.MetricsServiceV2Client', () => {
             client.innerApiCalls.listLogMetrics = stubSimpleCall(expectedResponse);
             const [response] = await client.listLogMetrics(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogMetrics as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogMetrics without error using callback', async () => {
@@ -651,19 +662,13 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -682,8 +687,12 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listLogMetrics as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogMetrics with error', async () => {
@@ -692,23 +701,22 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listLogMetrics = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listLogMetrics(request), expectedError);
-            assert((client.innerApiCalls.listLogMetrics as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listLogMetrics as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listLogMetricsStream without error', async () => {
@@ -717,7 +725,9 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -745,10 +755,11 @@ describe('v2.MetricsServiceV2Client', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listLogMetrics.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listLogMetrics, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogMetrics.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -758,7 +769,9 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -781,10 +794,11 @@ describe('v2.MetricsServiceV2Client', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listLogMetrics.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listLogMetrics, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogMetrics.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -794,7 +808,9 @@ describe('v2.MetricsServiceV2Client', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -814,10 +830,11 @@ describe('v2.MetricsServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -827,11 +844,14 @@ describe('v2.MetricsServiceV2Client', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
+            const request = generateSampleMessage(
+              new protos.google.logging.v2.ListLogMetricsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listLogMetrics.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listLogMetricsAsync(request);
             await assert.rejects(async () => {
@@ -843,10 +863,11 @@ describe('v2.MetricsServiceV2Client', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listLogMetrics.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.GetLogMetricRequest());
-            request.metricName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getLogMetric(request), expectedError);
@@ -287,8 +307,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.CreateLogMetricRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createLogMetric(request), expectedError);
@@ -384,8 +412,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -408,8 +438,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -443,8 +475,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -466,7 +500,9 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.UpdateLogMetricRequest());
-            request.metricName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateLogMetric(request), expectedError);
@@ -481,8 +517,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -505,8 +543,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -540,8 +580,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
-            request.metricName = '';
-            const expectedHeaderRequestParams = "metric_name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
+            const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -563,7 +605,9 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.DeleteLogMetricRequest());
-            request.metricName = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+            request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteLogMetric(request), expectedError);
@@ -578,8 +622,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -606,8 +652,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -645,8 +693,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -668,8 +718,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -707,8 +759,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listLogMetrics.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listLogMetricsStream(request);
@@ -741,8 +795,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -772,8 +828,10 @@ describe('v2.MetricsServiceV2Client', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.logging.v2.ListLogMetricsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listLogMetrics.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listLogMetricsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -450,7 +450,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getAlertPolicy(request, options, callback);
@@ -532,7 +532,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createAlertPolicy(request, options, callback);
@@ -607,7 +607,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteAlertPolicy(request, options, callback);
@@ -706,7 +706,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'alert_policy.name': request.alertPolicy!.name || '',
+      'alert_policy.name': request.alertPolicy!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateAlertPolicy(request, options, callback);
@@ -810,7 +810,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listAlertPolicies(request, options, callback);
@@ -872,7 +872,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listAlertPolicies'];
     const callSettings = defaultCallSettings.merge(options);
@@ -943,7 +943,7 @@ export class AlertPolicyServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listAlertPolicies'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -454,7 +454,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getGroup(request, options, callback);
@@ -531,7 +531,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createGroup(request, options, callback);
@@ -606,7 +606,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'group.name': request.group!.name || '',
+      'group.name': request.group!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateGroup(request, options, callback);
@@ -682,7 +682,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteGroup(request, options, callback);
@@ -781,7 +781,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listGroups(request, options, callback);
@@ -838,7 +838,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listGroups'];
     const callSettings = defaultCallSettings.merge(options);
@@ -904,7 +904,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listGroups'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1006,7 +1006,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listGroupMembers(request, options, callback);
@@ -1061,7 +1061,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listGroupMembers'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1125,7 +1125,7 @@ export class GroupServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listGroupMembers'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -467,7 +467,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getMonitoredResourceDescriptor(request, options, callback);
@@ -541,7 +541,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getMetricDescriptor(request, options, callback);
@@ -618,7 +618,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createMetricDescriptor(request, options, callback);
@@ -693,7 +693,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteMetricDescriptor(request, options, callback);
@@ -776,7 +776,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createTimeSeries(request, options, callback);
@@ -868,7 +868,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listMonitoredResourceDescriptors(request, options, callback);
@@ -918,7 +918,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listMonitoredResourceDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -977,7 +977,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listMonitoredResourceDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1075,7 +1075,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listMetricDescriptors(request, options, callback);
@@ -1126,7 +1126,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listMetricDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1186,7 +1186,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listMetricDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1302,7 +1302,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listTimeSeries(request, options, callback);
@@ -1371,7 +1371,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listTimeSeries'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1449,7 +1449,7 @@ export class MetricServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listTimeSeries'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -445,7 +445,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getNotificationChannelDescriptor(request, options, callback);
@@ -521,7 +521,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getNotificationChannel(request, options, callback);
@@ -602,7 +602,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createNotificationChannel(request, options, callback);
@@ -679,7 +679,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'notification_channel.name': request.notificationChannel!.name || '',
+      'notification_channel.name': request.notificationChannel!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateNotificationChannel(request, options, callback);
@@ -756,7 +756,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteNotificationChannel(request, options, callback);
@@ -828,7 +828,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.sendNotificationChannelVerificationCode(request, options, callback);
@@ -931,7 +931,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getNotificationChannelVerificationCode(request, options, callback);
@@ -1012,7 +1012,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.verifyNotificationChannel(request, options, callback);
@@ -1106,7 +1106,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listNotificationChannelDescriptors(request, options, callback);
@@ -1157,7 +1157,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannelDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1217,7 +1217,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannelDescriptors'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1326,7 +1326,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listNotificationChannels(request, options, callback);
@@ -1388,7 +1388,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannels'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1459,7 +1459,7 @@ export class NotificationChannelServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     const defaultCallSettings = this._defaults['listNotificationChannels'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -451,7 +451,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createService(request, options, callback);
@@ -523,7 +523,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getService(request, options, callback);
@@ -597,7 +597,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'service.name': request.service!.name || '',
+      'service.name': request.service!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateService(request, options, callback);
@@ -669,7 +669,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteService(request, options, callback);
@@ -749,7 +749,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createServiceLevelObjective(request, options, callback);
@@ -827,7 +827,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getServiceLevelObjective(request, options, callback);
@@ -901,7 +901,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'service_level_objective.name': request.serviceLevelObjective!.name || '',
+      'service_level_objective.name': request.serviceLevelObjective!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateServiceLevelObjective(request, options, callback);
@@ -974,7 +974,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteServiceLevelObjective(request, options, callback);
@@ -1075,7 +1075,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listServices(request, options, callback);
@@ -1134,7 +1134,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listServices'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1202,7 +1202,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listServices'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1299,7 +1299,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listServiceLevelObjectives(request, options, callback);
@@ -1349,7 +1349,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listServiceLevelObjectives'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1408,7 +1408,7 @@ export class ServiceMonitoringServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listServiceLevelObjectives'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -450,7 +450,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getUptimeCheckConfig(request, options, callback);
@@ -524,7 +524,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createUptimeCheckConfig(request, options, callback);
@@ -613,7 +613,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'uptime_check_config.name': request.uptimeCheckConfig!.name || '',
+      'uptime_check_config.name': request.uptimeCheckConfig!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateUptimeCheckConfig(request, options, callback);
@@ -687,7 +687,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteUptimeCheckConfig(request, options, callback);
@@ -775,7 +775,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listUptimeCheckConfigs(request, options, callback);
@@ -820,7 +820,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listUptimeCheckConfigs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -874,7 +874,7 @@ export class UptimeCheckServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listUptimeCheckConfigs'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.getAlertPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.getAlertPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getAlertPolicy without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.getAlertPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getAlertPolicy(
@@ -254,8 +253,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getAlertPolicy with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getAlertPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getAlertPolicy(request), expectedError);
-            assert((client.innerApiCalls.getAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getAlertPolicy with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.createAlertPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.createAlertPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createAlertPolicy without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.createAlertPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createAlertPolicy(
@@ -359,8 +361,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createAlertPolicy with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createAlertPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createAlertPolicy(request), expectedError);
-            assert((client.innerApiCalls.createAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createAlertPolicy with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
@@ -411,24 +418,25 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteAlertPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteAlertPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteAlertPolicy without error using callback', async () => {
@@ -437,19 +445,16 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteAlertPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteAlertPolicy(
@@ -464,8 +469,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteAlertPolicy with error', async () => {
@@ -474,23 +483,22 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteAlertPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteAlertPolicy(request), expectedError);
-            assert((client.innerApiCalls.deleteAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteAlertPolicy with closed client', async () => {
@@ -499,7 +507,9 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
@@ -516,25 +526,26 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateAlertPolicyRequest()
+            );
             request.alertPolicy ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.updateAlertPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.updateAlertPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateAlertPolicy without error using callback', async () => {
@@ -543,20 +554,17 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateAlertPolicyRequest()
+            );
             request.alertPolicy ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.AlertPolicy()
+            );
             client.innerApiCalls.updateAlertPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateAlertPolicy(
@@ -571,8 +579,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateAlertPolicy with error', async () => {
@@ -581,24 +593,23 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateAlertPolicyRequest()
+            );
             request.alertPolicy ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateAlertPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateAlertPolicy(request), expectedError);
-            assert((client.innerApiCalls.updateAlertPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateAlertPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateAlertPolicy with closed client', async () => {
@@ -607,7 +618,9 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateAlertPolicyRequest()
+            );
             request.alertPolicy ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
@@ -625,19 +638,13 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -645,8 +652,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             client.innerApiCalls.listAlertPolicies = stubSimpleCall(expectedResponse);
             const [response] = await client.listAlertPolicies(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listAlertPolicies as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listAlertPolicies without error using callback', async () => {
@@ -655,19 +666,13 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -686,8 +691,12 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listAlertPolicies as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listAlertPolicies with error', async () => {
@@ -696,23 +705,22 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listAlertPolicies = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listAlertPolicies(request), expectedError);
-            assert((client.innerApiCalls.listAlertPolicies as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listAlertPolicies as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listAlertPoliciesStream without error', async () => {
@@ -721,7 +729,9 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
@@ -749,10 +759,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listAlertPolicies.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listAlertPolicies, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listAlertPolicies.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -762,7 +773,9 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
@@ -785,10 +798,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listAlertPolicies.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listAlertPolicies, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listAlertPolicies.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -798,7 +812,9 @@ describe('v3.AlertPolicyServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
@@ -818,10 +834,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listAlertPolicies.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listAlertPolicies.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -831,11 +848,14 @@ describe('v3.AlertPolicyServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListAlertPoliciesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listAlertPolicies.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listAlertPoliciesAsync(request);
             await assert.rejects(async () => {
@@ -847,10 +867,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listAlertPolicies.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listAlertPolicies.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetAlertPolicyRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getAlertPolicy(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateAlertPolicyRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createAlertPolicy(request), expectedError);
@@ -384,8 +412,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -408,8 +438,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -443,8 +475,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -466,7 +500,9 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteAlertPolicyRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteAlertPolicy(request), expectedError);
@@ -481,9 +517,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
-            request.alertPolicy = {};
-            request.alertPolicy.name = '';
-            const expectedHeaderRequestParams = "alert_policy.name=";
+            request.alertPolicy ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+            request.alertPolicy.name = defaultValue1;
+            const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -506,9 +544,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
-            request.alertPolicy = {};
-            request.alertPolicy.name = '';
-            const expectedHeaderRequestParams = "alert_policy.name=";
+            request.alertPolicy ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+            request.alertPolicy.name = defaultValue1;
+            const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -542,9 +582,11 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
-            request.alertPolicy = {};
-            request.alertPolicy.name = '';
-            const expectedHeaderRequestParams = "alert_policy.name=";
+            request.alertPolicy ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+            request.alertPolicy.name = defaultValue1;
+            const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -566,8 +608,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateAlertPolicyRequest());
-            request.alertPolicy = {};
-            request.alertPolicy.name = '';
+            request.alertPolicy ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+            request.alertPolicy.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateAlertPolicy(request), expectedError);
@@ -582,8 +626,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -610,8 +656,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -649,8 +697,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -672,8 +722,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -711,8 +763,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listAlertPolicies.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listAlertPoliciesStream(request);
@@ -745,8 +799,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -776,8 +832,10 @@ describe('v3.AlertPolicyServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListAlertPoliciesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listAlertPolicies.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listAlertPoliciesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetGroupRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getGroup(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGroupRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createGroup(request), expectedError);
@@ -384,9 +412,11 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
-            request.group = {};
-            request.group.name = '';
-            const expectedHeaderRequestParams = "group.name=";
+            request.group ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+            request.group.name = defaultValue1;
+            const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -409,9 +439,11 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
-            request.group = {};
-            request.group.name = '';
-            const expectedHeaderRequestParams = "group.name=";
+            request.group ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+            request.group.name = defaultValue1;
+            const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -445,9 +477,11 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
-            request.group = {};
-            request.group.name = '';
-            const expectedHeaderRequestParams = "group.name=";
+            request.group ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+            request.group.name = defaultValue1;
+            const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,8 +503,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
-            request.group = {};
-            request.group.name = '';
+            request.group ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+            request.group.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateGroup(request), expectedError);
@@ -485,8 +521,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -509,8 +547,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -544,8 +584,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -567,7 +609,9 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteGroup(request), expectedError);
@@ -582,8 +626,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -610,8 +656,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -649,8 +697,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -672,8 +722,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -711,8 +763,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listGroups.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listGroupsStream(request);
@@ -745,8 +799,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -776,8 +832,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listGroups.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGroupsAsync(request);
             await assert.rejects(async () => {
@@ -805,8 +863,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -833,8 +893,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -872,8 +934,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -895,8 +959,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -934,8 +1000,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listGroupMembers.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listGroupMembersStream(request);
@@ -968,8 +1036,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -999,8 +1069,10 @@ describe('v3.GroupServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listGroupMembers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGroupMembersAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.getGroup = stubSimpleCall(expectedResponse);
             const [response] = await client.getGroup(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGroup without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.getGroup = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getGroup(
@@ -254,8 +253,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGroup with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getGroup = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getGroup(request), expectedError);
-            assert((client.innerApiCalls.getGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGroup with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGroupRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.createGroup = stubSimpleCall(expectedResponse);
             const [response] = await client.createGroup(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGroup without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.createGroup = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createGroup(
@@ -359,8 +361,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGroup with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createGroup = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createGroup(request), expectedError);
-            assert((client.innerApiCalls.createGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGroup with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGroupRequest', ['name']);
             request.name = defaultValue1;
@@ -411,25 +418,26 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateGroupRequest()
+            );
             request.group ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.updateGroup = stubSimpleCall(expectedResponse);
             const [response] = await client.updateGroup(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateGroup without error using callback', async () => {
@@ -438,20 +446,17 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateGroupRequest()
+            );
             request.group ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Group());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Group()
+            );
             client.innerApiCalls.updateGroup = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateGroup(
@@ -466,8 +471,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateGroup with error', async () => {
@@ -476,24 +485,23 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateGroupRequest()
+            );
             request.group ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateGroup = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateGroup(request), expectedError);
-            assert((client.innerApiCalls.updateGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateGroup with closed client', async () => {
@@ -502,7 +510,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateGroupRequest()
+            );
             request.group ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
@@ -520,24 +530,25 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteGroup = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteGroup(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGroup without error using callback', async () => {
@@ -546,19 +557,16 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteGroup = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteGroup(
@@ -573,8 +581,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGroup with error', async () => {
@@ -583,23 +595,22 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteGroup = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteGroup(request), expectedError);
-            assert((client.innerApiCalls.deleteGroup as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGroup as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGroup with closed client', async () => {
@@ -608,7 +619,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteGroupRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteGroupRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
@@ -625,19 +638,13 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -645,8 +652,12 @@ describe('v3.GroupServiceClient', () => {
             client.innerApiCalls.listGroups = stubSimpleCall(expectedResponse);
             const [response] = await client.listGroups(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGroups as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroups without error using callback', async () => {
@@ -655,19 +666,13 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -686,8 +691,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGroups as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroups with error', async () => {
@@ -696,23 +705,22 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listGroups = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listGroups(request), expectedError);
-            assert((client.innerApiCalls.listGroups as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroups as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroupsStream without error', async () => {
@@ -721,7 +729,9 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
@@ -749,10 +759,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listGroups.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGroups, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroups.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -762,7 +773,9 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
@@ -785,10 +798,11 @@ describe('v3.GroupServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listGroups.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGroups, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroups.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -798,7 +812,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
@@ -818,10 +834,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGroups.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroups.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -831,11 +848,14 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listGroups.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGroupsAsync(request);
             await assert.rejects(async () => {
@@ -847,10 +867,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGroups.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroups.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -862,19 +883,13 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -882,8 +897,12 @@ describe('v3.GroupServiceClient', () => {
             client.innerApiCalls.listGroupMembers = stubSimpleCall(expectedResponse);
             const [response] = await client.listGroupMembers(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGroupMembers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroupMembers without error using callback', async () => {
@@ -892,19 +911,13 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -923,8 +936,12 @@ describe('v3.GroupServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGroupMembers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroupMembers with error', async () => {
@@ -933,23 +950,22 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listGroupMembers = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listGroupMembers(request), expectedError);
-            assert((client.innerApiCalls.listGroupMembers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGroupMembers as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGroupMembersStream without error', async () => {
@@ -958,7 +974,9 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
@@ -986,10 +1004,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listGroupMembers.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGroupMembers, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroupMembers.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -999,7 +1018,9 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
@@ -1022,10 +1043,11 @@ describe('v3.GroupServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listGroupMembers.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGroupMembers, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroupMembers.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1035,7 +1057,9 @@ describe('v3.GroupServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
@@ -1055,10 +1079,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGroupMembers.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroupMembers.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1068,11 +1093,14 @@ describe('v3.GroupServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListGroupMembersRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListGroupMembersRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listGroupMembers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGroupMembersAsync(request);
             await assert.rejects(async () => {
@@ -1084,10 +1112,11 @@ describe('v3.GroupServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGroupMembers.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGroupMembers.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MonitoredResourceDescriptor()
+            );
             client.innerApiCalls.getMonitoredResourceDescriptor = stubSimpleCall(expectedResponse);
             const [response] = await client.getMonitoredResourceDescriptor(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMonitoredResourceDescriptor without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MonitoredResourceDescriptor()
+            );
             client.innerApiCalls.getMonitoredResourceDescriptor = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getMonitoredResourceDescriptor(
@@ -254,8 +253,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMonitoredResourceDescriptor with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getMonitoredResourceDescriptor = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getMonitoredResourceDescriptor(request), expectedError);
-            assert((client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMonitoredResourceDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMonitoredResourceDescriptor with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MetricDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MetricDescriptor()
+            );
             client.innerApiCalls.getMetricDescriptor = stubSimpleCall(expectedResponse);
             const [response] = await client.getMetricDescriptor(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMetricDescriptor without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MetricDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MetricDescriptor()
+            );
             client.innerApiCalls.getMetricDescriptor = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getMetricDescriptor(
@@ -359,8 +361,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMetricDescriptor with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getMetricDescriptor = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getMetricDescriptor(request), expectedError);
-            assert((client.innerApiCalls.getMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getMetricDescriptor with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
@@ -411,24 +418,25 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MetricDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MetricDescriptor()
+            );
             client.innerApiCalls.createMetricDescriptor = stubSimpleCall(expectedResponse);
             const [response] = await client.createMetricDescriptor(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createMetricDescriptor without error using callback', async () => {
@@ -437,19 +445,16 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.api.MetricDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.api.MetricDescriptor()
+            );
             client.innerApiCalls.createMetricDescriptor = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createMetricDescriptor(
@@ -464,8 +469,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createMetricDescriptor with error', async () => {
@@ -474,23 +483,22 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createMetricDescriptor = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createMetricDescriptor(request), expectedError);
-            assert((client.innerApiCalls.createMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createMetricDescriptor with closed client', async () => {
@@ -499,7 +507,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
@@ -516,24 +526,25 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteMetricDescriptor = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteMetricDescriptor(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteMetricDescriptor without error using callback', async () => {
@@ -542,19 +553,16 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteMetricDescriptor = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteMetricDescriptor(
@@ -569,8 +577,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteMetricDescriptor with error', async () => {
@@ -579,23 +591,22 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteMetricDescriptor = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteMetricDescriptor(request), expectedError);
-            assert((client.innerApiCalls.deleteMetricDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteMetricDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteMetricDescriptor with closed client', async () => {
@@ -604,7 +615,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
@@ -621,24 +634,25 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.createTimeSeries = stubSimpleCall(expectedResponse);
             const [response] = await client.createTimeSeries(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTimeSeries without error using callback', async () => {
@@ -647,19 +661,16 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.createTimeSeries = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createTimeSeries(
@@ -674,8 +685,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTimeSeries with error', async () => {
@@ -684,23 +699,22 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createTimeSeries = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createTimeSeries(request), expectedError);
-            assert((client.innerApiCalls.createTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTimeSeries with closed client', async () => {
@@ -709,7 +723,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
@@ -726,19 +742,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -746,8 +756,12 @@ describe('v3.MetricServiceClient', () => {
             client.innerApiCalls.listMonitoredResourceDescriptors = stubSimpleCall(expectedResponse);
             const [response] = await client.listMonitoredResourceDescriptors(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMonitoredResourceDescriptors without error using callback', async () => {
@@ -756,19 +770,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -787,8 +795,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMonitoredResourceDescriptors with error', async () => {
@@ -797,23 +809,22 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listMonitoredResourceDescriptors = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listMonitoredResourceDescriptors(request), expectedError);
-            assert((client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMonitoredResourceDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMonitoredResourceDescriptorsStream without error', async () => {
@@ -822,7 +833,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -850,10 +863,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listMonitoredResourceDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listMonitoredResourceDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMonitoredResourceDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -863,7 +877,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -886,10 +902,11 @@ describe('v3.MetricServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listMonitoredResourceDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listMonitoredResourceDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMonitoredResourceDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -899,7 +916,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -919,10 +938,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -932,11 +952,14 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listMonitoredResourceDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -948,10 +971,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -963,19 +987,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -983,8 +1001,12 @@ describe('v3.MetricServiceClient', () => {
             client.innerApiCalls.listMetricDescriptors = stubSimpleCall(expectedResponse);
             const [response] = await client.listMetricDescriptors(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMetricDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMetricDescriptors without error using callback', async () => {
@@ -993,19 +1015,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -1024,8 +1040,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listMetricDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMetricDescriptors with error', async () => {
@@ -1034,23 +1054,22 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listMetricDescriptors = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listMetricDescriptors(request), expectedError);
-            assert((client.innerApiCalls.listMetricDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listMetricDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listMetricDescriptorsStream without error', async () => {
@@ -1059,7 +1078,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1087,10 +1108,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listMetricDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listMetricDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMetricDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1100,7 +1122,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1123,10 +1147,11 @@ describe('v3.MetricServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listMetricDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listMetricDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMetricDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1136,7 +1161,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1156,10 +1183,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listMetricDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMetricDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1169,11 +1197,14 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listMetricDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listMetricDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -1185,10 +1216,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listMetricDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listMetricDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1200,19 +1232,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1220,8 +1246,12 @@ describe('v3.MetricServiceClient', () => {
             client.innerApiCalls.listTimeSeries = stubSimpleCall(expectedResponse);
             const [response] = await client.listTimeSeries(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTimeSeries without error using callback', async () => {
@@ -1230,19 +1260,13 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1261,8 +1285,12 @@ describe('v3.MetricServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTimeSeries with error', async () => {
@@ -1271,23 +1299,22 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listTimeSeries = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listTimeSeries(request), expectedError);
-            assert((client.innerApiCalls.listTimeSeries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTimeSeries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTimeSeriesStream without error', async () => {
@@ -1296,7 +1323,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
@@ -1324,10 +1353,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listTimeSeries.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTimeSeries, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTimeSeries.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1337,7 +1367,9 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
@@ -1360,10 +1392,11 @@ describe('v3.MetricServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listTimeSeries.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTimeSeries, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTimeSeries.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1373,7 +1406,9 @@ describe('v3.MetricServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
@@ -1393,10 +1428,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTimeSeries.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTimeSeries.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1406,11 +1442,14 @@ describe('v3.MetricServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListTimeSeriesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listTimeSeries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTimeSeriesAsync(request);
             await assert.rejects(async () => {
@@ -1422,10 +1461,11 @@ describe('v3.MetricServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTimeSeries.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTimeSeries.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getMonitoredResourceDescriptor(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetMetricDescriptorRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getMetricDescriptor(request), expectedError);
@@ -384,8 +412,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -408,8 +438,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -443,8 +475,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -466,7 +500,9 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateMetricDescriptorRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createMetricDescriptor(request), expectedError);
@@ -481,8 +517,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -505,8 +543,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -540,8 +580,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -563,7 +605,9 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteMetricDescriptorRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteMetricDescriptor(request), expectedError);
@@ -578,8 +622,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -602,8 +648,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -637,8 +685,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -660,7 +710,9 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateTimeSeriesRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createTimeSeries(request), expectedError);
@@ -675,8 +727,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -703,8 +757,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -742,8 +798,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -765,8 +823,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -804,8 +864,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listMonitoredResourceDescriptorsStream(request);
@@ -838,8 +900,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -869,8 +933,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listMonitoredResourceDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listMonitoredResourceDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -898,8 +964,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -926,8 +994,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -965,8 +1035,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -988,8 +1060,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -1027,8 +1101,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listMetricDescriptors.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listMetricDescriptorsStream(request);
@@ -1061,8 +1137,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -1092,8 +1170,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListMetricDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listMetricDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listMetricDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -1121,8 +1201,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1149,8 +1231,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1188,8 +1272,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1211,8 +1297,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1250,8 +1338,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listTimeSeries.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listTimeSeriesStream(request);
@@ -1284,8 +1374,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1315,8 +1407,10 @@ describe('v3.MetricServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListTimeSeriesRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listTimeSeries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTimeSeriesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getNotificationChannelDescriptor(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getNotificationChannel(request), expectedError);
@@ -384,8 +412,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -408,8 +438,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -443,8 +475,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -466,7 +500,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createNotificationChannel(request), expectedError);
@@ -481,9 +517,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
-            request.notificationChannel = {};
-            request.notificationChannel.name = '';
-            const expectedHeaderRequestParams = "notification_channel.name=";
+            request.notificationChannel ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+            request.notificationChannel.name = defaultValue1;
+            const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -506,9 +544,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
-            request.notificationChannel = {};
-            request.notificationChannel.name = '';
-            const expectedHeaderRequestParams = "notification_channel.name=";
+            request.notificationChannel ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+            request.notificationChannel.name = defaultValue1;
+            const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -542,9 +582,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
-            request.notificationChannel = {};
-            request.notificationChannel.name = '';
-            const expectedHeaderRequestParams = "notification_channel.name=";
+            request.notificationChannel ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+            request.notificationChannel.name = defaultValue1;
+            const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -566,8 +608,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
-            request.notificationChannel = {};
-            request.notificationChannel.name = '';
+            request.notificationChannel ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+            request.notificationChannel.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateNotificationChannel(request), expectedError);
@@ -582,8 +626,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -606,8 +652,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -641,8 +689,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -664,7 +714,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteNotificationChannel(request), expectedError);
@@ -679,8 +731,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -703,8 +757,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -738,8 +794,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -761,7 +819,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.sendNotificationChannelVerificationCode(request), expectedError);
@@ -776,8 +836,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -800,8 +862,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -835,8 +899,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -858,7 +924,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getNotificationChannelVerificationCode(request), expectedError);
@@ -873,8 +941,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -897,8 +967,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -932,8 +1004,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -955,7 +1029,9 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.verifyNotificationChannel(request), expectedError);
@@ -970,8 +1046,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -998,8 +1076,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1037,8 +1117,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1060,8 +1142,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1099,8 +1183,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannelDescriptors.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listNotificationChannelDescriptorsStream(request);
@@ -1133,8 +1219,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1164,8 +1252,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannelDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listNotificationChannelDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -1193,8 +1283,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1221,8 +1313,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1260,8 +1354,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1283,8 +1379,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1322,8 +1420,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannels.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listNotificationChannelsStream(request);
@@ -1356,8 +1456,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1387,8 +1489,10 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannels.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listNotificationChannelsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannelDescriptor()
+            );
             client.innerApiCalls.getNotificationChannelDescriptor = stubSimpleCall(expectedResponse);
             const [response] = await client.getNotificationChannelDescriptor(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelDescriptor without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannelDescriptor()
+            );
             client.innerApiCalls.getNotificationChannelDescriptor = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getNotificationChannelDescriptor(
@@ -254,8 +253,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelDescriptor with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getNotificationChannelDescriptor = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getNotificationChannelDescriptor(request), expectedError);
-            assert((client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelDescriptor as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelDescriptor with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.getNotificationChannel = stubSimpleCall(expectedResponse);
             const [response] = await client.getNotificationChannel(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannel without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.getNotificationChannel = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getNotificationChannel(
@@ -359,8 +361,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannel with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getNotificationChannel = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getNotificationChannel(request), expectedError);
-            assert((client.innerApiCalls.getNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannel with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
@@ -411,24 +418,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.createNotificationChannel = stubSimpleCall(expectedResponse);
             const [response] = await client.createNotificationChannel(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createNotificationChannel without error using callback', async () => {
@@ -437,19 +445,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.createNotificationChannel = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createNotificationChannel(
@@ -464,8 +469,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createNotificationChannel with error', async () => {
@@ -474,23 +483,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createNotificationChannel = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createNotificationChannel(request), expectedError);
-            assert((client.innerApiCalls.createNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createNotificationChannel with closed client', async () => {
@@ -499,7 +507,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
@@ -516,25 +526,26 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateNotificationChannelRequest()
+            );
             request.notificationChannel ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.updateNotificationChannel = stubSimpleCall(expectedResponse);
             const [response] = await client.updateNotificationChannel(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateNotificationChannel without error using callback', async () => {
@@ -543,20 +554,17 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateNotificationChannelRequest()
+            );
             request.notificationChannel ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.updateNotificationChannel = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateNotificationChannel(
@@ -571,8 +579,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateNotificationChannel with error', async () => {
@@ -581,24 +593,23 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateNotificationChannelRequest()
+            );
             request.notificationChannel ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateNotificationChannel = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateNotificationChannel(request), expectedError);
-            assert((client.innerApiCalls.updateNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateNotificationChannel with closed client', async () => {
@@ -607,7 +618,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateNotificationChannelRequest()
+            );
             request.notificationChannel ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
@@ -625,24 +638,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteNotificationChannel = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteNotificationChannel(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteNotificationChannel without error using callback', async () => {
@@ -651,19 +665,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteNotificationChannel = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteNotificationChannel(
@@ -678,8 +689,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteNotificationChannel with error', async () => {
@@ -688,23 +703,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteNotificationChannel = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteNotificationChannel(request), expectedError);
-            assert((client.innerApiCalls.deleteNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteNotificationChannel with closed client', async () => {
@@ -713,7 +727,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
@@ -730,24 +746,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.sendNotificationChannelVerificationCode = stubSimpleCall(expectedResponse);
             const [response] = await client.sendNotificationChannelVerificationCode(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes sendNotificationChannelVerificationCode without error using callback', async () => {
@@ -756,19 +773,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.sendNotificationChannelVerificationCode = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.sendNotificationChannelVerificationCode(
@@ -783,8 +797,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes sendNotificationChannelVerificationCode with error', async () => {
@@ -793,23 +811,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.sendNotificationChannelVerificationCode = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.sendNotificationChannelVerificationCode(request), expectedError);
-            assert((client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.sendNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes sendNotificationChannelVerificationCode with closed client', async () => {
@@ -818,7 +835,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
@@ -835,24 +854,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse()
+            );
             client.innerApiCalls.getNotificationChannelVerificationCode = stubSimpleCall(expectedResponse);
             const [response] = await client.getNotificationChannelVerificationCode(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelVerificationCode without error using callback', async () => {
@@ -861,19 +881,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse()
+            );
             client.innerApiCalls.getNotificationChannelVerificationCode = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getNotificationChannelVerificationCode(
@@ -888,8 +905,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelVerificationCode with error', async () => {
@@ -898,23 +919,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getNotificationChannelVerificationCode = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getNotificationChannelVerificationCode(request), expectedError);
-            assert((client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getNotificationChannelVerificationCode as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getNotificationChannelVerificationCode with closed client', async () => {
@@ -923,7 +943,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
@@ -940,24 +962,25 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.verifyNotificationChannel = stubSimpleCall(expectedResponse);
             const [response] = await client.verifyNotificationChannel(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyNotificationChannel without error using callback', async () => {
@@ -966,19 +989,16 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.NotificationChannel()
+            );
             client.innerApiCalls.verifyNotificationChannel = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.verifyNotificationChannel(
@@ -993,8 +1013,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyNotificationChannel with error', async () => {
@@ -1003,23 +1027,22 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.verifyNotificationChannel = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.verifyNotificationChannel(request), expectedError);
-            assert((client.innerApiCalls.verifyNotificationChannel as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyNotificationChannel as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyNotificationChannel with closed client', async () => {
@@ -1028,7 +1051,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.VerifyNotificationChannelRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
@@ -1045,19 +1070,13 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1065,8 +1084,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             client.innerApiCalls.listNotificationChannelDescriptors = stubSimpleCall(expectedResponse);
             const [response] = await client.listNotificationChannelDescriptors(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannelDescriptors without error using callback', async () => {
@@ -1075,19 +1098,13 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1106,8 +1123,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannelDescriptors with error', async () => {
@@ -1116,23 +1137,22 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listNotificationChannelDescriptors = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listNotificationChannelDescriptors(request), expectedError);
-            assert((client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannelDescriptors as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannelDescriptorsStream without error', async () => {
@@ -1141,7 +1161,9 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1169,10 +1191,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listNotificationChannelDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listNotificationChannelDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannelDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1182,7 +1205,9 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1205,10 +1230,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listNotificationChannelDescriptors.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listNotificationChannelDescriptors, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannelDescriptors.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1218,7 +1244,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
@@ -1238,10 +1266,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listNotificationChannelDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannelDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1251,11 +1280,14 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannelDescriptors.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listNotificationChannelDescriptorsAsync(request);
             await assert.rejects(async () => {
@@ -1267,10 +1299,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listNotificationChannelDescriptors.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannelDescriptors.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1282,19 +1315,13 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1302,8 +1329,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             client.innerApiCalls.listNotificationChannels = stubSimpleCall(expectedResponse);
             const [response] = await client.listNotificationChannels(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listNotificationChannels as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannels without error using callback', async () => {
@@ -1312,19 +1343,13 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1343,8 +1368,12 @@ describe('v3.NotificationChannelServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listNotificationChannels as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannels with error', async () => {
@@ -1353,23 +1382,22 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listNotificationChannels = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listNotificationChannels(request), expectedError);
-            assert((client.innerApiCalls.listNotificationChannels as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listNotificationChannels as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listNotificationChannelsStream without error', async () => {
@@ -1378,7 +1406,9 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
@@ -1406,10 +1436,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listNotificationChannels.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listNotificationChannels, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannels.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1419,7 +1450,9 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
@@ -1442,10 +1475,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listNotificationChannels.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listNotificationChannels, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannels.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1455,7 +1489,9 @@ describe('v3.NotificationChannelServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
@@ -1475,10 +1511,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listNotificationChannels.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannels.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1488,11 +1525,14 @@ describe('v3.NotificationChannelServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListNotificationChannelsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListNotificationChannelsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
-            const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listNotificationChannels.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listNotificationChannelsAsync(request);
             await assert.rejects(async () => {
@@ -1504,10 +1544,11 @@ describe('v3.NotificationChannelServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listNotificationChannels.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listNotificationChannels.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.createService = stubSimpleCall(expectedResponse);
             const [response] = await client.createService(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createService without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.createService = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createService(
@@ -254,8 +253,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createService with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createService = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createService(request), expectedError);
-            assert((client.innerApiCalls.createService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createService with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.getService = stubSimpleCall(expectedResponse);
             const [response] = await client.getService(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getService without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.getService = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getService(
@@ -359,8 +361,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getService with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getService = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getService(request), expectedError);
-            assert((client.innerApiCalls.getService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getService with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceRequest', ['name']);
             request.name = defaultValue1;
@@ -411,25 +418,26 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceRequest()
+            );
             request.service ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.updateService = stubSimpleCall(expectedResponse);
             const [response] = await client.updateService(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateService without error using callback', async () => {
@@ -438,20 +446,17 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceRequest()
+            );
             request.service ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.Service());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.Service()
+            );
             client.innerApiCalls.updateService = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateService(
@@ -466,8 +471,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateService with error', async () => {
@@ -476,24 +485,23 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceRequest()
+            );
             request.service ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateService = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateService(request), expectedError);
-            assert((client.innerApiCalls.updateService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateService with closed client', async () => {
@@ -502,7 +510,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceRequest()
+            );
             request.service ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
@@ -520,24 +530,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteService = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteService(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteService without error using callback', async () => {
@@ -546,19 +557,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteService = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteService(
@@ -573,8 +581,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteService with error', async () => {
@@ -583,23 +595,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteService = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteService(request), expectedError);
-            assert((client.innerApiCalls.deleteService as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteService as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteService with closed client', async () => {
@@ -608,7 +619,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
@@ -625,24 +638,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.createServiceLevelObjective = stubSimpleCall(expectedResponse);
             const [response] = await client.createServiceLevelObjective(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createServiceLevelObjective without error using callback', async () => {
@@ -651,19 +665,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.createServiceLevelObjective = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createServiceLevelObjective(
@@ -678,8 +689,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createServiceLevelObjective with error', async () => {
@@ -688,23 +703,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createServiceLevelObjective = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createServiceLevelObjective(request), expectedError);
-            assert((client.innerApiCalls.createServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createServiceLevelObjective with closed client', async () => {
@@ -713,7 +727,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
@@ -730,24 +746,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.getServiceLevelObjective = stubSimpleCall(expectedResponse);
             const [response] = await client.getServiceLevelObjective(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getServiceLevelObjective without error using callback', async () => {
@@ -756,19 +773,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.getServiceLevelObjective = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getServiceLevelObjective(
@@ -783,8 +797,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getServiceLevelObjective with error', async () => {
@@ -793,23 +811,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getServiceLevelObjective = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getServiceLevelObjective(request), expectedError);
-            assert((client.innerApiCalls.getServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getServiceLevelObjective with closed client', async () => {
@@ -818,7 +835,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
@@ -835,25 +854,26 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest()
+            );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.updateServiceLevelObjective = stubSimpleCall(expectedResponse);
             const [response] = await client.updateServiceLevelObjective(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateServiceLevelObjective without error using callback', async () => {
@@ -862,20 +882,17 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest()
+            );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.ServiceLevelObjective()
+            );
             client.innerApiCalls.updateServiceLevelObjective = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateServiceLevelObjective(
@@ -890,8 +907,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateServiceLevelObjective with error', async () => {
@@ -900,24 +921,23 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest()
+            );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateServiceLevelObjective = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateServiceLevelObjective(request), expectedError);
-            assert((client.innerApiCalls.updateServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateServiceLevelObjective with closed client', async () => {
@@ -926,7 +946,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest()
+            );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
@@ -944,24 +966,25 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteServiceLevelObjective = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteServiceLevelObjective(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteServiceLevelObjective without error using callback', async () => {
@@ -970,19 +993,16 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteServiceLevelObjective = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteServiceLevelObjective(
@@ -997,8 +1017,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteServiceLevelObjective with error', async () => {
@@ -1007,23 +1031,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteServiceLevelObjective = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteServiceLevelObjective(request), expectedError);
-            assert((client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteServiceLevelObjective as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteServiceLevelObjective with closed client', async () => {
@@ -1032,7 +1055,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
@@ -1049,19 +1074,13 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1069,8 +1088,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             client.innerApiCalls.listServices = stubSimpleCall(expectedResponse);
             const [response] = await client.listServices(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listServices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServices without error using callback', async () => {
@@ -1079,19 +1102,13 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1110,8 +1127,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listServices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServices with error', async () => {
@@ -1120,23 +1141,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listServices = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listServices(request), expectedError);
-            assert((client.innerApiCalls.listServices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServices as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServicesStream without error', async () => {
@@ -1145,7 +1165,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1173,10 +1195,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listServices.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listServices, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServices.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1186,7 +1209,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1209,10 +1234,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listServices.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listServices, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServices.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1222,7 +1248,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1242,10 +1270,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listServices.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServices.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1255,11 +1284,14 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServicesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listServices.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listServicesAsync(request);
             await assert.rejects(async () => {
@@ -1271,10 +1303,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listServices.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServices.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1286,19 +1319,13 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1306,8 +1333,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             client.innerApiCalls.listServiceLevelObjectives = stubSimpleCall(expectedResponse);
             const [response] = await client.listServiceLevelObjectives(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listServiceLevelObjectives as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServiceLevelObjectives without error using callback', async () => {
@@ -1316,19 +1347,13 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1347,8 +1372,12 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listServiceLevelObjectives as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServiceLevelObjectives with error', async () => {
@@ -1357,23 +1386,22 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listServiceLevelObjectives = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listServiceLevelObjectives(request), expectedError);
-            assert((client.innerApiCalls.listServiceLevelObjectives as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listServiceLevelObjectives as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listServiceLevelObjectivesStream without error', async () => {
@@ -1382,7 +1410,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1410,10 +1440,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listServiceLevelObjectives.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listServiceLevelObjectives, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServiceLevelObjectives.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1423,7 +1454,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1446,10 +1479,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listServiceLevelObjectives.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listServiceLevelObjectives, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServiceLevelObjectives.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1459,7 +1493,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1479,10 +1515,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listServiceLevelObjectives.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServiceLevelObjectives.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1492,11 +1529,14 @@ describe('v3.ServiceMonitoringServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listServiceLevelObjectives.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listServiceLevelObjectivesAsync(request);
             await assert.rejects(async () => {
@@ -1508,10 +1548,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listServiceLevelObjectives.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listServiceLevelObjectives.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createService(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getService(request), expectedError);
@@ -384,9 +412,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
-            request.service = {};
-            request.service.name = '';
-            const expectedHeaderRequestParams = "service.name=";
+            request.service ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+            request.service.name = defaultValue1;
+            const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -409,9 +439,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
-            request.service = {};
-            request.service.name = '';
-            const expectedHeaderRequestParams = "service.name=";
+            request.service ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+            request.service.name = defaultValue1;
+            const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -445,9 +477,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
-            request.service = {};
-            request.service.name = '';
-            const expectedHeaderRequestParams = "service.name=";
+            request.service ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+            request.service.name = defaultValue1;
+            const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,8 +503,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceRequest());
-            request.service = {};
-            request.service.name = '';
+            request.service ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+            request.service.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateService(request), expectedError);
@@ -485,8 +521,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -509,8 +547,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -544,8 +584,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -567,7 +609,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteService(request), expectedError);
@@ -582,8 +626,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -606,8 +652,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -641,8 +689,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -664,7 +714,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createServiceLevelObjective(request), expectedError);
@@ -679,8 +731,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -703,8 +757,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -738,8 +794,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -761,7 +819,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getServiceLevelObjective(request), expectedError);
@@ -776,9 +836,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
-            request.serviceLevelObjective = {};
-            request.serviceLevelObjective.name = '';
-            const expectedHeaderRequestParams = "service_level_objective.name=";
+            request.serviceLevelObjective ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+            request.serviceLevelObjective.name = defaultValue1;
+            const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -801,9 +863,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
-            request.serviceLevelObjective = {};
-            request.serviceLevelObjective.name = '';
-            const expectedHeaderRequestParams = "service_level_objective.name=";
+            request.serviceLevelObjective ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+            request.serviceLevelObjective.name = defaultValue1;
+            const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -837,9 +901,11 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
-            request.serviceLevelObjective = {};
-            request.serviceLevelObjective.name = '';
-            const expectedHeaderRequestParams = "service_level_objective.name=";
+            request.serviceLevelObjective ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+            request.serviceLevelObjective.name = defaultValue1;
+            const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -861,8 +927,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateServiceLevelObjectiveRequest());
-            request.serviceLevelObjective = {};
-            request.serviceLevelObjective.name = '';
+            request.serviceLevelObjective ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+            request.serviceLevelObjective.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateServiceLevelObjective(request), expectedError);
@@ -877,8 +945,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -901,8 +971,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -936,8 +1008,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -959,7 +1033,9 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteServiceLevelObjective(request), expectedError);
@@ -974,8 +1050,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1002,8 +1080,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1041,8 +1121,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1064,8 +1146,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1103,8 +1187,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listServices.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listServicesStream(request);
@@ -1137,8 +1223,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1168,8 +1256,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServicesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListServicesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listServices.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listServicesAsync(request);
             await assert.rejects(async () => {
@@ -1197,8 +1287,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1225,8 +1317,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1264,8 +1358,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1287,8 +1383,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1326,8 +1424,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listServiceLevelObjectives.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listServiceLevelObjectivesStream(request);
@@ -1360,8 +1460,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1391,8 +1493,10 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listServiceLevelObjectives.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listServiceLevelObjectivesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getUptimeCheckConfig(request), expectedError);
@@ -287,8 +307,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createUptimeCheckConfig(request), expectedError);
@@ -384,9 +412,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
-            request.uptimeCheckConfig = {};
-            request.uptimeCheckConfig.name = '';
-            const expectedHeaderRequestParams = "uptime_check_config.name=";
+            request.uptimeCheckConfig ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+            request.uptimeCheckConfig.name = defaultValue1;
+            const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -409,9 +439,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
-            request.uptimeCheckConfig = {};
-            request.uptimeCheckConfig.name = '';
-            const expectedHeaderRequestParams = "uptime_check_config.name=";
+            request.uptimeCheckConfig ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+            request.uptimeCheckConfig.name = defaultValue1;
+            const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -445,9 +477,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
-            request.uptimeCheckConfig = {};
-            request.uptimeCheckConfig.name = '';
-            const expectedHeaderRequestParams = "uptime_check_config.name=";
+            request.uptimeCheckConfig ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+            request.uptimeCheckConfig.name = defaultValue1;
+            const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,8 +503,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
-            request.uptimeCheckConfig = {};
-            request.uptimeCheckConfig.name = '';
+            request.uptimeCheckConfig ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+            request.uptimeCheckConfig.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateUptimeCheckConfig(request), expectedError);
@@ -485,8 +521,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -509,8 +547,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -544,8 +584,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -567,7 +609,9 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteUptimeCheckConfig(request), expectedError);
@@ -582,8 +626,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -610,8 +656,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -649,8 +697,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -672,8 +722,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -711,8 +763,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckConfigs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listUptimeCheckConfigsStream(request);
@@ -745,8 +799,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -776,8 +832,10 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckConfigs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listUptimeCheckConfigsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.getUptimeCheckConfig = stubSimpleCall(expectedResponse);
             const [response] = await client.getUptimeCheckConfig(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUptimeCheckConfig without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.getUptimeCheckConfig = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getUptimeCheckConfig(
@@ -254,8 +253,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUptimeCheckConfig with error', async () => {
@@ -264,23 +267,22 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getUptimeCheckConfig = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getUptimeCheckConfig(request), expectedError);
-            assert((client.innerApiCalls.getUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUptimeCheckConfig with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.GetUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.createUptimeCheckConfig = stubSimpleCall(expectedResponse);
             const [response] = await client.createUptimeCheckConfig(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createUptimeCheckConfig without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.createUptimeCheckConfig = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createUptimeCheckConfig(
@@ -359,8 +361,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createUptimeCheckConfig with error', async () => {
@@ -369,23 +375,22 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createUptimeCheckConfig = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createUptimeCheckConfig(request), expectedError);
-            assert((client.innerApiCalls.createUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createUptimeCheckConfig with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
@@ -411,25 +418,26 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest()
+            );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.updateUptimeCheckConfig = stubSimpleCall(expectedResponse);
             const [response] = await client.updateUptimeCheckConfig(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUptimeCheckConfig without error using callback', async () => {
@@ -438,20 +446,17 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest()
+            );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.monitoring.v3.UptimeCheckConfig()
+            );
             client.innerApiCalls.updateUptimeCheckConfig = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateUptimeCheckConfig(
@@ -466,8 +471,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUptimeCheckConfig with error', async () => {
@@ -476,24 +485,23 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest()
+            );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateUptimeCheckConfig = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateUptimeCheckConfig(request), expectedError);
-            assert((client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUptimeCheckConfig with closed client', async () => {
@@ -502,7 +510,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.UpdateUptimeCheckConfigRequest()
+            );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
@@ -520,24 +530,25 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUptimeCheckConfig = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteUptimeCheckConfig(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUptimeCheckConfig without error using callback', async () => {
@@ -546,19 +557,16 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUptimeCheckConfig = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteUptimeCheckConfig(
@@ -573,8 +581,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUptimeCheckConfig with error', async () => {
@@ -583,23 +595,22 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteUptimeCheckConfig = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteUptimeCheckConfig(request), expectedError);
-            assert((client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUptimeCheckConfig as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUptimeCheckConfig with closed client', async () => {
@@ -608,7 +619,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
@@ -625,19 +638,13 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -645,8 +652,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             client.innerApiCalls.listUptimeCheckConfigs = stubSimpleCall(expectedResponse);
             const [response] = await client.listUptimeCheckConfigs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listUptimeCheckConfigs without error using callback', async () => {
@@ -655,19 +666,13 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -686,8 +691,12 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listUptimeCheckConfigs with error', async () => {
@@ -696,23 +705,22 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listUptimeCheckConfigs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listUptimeCheckConfigs(request), expectedError);
-            assert((client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listUptimeCheckConfigs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listUptimeCheckConfigsStream without error', async () => {
@@ -721,7 +729,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -749,10 +759,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listUptimeCheckConfigs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listUptimeCheckConfigs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listUptimeCheckConfigs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -762,7 +773,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -785,10 +798,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listUptimeCheckConfigs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listUptimeCheckConfigs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listUptimeCheckConfigs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -798,7 +812,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -818,10 +834,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listUptimeCheckConfigs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listUptimeCheckConfigs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -831,11 +848,14 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckConfigs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listUptimeCheckConfigsAsync(request);
             await assert.rejects(async () => {
@@ -847,10 +867,11 @@ describe('v3.UptimeCheckServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listUptimeCheckConfigs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listUptimeCheckConfigs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -862,9 +883,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -872,8 +893,6 @@ describe('v3.UptimeCheckServiceClient', () => {
             client.innerApiCalls.listUptimeCheckIps = stubSimpleCall(expectedResponse);
             const [response] = await client.listUptimeCheckIps(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUptimeCheckIps as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUptimeCheckIps without error using callback', async () => {
@@ -882,9 +901,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -903,8 +922,6 @@ describe('v3.UptimeCheckServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUptimeCheckIps as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listUptimeCheckIps with error', async () => {
@@ -913,13 +930,12 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listUptimeCheckIps = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listUptimeCheckIps(request), expectedError);
-            assert((client.innerApiCalls.listUptimeCheckIps as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUptimeCheckIpsStream without error', async () => {
@@ -928,7 +944,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -960,7 +978,9 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckIps.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listUptimeCheckIpsStream(request);
@@ -987,7 +1007,9 @@ describe('v3.UptimeCheckServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckIp()),
@@ -1011,7 +1033,10 @@ describe('v3.UptimeCheckServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.monitoring.v3.ListUptimeCheckIpsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.monitoring.v3.ListUptimeCheckIpsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listUptimeCheckIps.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listUptimeCheckIpsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -217,14 +218,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.paginatedMethodStream = stubSimpleCall(expectedResponse);
             const [response] = await client.paginatedMethodStream(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethodStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethodStream without error using callback', async () => {
@@ -233,9 +235,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.paginatedMethodStream = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.paginatedMethodStream(
@@ -250,8 +255,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethodStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes paginatedMethodStream with error', async () => {
@@ -260,13 +263,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.paginatedMethodStream = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.paginatedMethodStream(request), expectedError);
-            assert((client.innerApiCalls.paginatedMethodStream as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethodStream with closed client', async () => {
@@ -275,7 +277,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.paginatedMethodStream(request), expectedError);
@@ -289,14 +293,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.paginatedMethodAsync = stubSimpleCall(expectedResponse);
             const [response] = await client.paginatedMethodAsync(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethodAsync as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethodAsync without error using callback', async () => {
@@ -305,9 +310,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.paginatedMethodAsync = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.paginatedMethodAsync(
@@ -322,8 +330,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethodAsync as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes paginatedMethodAsync with error', async () => {
@@ -332,13 +338,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.paginatedMethodAsync = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.paginatedMethodAsync(request), expectedError);
-            assert((client.innerApiCalls.paginatedMethodAsync as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethodAsync with closed client', async () => {
@@ -347,7 +352,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.paginatedMethodAsync(request), expectedError);
@@ -361,14 +368,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.checkLongRunningProgress = stubSimpleCall(expectedResponse);
             const [response] = await client.checkLongRunningProgress(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.checkLongRunningProgress as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkLongRunningProgress without error using callback', async () => {
@@ -377,9 +385,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.checkLongRunningProgress = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.checkLongRunningProgress(
@@ -394,8 +405,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.checkLongRunningProgress as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes checkLongRunningProgress with error', async () => {
@@ -404,13 +413,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.checkLongRunningProgress = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.checkLongRunningProgress(request), expectedError);
-            assert((client.innerApiCalls.checkLongRunningProgress as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkLongRunningProgress with closed client', async () => {
@@ -419,7 +427,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.checkLongRunningProgress(request), expectedError);
@@ -433,14 +443,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.initialize = stubSimpleCall(expectedResponse);
             const [response] = await client.initialize(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.initialize as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes initialize without error using callback', async () => {
@@ -449,9 +460,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.initialize = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.initialize(
@@ -466,8 +480,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.initialize as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes initialize with error', async () => {
@@ -476,13 +488,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.initialize = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.initialize(request), expectedError);
-            assert((client.innerApiCalls.initialize as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes initialize with closed client', async () => {
@@ -491,7 +502,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.initialize(request), expectedError);
@@ -505,14 +518,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.servicePath = stubSimpleCall(expectedResponse);
             const [response] = await client.servicePath(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.servicePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes servicePath without error using callback', async () => {
@@ -521,9 +535,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.servicePath = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.servicePath(
@@ -538,8 +555,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.servicePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes servicePath with error', async () => {
@@ -548,13 +563,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.servicePath = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.servicePath(request), expectedError);
-            assert((client.innerApiCalls.servicePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes servicePath with closed client', async () => {
@@ -563,7 +577,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.servicePath(request), expectedError);
@@ -577,14 +593,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.apiEndpoint = stubSimpleCall(expectedResponse);
             const [response] = await client.apiEndpoint(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.apiEndpoint as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes apiEndpoint without error using callback', async () => {
@@ -593,9 +610,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.apiEndpoint = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.apiEndpoint(
@@ -610,8 +630,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.apiEndpoint as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes apiEndpoint with error', async () => {
@@ -620,13 +638,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.apiEndpoint = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.apiEndpoint(request), expectedError);
-            assert((client.innerApiCalls.apiEndpoint as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes apiEndpoint with closed client', async () => {
@@ -635,7 +652,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.apiEndpoint(request), expectedError);
@@ -649,14 +668,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.port = stubSimpleCall(expectedResponse);
             const [response] = await client.port(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.port as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes port without error using callback', async () => {
@@ -665,9 +685,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.port = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.port(
@@ -682,8 +705,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.port as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes port with error', async () => {
@@ -692,13 +713,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.port = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.port(request), expectedError);
-            assert((client.innerApiCalls.port as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes port with closed client', async () => {
@@ -707,7 +727,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.port(request), expectedError);
@@ -721,14 +743,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.scopes = stubSimpleCall(expectedResponse);
             const [response] = await client.scopes(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.scopes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes scopes without error using callback', async () => {
@@ -737,9 +760,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.scopes = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.scopes(
@@ -754,8 +780,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.scopes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes scopes with error', async () => {
@@ -764,13 +788,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.scopes = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.scopes(request), expectedError);
-            assert((client.innerApiCalls.scopes as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes scopes with closed client', async () => {
@@ -779,7 +802,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.scopes(request), expectedError);
@@ -793,14 +818,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.getProjectId = stubSimpleCall(expectedResponse);
             const [response] = await client.getProjectId(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getProjectId as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getProjectId without error using callback', async () => {
@@ -809,9 +835,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.getProjectId = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getProjectId(
@@ -826,8 +855,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getProjectId as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes getProjectId with error', async () => {
@@ -836,13 +863,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.getProjectId = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getProjectId(request), expectedError);
-            assert((client.innerApiCalls.getProjectId as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getProjectId with closed client', async () => {
@@ -851,7 +877,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getProjectId(request), expectedError);
@@ -865,14 +893,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.GetReservedWordRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.naming.v1beta1.ReservedWord());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.GetReservedWordRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.naming.v1beta1.ReservedWord()
+            );
             client.innerApiCalls.getReservedWord = stubSimpleCall(expectedResponse);
             const [response] = await client.getReservedWord(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getReservedWord as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getReservedWord without error using callback', async () => {
@@ -881,9 +910,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.GetReservedWordRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.naming.v1beta1.ReservedWord());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.GetReservedWordRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.naming.v1beta1.ReservedWord()
+            );
             client.innerApiCalls.getReservedWord = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getReservedWord(
@@ -898,8 +930,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getReservedWord as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes getReservedWord with error', async () => {
@@ -908,13 +938,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.GetReservedWordRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.GetReservedWordRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.getReservedWord = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getReservedWord(request), expectedError);
-            assert((client.innerApiCalls.getReservedWord as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getReservedWord with closed client', async () => {
@@ -923,7 +952,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.GetReservedWordRequest());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.GetReservedWordRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getReservedWord(request), expectedError);
@@ -937,14 +968,15 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.createAbcdeSomething = stubSimpleCall(expectedResponse);
             const [response] = await client.createABCDESomething(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createABCDESomething without error using callback', async () => {
@@ -953,9 +985,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.createAbcdeSomething = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createABCDESomething(
@@ -970,8 +1005,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createABCDESomething with error', async () => {
@@ -980,13 +1013,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createAbcdeSomething = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createABCDESomething(request), expectedError);
-            assert((client.innerApiCalls.createAbcdeSomething as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createABCDESomething with closed client', async () => {
@@ -995,7 +1027,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createABCDESomething(request), expectedError);
@@ -1009,15 +1043,16 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.longRunning = stubLongRunningCall(expectedResponse);
             const [operation] = await client.longRunning(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.longRunning as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes longRunning without error using callback', async () => {
@@ -1026,9 +1061,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.longRunning = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.longRunning(
@@ -1046,8 +1084,6 @@ describe('v1beta1.NamingClient', () => {
             const operation = await promise as LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IEmpty>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.longRunning as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes longRunning with call error', async () => {
@@ -1056,13 +1092,12 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.longRunning = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.longRunning(request), expectedError);
-            assert((client.innerApiCalls.longRunning as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes longRunning with LRO error', async () => {
@@ -1071,14 +1106,13 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.protobuf.Empty());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.longRunning = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.longRunning(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.longRunning as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkLongRunningProgress1 without error', async () => {
@@ -1087,7 +1121,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1121,9 +1157,9 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1131,8 +1167,6 @@ describe('v1beta1.NamingClient', () => {
             client.innerApiCalls.paginatedMethod = stubSimpleCall(expectedResponse);
             const [response] = await client.paginatedMethod(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethod as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethod without error using callback', async () => {
@@ -1141,9 +1175,9 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1162,8 +1196,6 @@ describe('v1beta1.NamingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.paginatedMethod as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes paginatedMethod with error', async () => {
@@ -1172,13 +1204,12 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.paginatedMethod = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.paginatedMethod(request), expectedError);
-            assert((client.innerApiCalls.paginatedMethod as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes paginatedMethodStream1 without error', async () => {
@@ -1187,7 +1218,9 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1219,7 +1252,9 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.paginatedMethodStream1(request);
@@ -1246,7 +1281,9 @@ describe('v1beta1.NamingClient', () => {
               projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.protobuf.Empty()),
               generateSampleMessage(new protos.google.protobuf.Empty()),
@@ -1270,7 +1307,10 @@ describe('v1beta1.NamingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize1();
-            const request = generateSampleMessage(new protos.google.naming.v1beta1.PaginatedMethodRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.naming.v1beta1.PaginatedMethodRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.paginatedMethod.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.paginatedMethodAsync1(request);
             await assert.rejects(async () => {

--- a/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -455,7 +455,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getInstance(request, options, callback);
@@ -553,7 +553,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createInstance(request, options, callback);
@@ -658,7 +658,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'instance.name': request.instance!.name || '',
+      'instance.name': request.instance!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateInstance(request, options, callback);
@@ -760,7 +760,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.importInstance(request, options, callback);
@@ -860,7 +860,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.exportInstance(request, options, callback);
@@ -957,7 +957,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.failoverInstance(request, options, callback);
@@ -1051,7 +1051,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteInstance(request, options, callback);
@@ -1165,7 +1165,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listInstances(request, options, callback);
@@ -1213,7 +1213,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listInstances'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1270,7 +1270,7 @@ export class CloudRedisClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listInstances'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -217,24 +218,25 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.Instance()
+            );
             client.innerApiCalls.getInstance = stubSimpleCall(expectedResponse);
             const [response] = await client.getInstance(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInstance without error using callback', async () => {
@@ -243,19 +245,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.Instance()
+            );
             client.innerApiCalls.getInstance = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getInstance(
@@ -270,8 +269,12 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInstance with error', async () => {
@@ -280,23 +283,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getInstance = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getInstance(request), expectedError);
-            assert((client.innerApiCalls.getInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getInstance with closed client', async () => {
@@ -305,7 +307,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetInstanceRequest', ['name']);
             request.name = defaultValue1;
@@ -322,25 +326,26 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.createInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.createInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInstance without error using callback', async () => {
@@ -349,19 +354,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.createInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createInstance(
@@ -379,8 +381,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInstance with call error', async () => {
@@ -389,23 +395,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.createInstance(request), expectedError);
-            assert((client.innerApiCalls.createInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createInstance with LRO error', async () => {
@@ -414,24 +419,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.createInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.createInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkCreateInstanceProgress without error', async () => {
@@ -440,7 +444,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -474,26 +480,27 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest()
+            );
             request.instance ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.updateInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.updateInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInstance without error using callback', async () => {
@@ -502,20 +509,17 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest()
+            );
             request.instance ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.updateInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateInstance(
@@ -533,8 +537,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInstance with call error', async () => {
@@ -543,24 +551,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest()
+            );
             request.instance ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.updateInstance(request), expectedError);
-            assert((client.innerApiCalls.updateInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateInstance with LRO error', async () => {
@@ -569,25 +576,24 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest()
+            );
             request.instance ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.updateInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.updateInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkUpdateInstanceProgress without error', async () => {
@@ -596,7 +602,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -630,25 +638,26 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.importInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.importInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.importInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importInstance without error using callback', async () => {
@@ -657,19 +666,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.importInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.importInstance(
@@ -687,8 +693,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.importInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importInstance with call error', async () => {
@@ -697,23 +707,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.importInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.importInstance(request), expectedError);
-            assert((client.innerApiCalls.importInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes importInstance with LRO error', async () => {
@@ -722,24 +731,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.importInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.importInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.importInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.importInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkImportInstanceProgress without error', async () => {
@@ -748,7 +756,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -782,25 +792,26 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.exportInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.exportInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.exportInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportInstance without error using callback', async () => {
@@ -809,19 +820,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.exportInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.exportInstance(
@@ -839,8 +847,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.exportInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportInstance with call error', async () => {
@@ -849,23 +861,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.exportInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.exportInstance(request), expectedError);
-            assert((client.innerApiCalls.exportInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes exportInstance with LRO error', async () => {
@@ -874,24 +885,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.exportInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.exportInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.exportInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.exportInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkExportInstanceProgress without error', async () => {
@@ -900,7 +910,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -934,25 +946,26 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.failoverInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.failoverInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.failoverInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes failoverInstance without error using callback', async () => {
@@ -961,19 +974,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.failoverInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.failoverInstance(
@@ -991,8 +1001,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.redis.v1beta1.IInstance, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.failoverInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes failoverInstance with call error', async () => {
@@ -1001,23 +1015,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.failoverInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.failoverInstance(request), expectedError);
-            assert((client.innerApiCalls.failoverInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes failoverInstance with LRO error', async () => {
@@ -1026,24 +1039,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.failoverInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.failoverInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.failoverInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.failoverInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkFailoverInstanceProgress without error', async () => {
@@ -1052,7 +1064,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1086,25 +1100,26 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.deleteInstance = stubLongRunningCall(expectedResponse);
             const [operation] = await client.deleteInstance(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInstance without error using callback', async () => {
@@ -1113,19 +1128,16 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.deleteInstance = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteInstance(
@@ -1143,8 +1155,12 @@ describe('v1beta1.CloudRedisClient', () => {
             const operation = await promise as LROperation<protos.google.protobuf.IEmpty, protos.google.protobuf.IAny>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInstance with call error', async () => {
@@ -1153,23 +1169,22 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteInstance = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.deleteInstance(request), expectedError);
-            assert((client.innerApiCalls.deleteInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteInstance with LRO error', async () => {
@@ -1178,24 +1193,23 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteInstance = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.deleteInstance(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.deleteInstance as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteInstance as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkDeleteInstanceProgress without error', async () => {
@@ -1204,7 +1218,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1238,19 +1254,13 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1258,8 +1268,12 @@ describe('v1beta1.CloudRedisClient', () => {
             client.innerApiCalls.listInstances = stubSimpleCall(expectedResponse);
             const [response] = await client.listInstances(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInstances as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInstances without error using callback', async () => {
@@ -1268,19 +1282,13 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1299,8 +1307,12 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listInstances as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInstances with error', async () => {
@@ -1309,23 +1321,22 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listInstances = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listInstances(request), expectedError);
-            assert((client.innerApiCalls.listInstances as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listInstances as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listInstancesStream without error', async () => {
@@ -1334,7 +1345,9 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1362,10 +1375,11 @@ describe('v1beta1.CloudRedisClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listInstances.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listInstances, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInstances.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1375,7 +1389,9 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1398,10 +1414,11 @@ describe('v1beta1.CloudRedisClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listInstances.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listInstances, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInstances.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1411,7 +1428,9 @@ describe('v1beta1.CloudRedisClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1431,10 +1450,11 @@ describe('v1beta1.CloudRedisClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listInstances.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInstances.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1444,11 +1464,14 @@ describe('v1beta1.CloudRedisClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listInstances.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listInstancesAsync(request);
             await assert.rejects(async () => {
@@ -1460,10 +1483,11 @@ describe('v1beta1.CloudRedisClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listInstances.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listInstances.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -206,8 +218,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -230,8 +244,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -265,8 +281,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -288,7 +306,9 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.GetInstanceRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetInstanceRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getInstance(request), expectedError);
@@ -303,8 +323,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -328,8 +350,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -366,8 +390,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -389,8 +415,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.CreateInstanceRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -447,9 +475,11 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
-            request.instance = {};
-            request.instance.name = '';
-            const expectedHeaderRequestParams = "instance.name=";
+            request.instance ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+            request.instance.name = defaultValue1;
+            const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -473,9 +503,11 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
-            request.instance = {};
-            request.instance.name = '';
-            const expectedHeaderRequestParams = "instance.name=";
+            request.instance ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+            request.instance.name = defaultValue1;
+            const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -512,9 +544,11 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
-            request.instance = {};
-            request.instance.name = '';
-            const expectedHeaderRequestParams = "instance.name=";
+            request.instance ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+            request.instance.name = defaultValue1;
+            const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -536,9 +570,11 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.UpdateInstanceRequest());
-            request.instance = {};
-            request.instance.name = '';
-            const expectedHeaderRequestParams = "instance.name=";
+            request.instance ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+            request.instance.name = defaultValue1;
+            const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -595,8 +631,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -620,8 +658,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -658,8 +698,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -681,8 +723,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ImportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -739,8 +783,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -764,8 +810,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -802,8 +850,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -825,8 +875,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ExportInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -883,8 +935,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -908,8 +962,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -946,8 +1002,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -969,8 +1027,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1027,8 +1087,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1052,8 +1114,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1090,8 +1154,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1113,8 +1179,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1171,8 +1239,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1199,8 +1269,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1238,8 +1310,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1261,8 +1335,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1300,8 +1376,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listInstances.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listInstancesStream(request);
@@ -1334,8 +1412,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1365,8 +1445,10 @@ describe('v1beta1.CloudRedisClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.redis.v1beta1.ListInstancesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listInstances.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listInstancesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as testserviceModule from '../src';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -154,25 +155,24 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.fastFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.fastFibonacci(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes fastFibonacci without error using callback', async () => {
@@ -181,20 +181,15 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.fastFibonacci = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.fastFibonacci(
@@ -209,8 +204,12 @@ describe('v1.TestServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes fastFibonacci with error', async () => {
@@ -219,24 +218,21 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.fastFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.fastFibonacci(request), expectedError);
-            assert((client.innerApiCalls.fastFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.fastFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes fastFibonacci with closed client', async () => {
@@ -245,7 +241,9 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
             const expectedError = new Error('The client has already been closed.');
@@ -261,28 +259,24 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.name = 'value';
-            expectedHeaderRequestParamsObj['name'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=**}
             request.name = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.randomFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.randomFibonacci(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.randomFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes randomFibonacci without error using callback', async () => {
@@ -291,23 +285,15 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.name = 'value';
-            expectedHeaderRequestParamsObj['name'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=**}
             request.name = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.randomFibonacci = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.randomFibonacci(
@@ -322,8 +308,12 @@ describe('v1.TestServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.randomFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes randomFibonacci with error', async () => {
@@ -332,27 +322,21 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.name = 'value';
-            expectedHeaderRequestParamsObj['name'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=**}
             request.name = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.randomFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.randomFibonacci(request), expectedError);
-            assert((client.innerApiCalls.randomFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.randomFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes randomFibonacci with closed client', async () => {
@@ -361,9 +345,9 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            // path template is empty
-            request.name = 'value';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=**}
             request.name = 'value';
             const expectedError = new Error('The client has already been closed.');
@@ -379,33 +363,24 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template: {database=projects/*}
-            request.parentId = 'projects/value';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
-            request.nest1 = {};
-            request.nest1.nest2 = {};
-            // path template: {database=projects/*/databases/*}/documents
-            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.slowFibonacci = stubSimpleCall(expectedResponse);
             const [response] = await client.slowFibonacci(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes slowFibonacci without error using callback', async () => {
@@ -414,28 +389,15 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template: {database=projects/*}
-            request.parentId = 'projects/value';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
-            request.nest1 = {};
-            request.nest1.nest2 = {};
-            // path template: {database=projects/*/databases/*}/documents
-            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.slowFibonacci = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.slowFibonacci(
@@ -450,8 +412,12 @@ describe('v1.TestServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes slowFibonacci with error', async () => {
@@ -460,32 +426,21 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template: {database=projects/*}
-            request.parentId = 'projects/value';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue';
-            request.nest1 = {};
-            request.nest1.nest2 = {};
-            // path template: {database=projects/*/databases/*}/documents
-            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['database'] = 'projects%2Fvalue%2Fdatabases%2Fvalue';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            expectedHeaderRequestParamsObj['routing_id'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.slowFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.slowFibonacci(request), expectedError);
-            assert((client.innerApiCalls.slowFibonacci as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.slowFibonacci as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes slowFibonacci with closed client', async () => {
@@ -494,13 +449,9 @@ describe('v1.TestServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.routingtest.v1.FibonacciRequest());
-            // path template: {database=projects/*}
-            request.parentId = 'projects/value';
-            request.nest1 = {};
-            request.nest1.nest2 = {};
-            // path template: {database=projects/*/databases/*}/documents
-            request.nest1.nest2.nameId = 'projects/value/databases/value/documents';
+            const request = generateSampleMessage(
+              new protos.google.routingtest.v1.FibonacciRequest()
+            );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
             const expectedError = new Error('The client has already been closed.');

--- a/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -160,7 +160,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'database=projects%2Fvalue%2Fdatabases%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -186,7 +186,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'database=projects%2Fvalue%2Fdatabases%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -223,7 +223,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {database=projects/*/databases/*}/documents
             request.name = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'database=projects%2Fvalue%2Fdatabases%2Fvalue';
             const expectedError = new Error('expected');
             client.innerApiCalls.fastFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.fastFibonacci(request), expectedError);
@@ -264,7 +264,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=**}
             request.name = 'value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=value';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -290,7 +290,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=**}
             request.name = 'value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=value';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -327,7 +327,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=**}
             request.name = 'value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=value';
             const expectedError = new Error('expected');
             client.innerApiCalls.randomFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.randomFibonacci(request), expectedError);
@@ -368,7 +368,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -394,7 +394,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.protobuf.Empty()
             );
@@ -431,7 +431,7 @@ describe('v1.TestServiceClient', () => {
             );
             // path template: {routing_id=projects/*}/databases/*/documents
             request.anotherParentId = 'projects/value/databases/value/documents';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'routing_id=projects%2Fvalue';
             const expectedError = new Error('expected');
             client.innerApiCalls.slowFibonacci = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.slowFibonacci(request), expectedError);

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -27,16 +27,10 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
-// Dynamically loaded proto JSON is needed to get the type information
-// to fill in default values for request objects
-const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
-
 function getTypeDefaultValue(typeName: string, fields: string[]) {
-    let type = root.lookupType(typeName) as protobuf.Type;
-    for (const field of fields.slice(0, -1)) {
-        type = type.fields[field]?.resolvedType as protobuf.Type;
-    }
-    return type.fields[fields[fields.length - 1]]?.defaultValue;
+    // non-string x-goog-request-param values are not supported;
+    // we always assume that it's a string.
+    return '';
 }
 
 function generateSampleMessage<T extends object>(instance: T) {

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -27,6 +27,7 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     // non-string x-goog-request-param values are not supported;
     // we always assume that it's a string.
@@ -237,46 +238,24 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCall(expectedResponse);
             const [response] = await client.echo(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo without error using callback', async () => {
@@ -285,41 +264,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.echo(
@@ -334,8 +287,12 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with error', async () => {
@@ -344,45 +301,21 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with closed client', async () => {
@@ -391,21 +324,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            // path template is empty
-            request.header = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
             const expectedError = new Error('The client has already been closed.');
@@ -421,14 +342,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpandLegacy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy without error using callback', async () => {
@@ -437,9 +359,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.pagedExpandLegacy(
@@ -454,8 +379,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpandLegacy with error', async () => {
@@ -464,13 +387,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy with closed client', async () => {
@@ -479,7 +401,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
@@ -493,14 +417,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCall(expectedResponse);
             const [response] = await client.block(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block without error using callback', async () => {
@@ -509,9 +434,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.block(
@@ -526,8 +454,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes block with error', async () => {
@@ -536,13 +462,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.block = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.block(request), expectedError);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block with closed client', async () => {
@@ -551,7 +476,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.block(request), expectedError);
@@ -565,15 +492,16 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCall(expectedResponse);
             const [operation] = await client.wait(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait without error using callback', async () => {
@@ -582,9 +510,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.wait(
@@ -602,8 +533,6 @@ describe('v1beta1.EchoClient', () => {
             const operation = await promise as LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes wait with call error', async () => {
@@ -612,13 +541,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.wait(request), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait with LRO error', async () => {
@@ -627,14 +555,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.wait(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkWaitProgress without error', async () => {
@@ -643,7 +570,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -677,9 +606,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
             const stream = client.expand(request);
             const promise = new Promise((resolve, reject) => {
@@ -692,8 +624,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with error', async () => {
@@ -702,8 +632,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.expand = stubServerStreamingCall(undefined, expectedError);
             const stream = client.expand(request);
@@ -716,8 +647,6 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with closed client', async () => {
@@ -726,7 +655,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.expand(request);
@@ -749,8 +680,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.chat = stubBidiStreamingCall(expectedResponse);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {
@@ -777,7 +713,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
@@ -806,8 +744,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.collect = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
@@ -835,7 +778,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.collect = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -864,9 +809,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -874,8 +819,6 @@ describe('v1beta1.EchoClient', () => {
             client.innerApiCalls.pagedExpand = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpand(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpand without error using callback', async () => {
@@ -884,9 +827,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -905,8 +848,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpand with error', async () => {
@@ -915,13 +856,12 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpand = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpand(request), expectedError);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandStream without error', async () => {
@@ -930,7 +870,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -962,7 +904,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.pagedExpandStream(request);
@@ -989,7 +933,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -1013,7 +959,10 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.pagedExpandAsync(request);
             await assert.rejects(async () => {

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -243,7 +243,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -269,7 +269,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -306,7 +306,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -676,11 +676,11 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_int32': request.info!.fInt32 || '',
-      'info.f_double': request.info!.fDouble || '',
-      'info.f_bool': request.info!.fBool || '',
-      'info.f_kingdom': request.info!.fKingdom || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_int32': request.info!.fInt32 ?? '',
+      'info.f_double': request.info!.fDouble ?? '',
+      'info.f_bool': request.info!.fBool ?? '',
+      'info.f_kingdom': request.info!.fKingdom ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataSimplePath(request, options, callback);
@@ -764,9 +764,9 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_child.f_string': request.info!.fChild!.fString || '',
-      'info.f_bool': request.info!.fBool || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_child.f_string': request.info!.fChild!.fString ?? '',
+      'info.f_bool': request.info!.fBool ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataPathResource(request, options, callback);
@@ -850,8 +850,8 @@ export class ComplianceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'info.f_string': request.info!.fString || '',
-      'info.f_child.f_string': request.info!.fChild!.fString || '',
+      'info.f_string': request.info!.fString ?? '',
+      'info.f_child.f_string': request.info!.fChild!.fString ?? '',
     });
     this.initialize();
     return this.innerApiCalls.repeatDataPathTrailingResource(request, options, callback);

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -493,7 +493,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getUser(request, options, callback);
@@ -567,7 +567,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'user.name': request.user!.name || '',
+      'user.name': request.user!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateUser(request, options, callback);
@@ -638,7 +638,7 @@ export class IdentityClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteUser(request, options, callback);

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -523,7 +523,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getRoom(request, options, callback);
@@ -597,7 +597,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'room.name': request.room!.name || '',
+      'room.name': request.room!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateRoom(request, options, callback);
@@ -668,7 +668,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteRoom(request, options, callback);
@@ -744,7 +744,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createBlurb(request, options, callback);
@@ -815,7 +815,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getBlurb(request, options, callback);
@@ -889,7 +889,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'blurb.name': request.blurb!.name || '',
+      'blurb.name': request.blurb!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateBlurb(request, options, callback);
@@ -960,7 +960,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteBlurb(request, options, callback);
@@ -997,7 +997,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.streamBlurbs(request, options);
@@ -1157,7 +1157,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.searchBlurbs(request, options, callback);
@@ -1421,7 +1421,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listBlurbs(request, options, callback);
@@ -1464,7 +1464,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1516,7 +1516,7 @@ export class MessagingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listBlurbs'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -481,7 +481,7 @@ export class SequenceServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSequenceReport(request, options, callback);
@@ -551,7 +551,7 @@ export class SequenceServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.attemptSequence(request, options, callback);

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -498,7 +498,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSession(request, options, callback);
@@ -569,7 +569,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteSession(request, options, callback);
@@ -642,7 +642,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.reportSession(request, options, callback);
@@ -718,7 +718,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteTest(request, options, callback);
@@ -796,7 +796,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.verifyTest(request, options, callback);
@@ -1029,7 +1029,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listTests(request, options, callback);
@@ -1068,7 +1068,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTests'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1116,7 +1116,7 @@ export class TestingClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTests'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -25,6 +25,18 @@ import * as complianceModule from '../src';
 
 import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -379,17 +391,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -412,17 +434,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -456,17 +488,27 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_int32=&info.f_double=&info.f_bool=&info.f_kingdom=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -488,16 +530,26 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fInt32 = '';
-            request.info = {};
-            request.info.fDouble = '';
-            request.info = {};
-            request.info.fBool = '';
-            request.info = {};
-            request.info.fKingdom = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+            request.info.fInt32 = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+            request.info.fDouble = defaultValue3;
+            request.info ??= {};
+            const defaultValue4 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue4;
+            request.info ??= {};
+            const defaultValue5 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+            request.info.fKingdom = defaultValue5;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataSimplePath(request), expectedError);
@@ -512,14 +564,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -542,14 +600,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -583,14 +647,20 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=&info.f_bool=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -612,13 +682,19 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            request.info = {};
-            request.info.fBool = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            request.info ??= {};
+            const defaultValue3 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+            request.info.fBool = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataPathResource(request), expectedError);
@@ -633,12 +709,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -661,12 +741,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -700,12 +784,16 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
-            const expectedHeaderRequestParams = "info.f_string=&info.f_child.f_string=";
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
+            const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -727,11 +815,15 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            request.info = {};
-            request.info.fString = '';
-            request.info = {};
-            request.info.fChild = {};
-            request.info.fChild.fString = '';
+            request.info ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+            request.info.fString = defaultValue1;
+            request.info ??= {};
+            request.info.fChild ??= {};
+            const defaultValue2 =
+              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+            request.info.fChild.fString = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataPathTrailingResource(request), expectedError);

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax'
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -174,14 +175,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBody = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBody(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBody without error using callback', async () => {
@@ -190,9 +192,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBody = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBody(
@@ -207,8 +212,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBody with error', async () => {
@@ -217,13 +220,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBody = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBody(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBody as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBody with closed client', async () => {
@@ -232,7 +234,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBody(request), expectedError);
@@ -246,14 +250,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyInfo(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyInfo without error using callback', async () => {
@@ -262,9 +267,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyInfo(
@@ -279,8 +287,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyInfo with error', async () => {
@@ -289,13 +295,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyInfo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyInfo(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyInfo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyInfo with closed client', async () => {
@@ -304,7 +309,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyInfo(request), expectedError);
@@ -318,14 +325,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataQuery = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataQuery(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataQuery without error using callback', async () => {
@@ -334,9 +342,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataQuery = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataQuery(
@@ -351,8 +362,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataQuery with error', async () => {
@@ -361,13 +370,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataQuery = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataQuery(request), expectedError);
-            assert((client.innerApiCalls.repeatDataQuery as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataQuery with closed client', async () => {
@@ -376,7 +384,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataQuery(request), expectedError);
@@ -390,7 +400,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -412,19 +424,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataSimplePath(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath without error using callback', async () => {
@@ -433,7 +444,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -455,14 +468,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataSimplePath(
@@ -477,8 +485,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath with error', async () => {
@@ -487,7 +499,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -509,18 +523,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataSimplePath = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataSimplePath(request), expectedError);
-            assert((client.innerApiCalls.repeatDataSimplePath as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataSimplePath as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataSimplePath with closed client', async () => {
@@ -529,7 +540,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -563,7 +576,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -578,19 +593,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathResource = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataPathResource(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource without error using callback', async () => {
@@ -599,7 +613,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -614,14 +630,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathResource = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataPathResource(
@@ -636,8 +647,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource with error', async () => {
@@ -646,7 +661,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -661,18 +678,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataPathResource = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataPathResource(request), expectedError);
-            assert((client.innerApiCalls.repeatDataPathResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathResource with closed client', async () => {
@@ -681,7 +695,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -708,7 +724,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -719,19 +737,18 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataPathTrailingResource(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource without error using callback', async () => {
@@ -740,7 +757,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -751,14 +770,9 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataPathTrailingResource(
@@ -773,8 +787,12 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource with error', async () => {
@@ -783,7 +801,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -794,18 +814,15 @@ describe('v1beta1.ComplianceClient', () => {
               getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataPathTrailingResource = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataPathTrailingResource(request), expectedError);
-            assert((client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.repeatDataPathTrailingResource as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes repeatDataPathTrailingResource with closed client', async () => {
@@ -814,7 +831,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             request.info ??= {};
             const defaultValue1 =
               getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
@@ -837,14 +856,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyPut(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPut without error using callback', async () => {
@@ -853,9 +873,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyPut(
@@ -870,8 +893,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyPut with error', async () => {
@@ -880,13 +901,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyPut = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyPut(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyPut as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPut with closed client', async () => {
@@ -895,7 +915,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyPut(request), expectedError);
@@ -909,14 +931,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCall(expectedResponse);
             const [response] = await client.repeatDataBodyPatch(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPatch without error using callback', async () => {
@@ -925,9 +948,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatResponse()
+            );
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.repeatDataBodyPatch(
@@ -942,8 +968,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes repeatDataBodyPatch with error', async () => {
@@ -952,13 +976,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.repeatDataBodyPatch = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.repeatDataBodyPatch(request), expectedError);
-            assert((client.innerApiCalls.repeatDataBodyPatch as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes repeatDataBodyPatch with closed client', async () => {
@@ -967,7 +990,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.RepeatRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.RepeatRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.repeatDataBodyPatch(request), expectedError);
@@ -981,14 +1006,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.getEnum = stubSimpleCall(expectedResponse);
             const [response] = await client.getEnum(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getEnum without error using callback', async () => {
@@ -997,9 +1023,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.getEnum = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getEnum(
@@ -1014,8 +1043,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes getEnum with error', async () => {
@@ -1024,13 +1051,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.getEnum = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getEnum(request), expectedError);
-            assert((client.innerApiCalls.getEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes getEnum with closed client', async () => {
@@ -1039,7 +1065,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getEnum(request), expectedError);
@@ -1053,14 +1081,15 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.verifyEnum = stubSimpleCall(expectedResponse);
             const [response] = await client.verifyEnum(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes verifyEnum without error using callback', async () => {
@@ -1069,9 +1098,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             client.innerApiCalls.verifyEnum = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.verifyEnum(
@@ -1086,8 +1118,6 @@ describe('v1beta1.ComplianceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes verifyEnum with error', async () => {
@@ -1096,13 +1126,12 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.verifyEnum = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.verifyEnum(request), expectedError);
-            assert((client.innerApiCalls.verifyEnum as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes verifyEnum with closed client', async () => {
@@ -1111,7 +1140,9 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EnumResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EnumResponse()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.verifyEnum(request), expectedError);
@@ -1125,7 +1156,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1137,7 +1168,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -1152,7 +1183,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1164,7 +1195,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1191,7 +1222,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1217,7 +1248,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1229,7 +1260,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -1244,7 +1275,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1256,7 +1287,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1283,7 +1314,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1309,7 +1340,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1321,7 +1352,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -1336,7 +1367,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1348,7 +1379,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1375,7 +1406,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1401,7 +1432,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1413,7 +1444,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -1428,7 +1459,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1440,7 +1471,7 @@ describe('v1beta1.ComplianceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1470,7 +1501,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1521,10 +1552,11 @@ describe('v1beta1.ComplianceClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -1534,7 +1566,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1550,10 +1582,11 @@ describe('v1beta1.ComplianceClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1565,7 +1598,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1583,7 +1616,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1615,7 +1648,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -1632,7 +1665,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1650,7 +1683,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1682,7 +1715,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -1699,7 +1732,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1717,7 +1750,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1749,7 +1782,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -1765,7 +1798,7 @@ describe('v1beta1.ComplianceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1796,7 +1829,7 @@ describe('v1beta1.ComplianceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos, IamProtos, LocationProtos} from
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -250,46 +251,24 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCall(expectedResponse);
             const [response] = await client.echo(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo without error using callback', async () => {
@@ -298,41 +277,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const expectedHeaderRequestParams = '=';
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.echo = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.echo(
@@ -347,8 +300,12 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with error', async () => {
@@ -357,45 +314,21 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-            // path template is empty
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['header'] = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            expectedHeaderRequestParamsObj['routing_id'] = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'regions%2Fvalue%2Fzones%2Fvalue%2Fvalue';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            expectedHeaderRequestParamsObj['super_id'] = 'projects%2Fvalue';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['table_name'] = 'projects%2Fvalue%2Finstances%2Fvalue%2Fvalue';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            expectedHeaderRequestParamsObj['instance_id'] = 'instances%2Fvalue';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
-            expectedHeaderRequestParamsObj['baz'] = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            expectedHeaderRequestParamsObj['qux'] = 'projects%2Fvalue';
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
+            const expectedHeaderRequestParams = '=';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);
-            assert((client.innerApiCalls.echo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.echo as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes echo with closed client', async () => {
@@ -404,21 +337,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            // path template is empty
-            request.header = 'value';
-            // path template: {routing_id=**}
-            request.header = 'value';
-            // path template: {table_name=regions/*/zones/*/**}
-            request.header = 'regions/value/zones/value/value';
-            // path template: {super_id=projects/*}/**
-            request.header = 'projects/value/value';
-            // path template: {table_name=projects/*/instances/*/**}
-            request.header = 'projects/value/instances/value/value';
-            // path template: projects/*/{instance_id=instances/*}/**
-            request.header = 'projects/value/instances/value/value';
-            // path template: {baz=**}
-            request.otherHeader = 'value';
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
             const expectedError = new Error('The client has already been closed.');
@@ -434,14 +355,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpandLegacy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy without error using callback', async () => {
@@ -450,9 +372,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandResponse()
+            );
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.pagedExpandLegacy(
@@ -467,8 +392,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpandLegacy with error', async () => {
@@ -477,13 +400,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpandLegacy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
-            assert((client.innerApiCalls.pagedExpandLegacy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandLegacy with closed client', async () => {
@@ -492,7 +414,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandLegacyRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandLegacyRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.pagedExpandLegacy(request), expectedError);
@@ -506,14 +430,15 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCall(expectedResponse);
             const [response] = await client.block(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block without error using callback', async () => {
@@ -522,9 +447,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.BlockResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockResponse()
+            );
             client.innerApiCalls.block = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.block(
@@ -539,8 +467,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes block with error', async () => {
@@ -549,13 +475,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.block = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.block(request), expectedError);
-            assert((client.innerApiCalls.block as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes block with closed client', async () => {
@@ -564,7 +489,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.BlockRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.BlockRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.block(request), expectedError);
@@ -578,15 +505,16 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCall(expectedResponse);
             const [operation] = await client.wait(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait without error using callback', async () => {
@@ -595,9 +523,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.wait = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.wait(
@@ -615,8 +546,6 @@ describe('v1beta1.EchoClient', () => {
             const operation = await promise as LROperation<protos.google.showcase.v1beta1.IWaitResponse, protos.google.showcase.v1beta1.IWaitMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes wait with call error', async () => {
@@ -625,13 +554,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.wait(request), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes wait with LRO error', async () => {
@@ -640,14 +568,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.WaitRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.WaitRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.wait = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.wait(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.wait as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkWaitProgress without error', async () => {
@@ -656,7 +583,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -690,9 +619,12 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.expand = stubServerStreamingCall(expectedResponse);
             const stream = client.expand(request);
             const promise = new Promise((resolve, reject) => {
@@ -705,8 +637,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with error', async () => {
@@ -715,8 +645,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.expand = stubServerStreamingCall(undefined, expectedError);
             const stream = client.expand(request);
@@ -729,8 +660,6 @@ describe('v1beta1.EchoClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.expand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
         });
 
         it('invokes expand with closed client', async () => {
@@ -739,7 +668,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ExpandRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.expand(request);
@@ -762,8 +693,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.chat = stubBidiStreamingCall(expectedResponse);
             const stream = client.chat();
             const promise = new Promise((resolve, reject) => {
@@ -790,7 +726,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.chat = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.chat();
@@ -819,8 +757,13 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoResponse()
+            );
             client.innerApiCalls.collect = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
@@ -848,7 +791,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.EchoRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.EchoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.collect = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -877,9 +822,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -887,8 +832,6 @@ describe('v1beta1.EchoClient', () => {
             client.innerApiCalls.pagedExpand = stubSimpleCall(expectedResponse);
             const [response] = await client.pagedExpand(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpand without error using callback', async () => {
@@ -897,9 +840,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -918,8 +861,6 @@ describe('v1beta1.EchoClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes pagedExpand with error', async () => {
@@ -928,13 +869,12 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.pagedExpand = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pagedExpand(request), expectedError);
-            assert((client.innerApiCalls.pagedExpand as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes pagedExpandStream without error', async () => {
@@ -943,7 +883,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -975,7 +917,9 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.pagedExpandStream(request);
@@ -1002,7 +946,9 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
               generateSampleMessage(new protos.google.showcase.v1beta1.EchoResponse()),
@@ -1026,7 +972,10 @@ describe('v1beta1.EchoClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.PagedExpandRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.PagedExpandRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.pagedExpand.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.pagedExpandAsync(request);
             await assert.rejects(async () => {
@@ -1049,7 +998,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1061,7 +1010,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -1076,7 +1025,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1088,7 +1037,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1115,7 +1064,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1141,7 +1090,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1153,7 +1102,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -1168,7 +1117,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1180,7 +1129,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1207,7 +1156,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1233,7 +1182,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1245,7 +1194,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -1260,7 +1209,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1272,7 +1221,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1299,7 +1248,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1325,7 +1274,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1337,7 +1286,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -1352,7 +1301,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1364,7 +1313,7 @@ describe('v1beta1.EchoClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1394,7 +1343,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1445,10 +1394,11 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -1458,7 +1408,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1474,10 +1424,11 @@ describe('v1beta1.EchoClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1489,7 +1440,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1507,7 +1458,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1539,7 +1490,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -1556,7 +1507,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1574,7 +1525,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1606,7 +1557,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -1623,7 +1574,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1641,7 +1592,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1673,7 +1624,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -1689,7 +1640,7 @@ describe('v1beta1.EchoClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1720,7 +1671,7 @@ describe('v1beta1.EchoClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -256,7 +256,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -282,7 +282,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedResponse = generateSampleMessage(
               new protos.google.showcase.v1beta1.EchoResponse()
             );
@@ -319,7 +319,7 @@ describe('v1beta1.EchoClient', () => {
             );
             // path template: {qux=projects/*}/**
             request.otherHeader = 'projects/value/value';
-            const expectedHeaderRequestParams = '=';
+            const expectedHeaderRequestParams = 'qux=projects%2Fvalue';
             const expectedError = new Error('expected');
             client.innerApiCalls.echo = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.echo(request), expectedError);

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -262,8 +274,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -286,8 +300,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -321,8 +337,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -344,7 +362,9 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetUserRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getUser(request), expectedError);
@@ -359,9 +379,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -384,9 +406,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -420,9 +444,11 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
-            const expectedHeaderRequestParams = "user.name=";
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
+            const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -444,8 +470,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
-            request.user = {};
-            request.user.name = '';
+            request.user ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+            request.user.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateUser(request), expectedError);
@@ -460,8 +488,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -484,8 +514,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -519,8 +551,10 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -542,7 +576,9 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteUserRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteUser(request), expectedError);

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax'
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,14 +202,15 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.createUser = stubSimpleCall(expectedResponse);
             const [response] = await client.createUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createUser without error using callback', async () => {
@@ -217,9 +219,12 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.createUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createUser(
@@ -234,8 +239,6 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createUser with error', async () => {
@@ -244,13 +247,12 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createUser(request), expectedError);
-            assert((client.innerApiCalls.createUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createUser with closed client', async () => {
@@ -259,7 +261,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateUserRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createUser(request), expectedError);
@@ -273,24 +277,25 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.getUser = stubSimpleCall(expectedResponse);
             const [response] = await client.getUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser without error using callback', async () => {
@@ -299,19 +304,16 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.getUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getUser(
@@ -326,8 +328,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser with error', async () => {
@@ -336,23 +342,22 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getUser(request), expectedError);
-            assert((client.innerApiCalls.getUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getUser with closed client', async () => {
@@ -361,7 +366,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetUserRequest', ['name']);
             request.name = defaultValue1;
@@ -378,25 +385,26 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.updateUser = stubSimpleCall(expectedResponse);
             const [response] = await client.updateUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser without error using callback', async () => {
@@ -405,20 +413,17 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.User());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.User()
+            );
             client.innerApiCalls.updateUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateUser(
@@ -433,8 +438,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser with error', async () => {
@@ -443,24 +452,23 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateUser(request), expectedError);
-            assert((client.innerApiCalls.updateUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateUser with closed client', async () => {
@@ -469,7 +477,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateUserRequest()
+            );
             request.user ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
@@ -487,24 +497,25 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUser = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteUser(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser without error using callback', async () => {
@@ -513,19 +524,16 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteUser = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteUser(
@@ -540,8 +548,12 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser with error', async () => {
@@ -550,23 +562,22 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteUser = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteUser(request), expectedError);
-            assert((client.innerApiCalls.deleteUser as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteUser as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteUser with closed client', async () => {
@@ -575,7 +586,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteUserRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteUserRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteUserRequest', ['name']);
             request.name = defaultValue1;
@@ -592,9 +605,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -602,8 +615,6 @@ describe('v1beta1.IdentityClient', () => {
             client.innerApiCalls.listUsers = stubSimpleCall(expectedResponse);
             const [response] = await client.listUsers(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUsers without error using callback', async () => {
@@ -612,9 +623,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -633,8 +644,6 @@ describe('v1beta1.IdentityClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listUsers with error', async () => {
@@ -643,13 +652,12 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listUsers = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listUsers(request), expectedError);
-            assert((client.innerApiCalls.listUsers as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listUsersStream without error', async () => {
@@ -658,7 +666,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -690,7 +700,9 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listUsers.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listUsersStream(request);
@@ -717,7 +729,9 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
               generateSampleMessage(new protos.google.showcase.v1beta1.User()),
@@ -741,7 +755,10 @@ describe('v1beta1.IdentityClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListUsersRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListUsersRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listUsers.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listUsersAsync(request);
             await assert.rejects(async () => {
@@ -763,7 +780,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -775,7 +792,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -790,7 +807,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -802,7 +819,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -829,7 +846,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -855,7 +872,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -867,7 +884,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -882,7 +899,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -894,7 +911,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -921,7 +938,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -947,7 +964,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -959,7 +976,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -974,7 +991,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -986,7 +1003,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1013,7 +1030,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1039,7 +1056,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1051,7 +1068,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -1066,7 +1083,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1078,7 +1095,7 @@ describe('v1beta1.IdentityClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1108,7 +1125,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1159,10 +1176,11 @@ describe('v1beta1.IdentityClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -1172,7 +1190,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1188,10 +1206,11 @@ describe('v1beta1.IdentityClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1203,7 +1222,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1221,7 +1240,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1253,7 +1272,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -1270,7 +1289,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1288,7 +1307,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1320,7 +1339,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -1337,7 +1356,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1355,7 +1374,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1387,7 +1406,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -1403,7 +1422,7 @@ describe('v1beta1.IdentityClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1434,7 +1453,7 @@ describe('v1beta1.IdentityClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos, IamProtos, LocationProtos} from
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -250,14 +251,15 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.createRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.createRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createRoom without error using callback', async () => {
@@ -266,9 +268,12 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.createRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createRoom(
@@ -283,8 +288,6 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createRoom with error', async () => {
@@ -293,13 +296,12 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createRoom(request), expectedError);
-            assert((client.innerApiCalls.createRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createRoom with closed client', async () => {
@@ -308,7 +310,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateRoomRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createRoom(request), expectedError);
@@ -322,24 +326,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.getRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.getRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom without error using callback', async () => {
@@ -348,19 +353,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.getRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getRoom(
@@ -375,8 +377,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom with error', async () => {
@@ -385,23 +391,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getRoom(request), expectedError);
-            assert((client.innerApiCalls.getRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getRoom with closed client', async () => {
@@ -410,7 +415,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetRoomRequest', ['name']);
             request.name = defaultValue1;
@@ -427,25 +434,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.updateRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.updateRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom without error using callback', async () => {
@@ -454,20 +462,17 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Room());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Room()
+            );
             client.innerApiCalls.updateRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateRoom(
@@ -482,8 +487,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom with error', async () => {
@@ -492,24 +501,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateRoom(request), expectedError);
-            assert((client.innerApiCalls.updateRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateRoom with closed client', async () => {
@@ -518,7 +526,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateRoomRequest()
+            );
             request.room ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
@@ -536,24 +546,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteRoom = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteRoom(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom without error using callback', async () => {
@@ -562,19 +573,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteRoom = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteRoom(
@@ -589,8 +597,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom with error', async () => {
@@ -599,23 +611,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteRoom = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteRoom(request), expectedError);
-            assert((client.innerApiCalls.deleteRoom as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteRoom as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteRoom with closed client', async () => {
@@ -624,7 +635,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteRoomRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
@@ -641,24 +654,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.createBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.createBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb without error using callback', async () => {
@@ -667,19 +681,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.createBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createBlurb(
@@ -694,8 +705,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb with error', async () => {
@@ -704,23 +719,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createBlurb(request), expectedError);
-            assert((client.innerApiCalls.createBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createBlurb with closed client', async () => {
@@ -729,7 +743,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
@@ -746,24 +762,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.getBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.getBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb without error using callback', async () => {
@@ -772,19 +789,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.getBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getBlurb(
@@ -799,8 +813,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb with error', async () => {
@@ -809,23 +827,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getBlurb(request), expectedError);
-            assert((client.innerApiCalls.getBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getBlurb with closed client', async () => {
@@ -834,7 +851,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetBlurbRequest', ['name']);
             request.name = defaultValue1;
@@ -851,25 +870,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.updateBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.updateBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb without error using callback', async () => {
@@ -878,20 +898,17 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Blurb());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Blurb()
+            );
             client.innerApiCalls.updateBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateBlurb(
@@ -906,8 +923,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb with error', async () => {
@@ -916,24 +937,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateBlurb(request), expectedError);
-            assert((client.innerApiCalls.updateBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateBlurb with closed client', async () => {
@@ -942,7 +962,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.UpdateBlurbRequest()
+            );
             request.blurb ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
@@ -960,24 +982,25 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBlurb = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteBlurb(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb without error using callback', async () => {
@@ -986,19 +1009,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteBlurb = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteBlurb(
@@ -1013,8 +1033,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb with error', async () => {
@@ -1023,23 +1047,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteBlurb = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteBlurb(request), expectedError);
-            assert((client.innerApiCalls.deleteBlurb as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteBlurb as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteBlurb with closed client', async () => {
@@ -1048,7 +1071,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteBlurbRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
@@ -1065,25 +1090,26 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(expectedResponse);
             const [operation] = await client.searchBlurbs(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs without error using callback', async () => {
@@ -1092,19 +1118,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.searchBlurbs = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.searchBlurbs(
@@ -1122,8 +1145,12 @@ describe('v1beta1.MessagingClient', () => {
             const operation = await promise as LROperation<protos.google.showcase.v1beta1.ISearchBlurbsResponse, protos.google.showcase.v1beta1.ISearchBlurbsMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs with call error', async () => {
@@ -1132,23 +1159,22 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.searchBlurbs(request), expectedError);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes searchBlurbs with LRO error', async () => {
@@ -1157,24 +1183,23 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SearchBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.searchBlurbs = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.searchBlurbs(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.searchBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.searchBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkSearchBlurbsProgress without error', async () => {
@@ -1183,7 +1208,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1217,19 +1244,16 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
             client.innerApiCalls.streamBlurbs = stubServerStreamingCall(expectedResponse);
             const stream = client.streamBlurbs(request);
             const promise = new Promise((resolve, reject) => {
@@ -1242,8 +1266,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.streamBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes streamBlurbs with error', async () => {
@@ -1252,18 +1280,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.streamBlurbs = stubServerStreamingCall(undefined, expectedError);
             const stream = client.streamBlurbs(request);
@@ -1276,8 +1299,12 @@ describe('v1beta1.MessagingClient', () => {
                 });
             });
             await assert.rejects(promise, expectedError);
-            assert((client.innerApiCalls.streamBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            const actualRequest = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.streamBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes streamBlurbs with closed client', async () => {
@@ -1286,7 +1313,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
@@ -1312,8 +1341,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ConnectRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.StreamBlurbsResponse()
+            );
             client.innerApiCalls.connect = stubBidiStreamingCall(expectedResponse);
             const stream = client.connect();
             const promise = new Promise((resolve, reject) => {
@@ -1340,7 +1374,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ConnectRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ConnectRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.connect = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.connect();
@@ -1369,8 +1405,13 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SendBlurbsResponse());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
+            
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SendBlurbsResponse()
+            );
             client.innerApiCalls.sendBlurbs = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
             const promise = new Promise((resolve, reject) => {
@@ -1398,7 +1439,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateBlurbRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.sendBlurbs = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -1427,9 +1470,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1437,8 +1480,6 @@ describe('v1beta1.MessagingClient', () => {
             client.innerApiCalls.listRooms = stubSimpleCall(expectedResponse);
             const [response] = await client.listRooms(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listRooms without error using callback', async () => {
@@ -1447,9 +1488,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1468,8 +1509,6 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listRooms with error', async () => {
@@ -1478,13 +1517,12 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listRooms = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listRooms(request), expectedError);
-            assert((client.innerApiCalls.listRooms as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listRoomsStream without error', async () => {
@@ -1493,7 +1531,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1525,7 +1565,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listRooms.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listRoomsStream(request);
@@ -1552,7 +1594,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Room()),
@@ -1576,7 +1620,10 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListRoomsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListRoomsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listRooms.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listRoomsAsync(request);
             await assert.rejects(async () => {
@@ -1598,19 +1645,13 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1618,8 +1659,12 @@ describe('v1beta1.MessagingClient', () => {
             client.innerApiCalls.listBlurbs = stubSimpleCall(expectedResponse);
             const [response] = await client.listBlurbs(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbs without error using callback', async () => {
@@ -1628,19 +1673,13 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1659,8 +1698,12 @@ describe('v1beta1.MessagingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbs with error', async () => {
@@ -1669,23 +1712,22 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listBlurbs = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listBlurbs(request), expectedError);
-            assert((client.innerApiCalls.listBlurbs as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listBlurbs as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listBlurbsStream without error', async () => {
@@ -1694,7 +1736,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1722,10 +1766,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listBlurbs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBlurbs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1735,7 +1780,9 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1758,10 +1805,11 @@ describe('v1beta1.MessagingClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listBlurbs.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listBlurbs, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1771,7 +1819,9 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1791,10 +1841,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1804,11 +1855,14 @@ describe('v1beta1.MessagingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListBlurbsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBlurbsAsync(request);
             await assert.rejects(async () => {
@@ -1820,10 +1874,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listBlurbs.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1835,7 +1890,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1847,7 +1902,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -1862,7 +1917,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1874,7 +1929,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1901,7 +1956,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1927,7 +1982,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1939,7 +1994,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -1954,7 +2009,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1966,7 +2021,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1993,7 +2048,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -2019,7 +2074,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -2031,7 +2086,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -2046,7 +2101,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -2058,7 +2113,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -2085,7 +2140,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -2111,7 +2166,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -2123,7 +2178,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -2138,7 +2193,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -2150,7 +2205,7 @@ describe('v1beta1.MessagingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -2180,7 +2235,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -2231,10 +2286,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -2244,7 +2300,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -2260,10 +2316,11 @@ describe('v1beta1.MessagingClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -2275,7 +2332,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -2293,7 +2350,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -2325,7 +2382,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -2342,7 +2399,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -2360,7 +2417,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -2392,7 +2449,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -2409,7 +2466,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -2427,7 +2484,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -2459,7 +2516,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -2475,7 +2532,7 @@ describe('v1beta1.MessagingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -2506,7 +2563,7 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -311,8 +323,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -335,8 +349,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -370,8 +386,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -393,7 +411,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetRoomRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetRoomRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getRoom(request), expectedError);
@@ -408,9 +428,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -433,9 +455,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,9 +493,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
-            const expectedHeaderRequestParams = "room.name=";
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
+            const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -493,8 +519,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateRoomRequest());
-            request.room = {};
-            request.room.name = '';
+            request.room ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+            request.room.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateRoom(request), expectedError);
@@ -509,8 +537,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -533,8 +563,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -568,8 +600,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -591,7 +625,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteRoomRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteRoom(request), expectedError);
@@ -606,8 +642,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -630,8 +668,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -665,8 +705,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -688,7 +730,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateBlurbRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createBlurb(request), expectedError);
@@ -703,8 +747,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -727,8 +773,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -762,8 +810,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -785,7 +835,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetBlurbRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetBlurbRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getBlurb(request), expectedError);
@@ -800,9 +852,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -825,9 +879,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -861,9 +917,11 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
-            const expectedHeaderRequestParams = "blurb.name=";
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
+            const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -885,8 +943,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.UpdateBlurbRequest());
-            request.blurb = {};
-            request.blurb.name = '';
+            request.blurb ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+            request.blurb.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateBlurb(request), expectedError);
@@ -901,8 +961,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -925,8 +987,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -960,8 +1024,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -983,7 +1049,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteBlurbRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteBlurb(request), expectedError);
@@ -998,8 +1066,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1023,8 +1093,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1061,8 +1133,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1084,8 +1158,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.SearchBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1142,8 +1218,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1175,8 +1253,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1207,7 +1287,9 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.StreamBlurbsRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             const stream = client.streamBlurbs(request);
@@ -1517,8 +1599,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1545,8 +1629,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1584,8 +1670,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1607,8 +1695,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1646,8 +1736,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listBlurbsStream(request);
@@ -1680,8 +1772,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1711,8 +1805,10 @@ describe('v1beta1.MessagingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListBlurbsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listBlurbs.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listBlurbsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -25,6 +25,18 @@ import * as sequenceserviceModule from '../src';
 
 import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -235,8 +247,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -259,8 +273,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -294,8 +310,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -317,7 +335,9 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSequenceReport(request), expectedError);
@@ -332,8 +352,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -356,8 +378,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -391,8 +415,10 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -414,7 +440,9 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.attemptSequence(request), expectedError);

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax'
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -174,14 +175,15 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Sequence());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Sequence()
+            );
             client.innerApiCalls.createSequence = stubSimpleCall(expectedResponse);
             const [response] = await client.createSequence(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSequence without error using callback', async () => {
@@ -190,9 +192,12 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Sequence());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Sequence()
+            );
             client.innerApiCalls.createSequence = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createSequence(
@@ -207,8 +212,6 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createSequence with error', async () => {
@@ -217,13 +220,12 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createSequence = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createSequence(request), expectedError);
-            assert((client.innerApiCalls.createSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSequence with closed client', async () => {
@@ -232,7 +234,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSequenceRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createSequence(request), expectedError);
@@ -246,24 +250,25 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SequenceReport());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SequenceReport()
+            );
             client.innerApiCalls.getSequenceReport = stubSimpleCall(expectedResponse);
             const [response] = await client.getSequenceReport(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport without error using callback', async () => {
@@ -272,19 +277,16 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.SequenceReport());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.SequenceReport()
+            );
             client.innerApiCalls.getSequenceReport = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSequenceReport(
@@ -299,8 +301,12 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport with error', async () => {
@@ -309,23 +315,22 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSequenceReport = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSequenceReport(request), expectedError);
-            assert((client.innerApiCalls.getSequenceReport as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSequenceReport as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSequenceReport with closed client', async () => {
@@ -334,7 +339,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSequenceReportRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSequenceReportRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
@@ -351,24 +358,25 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.attemptSequence = stubSimpleCall(expectedResponse);
             const [response] = await client.attemptSequence(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence without error using callback', async () => {
@@ -377,19 +385,16 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.attemptSequence = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.attemptSequence(
@@ -404,8 +409,12 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence with error', async () => {
@@ -414,23 +423,22 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.attemptSequence = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.attemptSequence(request), expectedError);
-            assert((client.innerApiCalls.attemptSequence as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.attemptSequence as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes attemptSequence with closed client', async () => {
@@ -439,7 +447,9 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.AttemptSequenceRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.AttemptSequenceRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
@@ -456,7 +466,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -468,7 +478,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -483,7 +493,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -495,7 +505,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -522,7 +532,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -548,7 +558,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -560,7 +570,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -575,7 +585,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -587,7 +597,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -614,7 +624,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -640,7 +650,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -652,7 +662,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -667,7 +677,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -679,7 +689,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -706,7 +716,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -732,7 +742,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -744,7 +754,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -759,7 +769,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -771,7 +781,7 @@ describe('v1beta1.SequenceServiceClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -801,7 +811,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -852,10 +862,11 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -865,7 +876,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -881,10 +892,11 @@ describe('v1beta1.SequenceServiceClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -896,7 +908,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -914,7 +926,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -946,7 +958,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -963,7 +975,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -981,7 +993,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1013,7 +1025,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -1030,7 +1042,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1048,7 +1060,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1080,7 +1092,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -1096,7 +1108,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1127,7 +1139,7 @@ describe('v1beta1.SequenceServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -262,8 +274,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -286,8 +300,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -321,8 +337,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -344,7 +362,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSession(request), expectedError);
@@ -359,8 +379,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -383,8 +405,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -418,8 +442,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -441,7 +467,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteSession(request), expectedError);
@@ -456,8 +484,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -480,8 +510,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -515,8 +547,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -538,7 +572,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ReportSessionRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.reportSession(request), expectedError);
@@ -553,8 +589,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -577,8 +615,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -612,8 +652,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -635,7 +677,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTestRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteTest(request), expectedError);
@@ -650,8 +694,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -674,8 +720,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -709,8 +757,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -732,7 +782,9 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('VerifyTestRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.verifyTest(request), expectedError);
@@ -918,8 +970,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -946,8 +1000,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -985,8 +1041,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1008,8 +1066,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1047,8 +1107,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listTests.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listTestsStream(request);
@@ -1081,8 +1143,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1112,8 +1176,10 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListTestsRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listTests.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTestsAsync(request);
             await assert.rejects(async () => {

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, operationsProtos, IamProtos, LocationProtos} from 'google-gax'
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,14 +202,15 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.createSession = stubSimpleCall(expectedResponse);
             const [response] = await client.createSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSession without error using callback', async () => {
@@ -217,9 +219,12 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.createSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createSession(
@@ -234,8 +239,6 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes createSession with error', async () => {
@@ -244,13 +247,12 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.createSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createSession(request), expectedError);
-            assert((client.innerApiCalls.createSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes createSession with closed client', async () => {
@@ -259,7 +261,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.CreateSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.CreateSessionRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createSession(request), expectedError);
@@ -273,24 +277,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.getSession = stubSimpleCall(expectedResponse);
             const [response] = await client.getSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession without error using callback', async () => {
@@ -299,19 +304,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.Session());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.Session()
+            );
             client.innerApiCalls.getSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSession(
@@ -326,8 +328,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession with error', async () => {
@@ -336,23 +342,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSession(request), expectedError);
-            assert((client.innerApiCalls.getSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSession with closed client', async () => {
@@ -361,7 +366,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.GetSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.GetSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -378,24 +385,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSession = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession without error using callback', async () => {
@@ -404,19 +412,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteSession(
@@ -431,8 +436,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession with error', async () => {
@@ -441,23 +450,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteSession(request), expectedError);
-            assert((client.innerApiCalls.deleteSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteSession with closed client', async () => {
@@ -466,7 +474,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -483,24 +493,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionResponse()
+            );
             client.innerApiCalls.reportSession = stubSimpleCall(expectedResponse);
             const [response] = await client.reportSession(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession without error using callback', async () => {
@@ -509,19 +520,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionResponse()
+            );
             client.innerApiCalls.reportSession = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.reportSession(
@@ -536,8 +544,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession with error', async () => {
@@ -546,23 +558,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.reportSession = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.reportSession(request), expectedError);
-            assert((client.innerApiCalls.reportSession as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.reportSession as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes reportSession with closed client', async () => {
@@ -571,7 +582,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ReportSessionRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ReportSessionRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ReportSessionRequest', ['name']);
             request.name = defaultValue1;
@@ -588,24 +601,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTest = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteTest(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest without error using callback', async () => {
@@ -614,19 +628,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTest = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteTest(
@@ -641,8 +652,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest with error', async () => {
@@ -651,23 +666,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteTest = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteTest(request), expectedError);
-            assert((client.innerApiCalls.deleteTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTest with closed client', async () => {
@@ -676,7 +690,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.DeleteTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.DeleteTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTestRequest', ['name']);
             request.name = defaultValue1;
@@ -693,24 +709,25 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestResponse()
+            );
             client.innerApiCalls.verifyTest = stubSimpleCall(expectedResponse);
             const [response] = await client.verifyTest(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest without error using callback', async () => {
@@ -719,19 +736,16 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestResponse()
+            );
             client.innerApiCalls.verifyTest = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.verifyTest(
@@ -746,8 +760,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest with error', async () => {
@@ -756,23 +774,22 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.verifyTest = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.verifyTest(request), expectedError);
-            assert((client.innerApiCalls.verifyTest as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.verifyTest as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes verifyTest with closed client', async () => {
@@ -781,7 +798,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.VerifyTestRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.VerifyTestRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('VerifyTestRequest', ['name']);
             request.name = defaultValue1;
@@ -798,9 +817,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -808,8 +827,6 @@ describe('v1beta1.TestingClient', () => {
             client.innerApiCalls.listSessions = stubSimpleCall(expectedResponse);
             const [response] = await client.listSessions(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listSessions without error using callback', async () => {
@@ -818,9 +835,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = [
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -839,8 +856,6 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listSessions with error', async () => {
@@ -849,13 +864,12 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listSessions = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listSessions(request), expectedError);
-            assert((client.innerApiCalls.listSessions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listSessionsStream without error', async () => {
@@ -864,7 +878,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -896,7 +912,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedError = new Error('expected');
             client.descriptors.page.listSessions.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listSessionsStream(request);
@@ -923,7 +941,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
             const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Session()),
@@ -947,7 +967,10 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListSessionsRequest());const expectedError = new Error('expected');
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListSessionsRequest()
+            );
+            const expectedError = new Error('expected');
             client.descriptors.page.listSessions.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listSessionsAsync(request);
             await assert.rejects(async () => {
@@ -969,19 +992,13 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -989,8 +1006,12 @@ describe('v1beta1.TestingClient', () => {
             client.innerApiCalls.listTests = stubSimpleCall(expectedResponse);
             const [response] = await client.listTests(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTests without error using callback', async () => {
@@ -999,19 +1020,13 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1030,8 +1045,12 @@ describe('v1beta1.TestingClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTests with error', async () => {
@@ -1040,23 +1059,22 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listTests = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listTests(request), expectedError);
-            assert((client.innerApiCalls.listTests as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTests as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTestsStream without error', async () => {
@@ -1065,7 +1083,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1093,10 +1113,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listTests.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTests, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1106,7 +1127,9 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1129,10 +1152,11 @@ describe('v1beta1.TestingClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listTests.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTests, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1142,7 +1166,9 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1162,10 +1188,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1175,11 +1202,14 @@ describe('v1beta1.TestingClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.showcase.v1beta1.ListTestsRequest());
+            const request = generateSampleMessage(
+              new protos.google.showcase.v1beta1.ListTestsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listTests.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTestsAsync(request);
             await assert.rejects(async () => {
@@ -1191,10 +1221,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTests.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1206,7 +1237,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1218,7 +1249,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.getIamPolicy(request, expectedOptions);
@@ -1233,7 +1264,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1245,7 +1276,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.getIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1272,7 +1303,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.GetIamPolicyRequest()
+              new IamProtos.google.iam.v1.GetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1298,7 +1329,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1310,7 +1341,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = stubSimpleCall(expectedResponse);
             const response = await client.setIamPolicy(request, expectedOptions);
@@ -1325,7 +1356,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1337,7 +1368,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
             );
             client.iamClient.setIamPolicy = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1364,7 +1395,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.SetIamPolicyRequest()
+              new IamProtos.google.iam.v1.SetIamPolicyRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1390,7 +1421,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1402,7 +1433,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = stubSimpleCall(expectedResponse);
             const response = await client.testIamPermissions(request, expectedOptions);
@@ -1417,7 +1448,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1429,7 +1460,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
             );
             client.iamClient.testIamPermissions = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1456,7 +1487,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.TestIamPermissionsRequest()
+              new IamProtos.google.iam.v1.TestIamPermissionsRequest()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1482,7 +1513,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1494,7 +1525,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = stubSimpleCall(expectedResponse);
             const response = await client.getLocation(request, expectedOptions);
@@ -1509,7 +1540,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1521,7 +1552,7 @@ describe('v1beta1.TestingClient', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.getLocation = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1551,7 +1582,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.GetLocationRequest()
+              new LocationProtos.google.cloud.location.GetLocationRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1602,10 +1633,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with listLocations with error', async () => {
@@ -1615,7 +1647,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.ListLocationsRequest()
+              new LocationProtos.google.cloud.location.ListLocationsRequest()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1631,10 +1663,11 @@ describe('v1beta1.TestingClient', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.listLocations.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1646,7 +1679,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1664,7 +1697,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new operationsProtos.google.longrunning.Operation()
@@ -1696,7 +1729,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.GetOperationRequest()
+              new operationsProtos.google.longrunning.GetOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.getOperation = stubSimpleCall(undefined, expectedError);
@@ -1713,7 +1746,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1731,7 +1764,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1763,7 +1796,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.CancelOperationRequest()
+              new operationsProtos.google.longrunning.CancelOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.cancelOperation = stubSimpleCall(undefined, expectedError);
@@ -1780,7 +1813,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1798,7 +1831,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedResponse = generateSampleMessage(
                 new protos.google.protobuf.Empty()
@@ -1830,7 +1863,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.DeleteOperationRequest()
+              new operationsProtos.google.longrunning.DeleteOperationRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.deleteOperation = stubSimpleCall(undefined, expectedError);
@@ -1846,7 +1879,7 @@ describe('v1beta1.TestingClient', () => {
               projectId: 'bogus',
             });
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1877,7 +1910,7 @@ describe('v1beta1.TestingClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.ListOperationsRequest()
+              new operationsProtos.google.longrunning.ListOperationsRequest()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.listOperations.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -376,7 +376,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getQueue(request, options, callback);
@@ -467,7 +467,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createQueue(request, options, callback);
@@ -562,7 +562,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'queue.name': request.queue!.name || '',
+      'queue.name': request.queue!.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.updateQueue(request, options, callback);
@@ -646,7 +646,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteQueue(request, options, callback);
@@ -723,7 +723,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.purgeQueue(request, options, callback);
@@ -801,7 +801,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.pauseQueue(request, options, callback);
@@ -885,7 +885,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.resumeQueue(request, options, callback);
@@ -968,7 +968,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'resource': request.resource || '',
+      'resource': request.resource ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getIamPolicy(request, options, callback);
@@ -1055,7 +1055,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'resource': request.resource || '',
+      'resource': request.resource ?? '',
     });
     this.initialize();
     return this.innerApiCalls.setIamPolicy(request, options, callback);
@@ -1138,7 +1138,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'resource': request.resource || '',
+      'resource': request.resource ?? '',
     });
     this.initialize();
     return this.innerApiCalls.testIamPermissions(request, options, callback);
@@ -1223,7 +1223,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getTask(request, options, callback);
@@ -1348,7 +1348,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createTask(request, options, callback);
@@ -1424,7 +1424,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteTask(request, options, callback);
@@ -1532,7 +1532,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.runTask(request, options, callback);
@@ -1641,7 +1641,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listQueues(request, options, callback);
@@ -1706,7 +1706,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listQueues'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1780,7 +1780,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listQueues'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1903,7 +1903,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listTasks(request, options, callback);
@@ -1971,7 +1971,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTasks'];
     const callSettings = defaultCallSettings.merge(options);
@@ -2048,7 +2048,7 @@ export class CloudTasksClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listTasks'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -201,24 +202,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.getQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.getQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getQueue without error using callback', async () => {
@@ -227,19 +229,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.getQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getQueue(
@@ -254,8 +253,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getQueue with error', async () => {
@@ -264,23 +267,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getQueue(request), expectedError);
-            assert((client.innerApiCalls.getQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getQueue with closed client', async () => {
@@ -289,7 +291,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetQueueRequest', ['name']);
             request.name = defaultValue1;
@@ -306,24 +310,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.createQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.createQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createQueue without error using callback', async () => {
@@ -332,19 +337,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.createQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createQueue(
@@ -359,8 +361,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createQueue with error', async () => {
@@ -369,23 +375,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createQueue(request), expectedError);
-            assert((client.innerApiCalls.createQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createQueue with closed client', async () => {
@@ -394,7 +399,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
@@ -411,25 +418,26 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.UpdateQueueRequest()
+            );
             request.queue ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.updateQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.updateQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateQueue without error using callback', async () => {
@@ -438,20 +446,17 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.UpdateQueueRequest()
+            );
             request.queue ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.updateQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.updateQueue(
@@ -466,8 +471,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.updateQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateQueue with error', async () => {
@@ -476,24 +485,23 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.UpdateQueueRequest()
+            );
             request.queue ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.updateQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.updateQueue(request), expectedError);
-            assert((client.innerApiCalls.updateQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.updateQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes updateQueue with closed client', async () => {
@@ -502,7 +510,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.UpdateQueueRequest()
+            );
             request.queue ??= {};
             const defaultValue1 =
               getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
@@ -520,24 +530,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteQueue without error using callback', async () => {
@@ -546,19 +557,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteQueue(
@@ -573,8 +581,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteQueue with error', async () => {
@@ -583,23 +595,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteQueue(request), expectedError);
-            assert((client.innerApiCalls.deleteQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteQueue with closed client', async () => {
@@ -608,7 +619,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
@@ -625,24 +638,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PurgeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.purgeQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.purgeQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.purgeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes purgeQueue without error using callback', async () => {
@@ -651,19 +665,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PurgeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.purgeQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.purgeQueue(
@@ -678,8 +689,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.purgeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes purgeQueue with error', async () => {
@@ -688,23 +703,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PurgeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.purgeQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.purgeQueue(request), expectedError);
-            assert((client.innerApiCalls.purgeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.purgeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes purgeQueue with closed client', async () => {
@@ -713,7 +727,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PurgeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
@@ -730,24 +746,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PauseQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.pauseQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.pauseQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pauseQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes pauseQueue without error using callback', async () => {
@@ -756,19 +773,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PauseQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.pauseQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.pauseQueue(
@@ -783,8 +797,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.pauseQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes pauseQueue with error', async () => {
@@ -793,23 +811,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PauseQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.pauseQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.pauseQueue(request), expectedError);
-            assert((client.innerApiCalls.pauseQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.pauseQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes pauseQueue with closed client', async () => {
@@ -818,7 +835,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.PauseQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('PauseQueueRequest', ['name']);
             request.name = defaultValue1;
@@ -835,24 +854,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ResumeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.resumeQueue = stubSimpleCall(expectedResponse);
             const [response] = await client.resumeQueue(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.resumeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes resumeQueue without error using callback', async () => {
@@ -861,19 +881,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ResumeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Queue());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Queue()
+            );
             client.innerApiCalls.resumeQueue = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.resumeQueue(
@@ -888,8 +905,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.resumeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes resumeQueue with error', async () => {
@@ -898,23 +919,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ResumeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.resumeQueue = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.resumeQueue(request), expectedError);
-            assert((client.innerApiCalls.resumeQueue as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.resumeQueue as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes resumeQueue with closed client', async () => {
@@ -923,7 +943,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ResumeQueueRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
@@ -940,24 +962,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.GetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.Policy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.Policy()
+            );
             client.innerApiCalls.getIamPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.getIamPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getIamPolicy without error using callback', async () => {
@@ -966,19 +989,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.GetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.Policy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.Policy()
+            );
             client.innerApiCalls.getIamPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getIamPolicy(
@@ -993,8 +1013,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getIamPolicy with error', async () => {
@@ -1003,23 +1027,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.GetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getIamPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getIamPolicy(request), expectedError);
-            assert((client.innerApiCalls.getIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getIamPolicy with closed client', async () => {
@@ -1028,7 +1051,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.GetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
@@ -1045,24 +1070,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.SetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.Policy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.Policy()
+            );
             client.innerApiCalls.setIamPolicy = stubSimpleCall(expectedResponse);
             const [response] = await client.setIamPolicy(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.setIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes setIamPolicy without error using callback', async () => {
@@ -1071,19 +1097,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.SetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.Policy());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.Policy()
+            );
             client.innerApiCalls.setIamPolicy = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.setIamPolicy(
@@ -1098,8 +1121,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.setIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes setIamPolicy with error', async () => {
@@ -1108,23 +1135,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.SetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.setIamPolicy = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.setIamPolicy(request), expectedError);
-            assert((client.innerApiCalls.setIamPolicy as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.setIamPolicy as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes setIamPolicy with closed client', async () => {
@@ -1133,7 +1159,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.SetIamPolicyRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
@@ -1150,24 +1178,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsResponse()
+            );
             client.innerApiCalls.testIamPermissions = stubSimpleCall(expectedResponse);
             const [response] = await client.testIamPermissions(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.testIamPermissions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes testIamPermissions without error using callback', async () => {
@@ -1176,19 +1205,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsResponse()
+            );
             client.innerApiCalls.testIamPermissions = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.testIamPermissions(
@@ -1203,8 +1229,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.testIamPermissions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes testIamPermissions with error', async () => {
@@ -1213,23 +1243,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.testIamPermissions = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.testIamPermissions(request), expectedError);
-            assert((client.innerApiCalls.testIamPermissions as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.testIamPermissions as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes testIamPermissions with closed client', async () => {
@@ -1238,7 +1267,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
+            const request = generateSampleMessage(
+              new protos.google.iam.v1.TestIamPermissionsRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
@@ -1255,24 +1286,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.getTask = stubSimpleCall(expectedResponse);
             const [response] = await client.getTask(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getTask without error using callback', async () => {
@@ -1281,19 +1313,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.getTask = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getTask(
@@ -1308,8 +1337,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getTask with error', async () => {
@@ -1318,23 +1351,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getTask = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getTask(request), expectedError);
-            assert((client.innerApiCalls.getTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getTask with closed client', async () => {
@@ -1343,7 +1375,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.GetTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetTaskRequest', ['name']);
             request.name = defaultValue1;
@@ -1360,24 +1394,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.createTask = stubSimpleCall(expectedResponse);
             const [response] = await client.createTask(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTask without error using callback', async () => {
@@ -1386,19 +1421,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.createTask = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createTask(
@@ -1413,8 +1445,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTask with error', async () => {
@@ -1423,23 +1459,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createTask = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.createTask(request), expectedError);
-            assert((client.innerApiCalls.createTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createTask with closed client', async () => {
@@ -1448,7 +1483,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.CreateTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1465,24 +1502,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTask = stubSimpleCall(expectedResponse);
             const [response] = await client.deleteTask(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTask without error using callback', async () => {
@@ -1491,19 +1529,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.protobuf.Empty());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.protobuf.Empty()
+            );
             client.innerApiCalls.deleteTask = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteTask(
@@ -1518,8 +1553,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTask with error', async () => {
@@ -1528,23 +1567,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteTask = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.deleteTask(request), expectedError);
-            assert((client.innerApiCalls.deleteTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteTask with closed client', async () => {
@@ -1553,7 +1591,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.DeleteTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
@@ -1570,24 +1610,25 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.RunTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.runTask = stubSimpleCall(expectedResponse);
             const [response] = await client.runTask(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.runTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes runTask without error using callback', async () => {
@@ -1596,19 +1637,16 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.RunTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.tasks.v2.Task());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.Task()
+            );
             client.innerApiCalls.runTask = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.runTask(
@@ -1623,8 +1661,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.runTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes runTask with error', async () => {
@@ -1633,23 +1675,22 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.RunTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.runTask = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.runTask(request), expectedError);
-            assert((client.innerApiCalls.runTask as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.runTask as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes runTask with closed client', async () => {
@@ -1658,7 +1699,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.RunTaskRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('RunTaskRequest', ['name']);
             request.name = defaultValue1;
@@ -1675,19 +1718,13 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1695,8 +1732,12 @@ describe('v2.CloudTasksClient', () => {
             client.innerApiCalls.listQueues = stubSimpleCall(expectedResponse);
             const [response] = await client.listQueues(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listQueues as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listQueues without error using callback', async () => {
@@ -1705,19 +1746,13 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1736,8 +1771,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listQueues as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listQueues with error', async () => {
@@ -1746,23 +1785,22 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listQueues = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listQueues(request), expectedError);
-            assert((client.innerApiCalls.listQueues as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listQueues as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listQueuesStream without error', async () => {
@@ -1771,7 +1809,9 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1799,10 +1839,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listQueues.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listQueues, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listQueues.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1812,7 +1853,9 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1835,10 +1878,11 @@ describe('v2.CloudTasksClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listQueues.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listQueues, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listQueues.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1848,7 +1892,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1868,10 +1914,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listQueues.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listQueues.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1881,11 +1928,14 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListQueuesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listQueues.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listQueuesAsync(request);
             await assert.rejects(async () => {
@@ -1897,10 +1947,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listQueues.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listQueues.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1912,19 +1963,13 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -1932,8 +1977,12 @@ describe('v2.CloudTasksClient', () => {
             client.innerApiCalls.listTasks = stubSimpleCall(expectedResponse);
             const [response] = await client.listTasks(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTasks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTasks without error using callback', async () => {
@@ -1942,19 +1991,13 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -1973,8 +2016,12 @@ describe('v2.CloudTasksClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listTasks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTasks with error', async () => {
@@ -1983,23 +2030,22 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listTasks = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listTasks(request), expectedError);
-            assert((client.innerApiCalls.listTasks as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listTasks as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listTasksStream without error', async () => {
@@ -2008,7 +2054,9 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2036,10 +2084,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listTasks.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTasks, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTasks.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2049,7 +2098,9 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2072,10 +2123,11 @@ describe('v2.CloudTasksClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listTasks.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listTasks, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTasks.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -2085,7 +2137,9 @@ describe('v2.CloudTasksClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
@@ -2105,10 +2159,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTasks.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTasks.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -2118,11 +2173,14 @@ describe('v2.CloudTasksClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.tasks.v2.ListTasksRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listTasks.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTasksAsync(request);
             await assert.rejects(async () => {
@@ -2134,10 +2192,11 @@ describe('v2.CloudTasksClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listTasks.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listTasks.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -190,8 +202,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -214,8 +228,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -249,8 +265,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -272,7 +290,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetQueueRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetQueueRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getQueue(request), expectedError);
@@ -287,8 +307,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -311,8 +333,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -346,8 +370,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -369,7 +395,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateQueueRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createQueue(request), expectedError);
@@ -384,9 +412,11 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
-            request.queue = {};
-            request.queue.name = '';
-            const expectedHeaderRequestParams = "queue.name=";
+            request.queue ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+            request.queue.name = defaultValue1;
+            const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -409,9 +439,11 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
-            request.queue = {};
-            request.queue.name = '';
-            const expectedHeaderRequestParams = "queue.name=";
+            request.queue ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+            request.queue.name = defaultValue1;
+            const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -445,9 +477,11 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
-            request.queue = {};
-            request.queue.name = '';
-            const expectedHeaderRequestParams = "queue.name=";
+            request.queue ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+            request.queue.name = defaultValue1;
+            const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -469,8 +503,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.UpdateQueueRequest());
-            request.queue = {};
-            request.queue.name = '';
+            request.queue ??= {};
+            const defaultValue1 =
+              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+            request.queue.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.updateQueue(request), expectedError);
@@ -485,8 +521,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -509,8 +547,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -544,8 +584,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -567,7 +609,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteQueueRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteQueue(request), expectedError);
@@ -582,8 +626,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -606,8 +652,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -641,8 +689,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -664,7 +714,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PurgeQueueRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.purgeQueue(request), expectedError);
@@ -679,8 +731,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PauseQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -703,8 +757,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PauseQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -738,8 +794,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('PauseQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -761,7 +819,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.PauseQueueRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('PauseQueueRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.pauseQueue(request), expectedError);
@@ -776,8 +836,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -800,8 +862,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -835,8 +899,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -858,7 +924,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ResumeQueueRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.resumeQueue(request), expectedError);
@@ -873,8 +941,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -897,8 +967,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -932,8 +1004,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -955,7 +1029,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.GetIamPolicyRequest());
-            request.resource = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getIamPolicy(request), expectedError);
@@ -970,8 +1046,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -994,8 +1072,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1029,8 +1109,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1052,7 +1134,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.SetIamPolicyRequest());
-            request.resource = '';
+            const defaultValue1 =
+              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+            request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.setIamPolicy(request), expectedError);
@@ -1067,8 +1151,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1091,8 +1177,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1126,8 +1214,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
-            request.resource = '';
-            const expectedHeaderRequestParams = "resource=";
+            const defaultValue1 =
+              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+            request.resource = defaultValue1;
+            const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1149,7 +1239,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.iam.v1.TestIamPermissionsRequest());
-            request.resource = '';
+            const defaultValue1 =
+              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+            request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.testIamPermissions(request), expectedError);
@@ -1164,8 +1256,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1188,8 +1282,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1223,8 +1319,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1246,7 +1344,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.GetTaskRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetTaskRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getTask(request), expectedError);
@@ -1261,8 +1361,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1285,8 +1387,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1320,8 +1424,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1343,7 +1449,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.CreateTaskRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.createTask(request), expectedError);
@@ -1358,8 +1466,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1382,8 +1492,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1417,8 +1529,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1440,7 +1554,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.DeleteTaskRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.deleteTask(request), expectedError);
@@ -1455,8 +1571,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RunTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1479,8 +1597,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RunTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1514,8 +1634,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('RunTaskRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1537,7 +1659,9 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.RunTaskRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('RunTaskRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.runTask(request), expectedError);
@@ -1552,8 +1676,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1580,8 +1706,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1619,8 +1747,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1642,8 +1772,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1681,8 +1813,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listQueues.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listQueuesStream(request);
@@ -1715,8 +1849,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1746,8 +1882,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListQueuesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listQueues.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listQueuesAsync(request);
             await assert.rejects(async () => {
@@ -1775,8 +1913,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1803,8 +1943,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1842,8 +1984,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1865,8 +2009,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -1904,8 +2050,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listTasks.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listTasksStream(request);
@@ -1938,8 +2086,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -1969,8 +2119,10 @@ describe('v2.CloudTasksClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.tasks.v2.ListTasksRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListTasksRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listTasks.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listTasksAsync(request);
             await assert.rejects(async () => {

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as texttospeechModule from '../src';
 
 import {protobuf} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -154,14 +155,15 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesResponse());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesResponse()
+            );
             client.innerApiCalls.listVoices = stubSimpleCall(expectedResponse);
             const [response] = await client.listVoices(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listVoices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listVoices without error using callback', async () => {
@@ -170,9 +172,12 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesResponse());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesResponse()
+            );
             client.innerApiCalls.listVoices = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.listVoices(
@@ -187,8 +192,6 @@ describe('v1.TextToSpeechClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listVoices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes listVoices with error', async () => {
@@ -197,13 +200,12 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.listVoices = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listVoices(request), expectedError);
-            assert((client.innerApiCalls.listVoices as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes listVoices with closed client', async () => {
@@ -212,7 +214,9 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.ListVoicesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.ListVoicesRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.listVoices(request), expectedError);
@@ -226,14 +230,15 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse()
+            );
             client.innerApiCalls.synthesizeSpeech = stubSimpleCall(expectedResponse);
             const [response] = await client.synthesizeSpeech(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.synthesizeSpeech as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes synthesizeSpeech without error using callback', async () => {
@@ -242,9 +247,12 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse()
+            );
             client.innerApiCalls.synthesizeSpeech = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.synthesizeSpeech(
@@ -259,8 +267,6 @@ describe('v1.TextToSpeechClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.synthesizeSpeech as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes synthesizeSpeech with error', async () => {
@@ -269,13 +275,12 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.synthesizeSpeech = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.synthesizeSpeech(request), expectedError);
-            assert((client.innerApiCalls.synthesizeSpeech as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes synthesizeSpeech with closed client', async () => {
@@ -284,7 +289,9 @@ describe('v1.TextToSpeechClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.texttospeech.v1.SynthesizeSpeechRequest()
+            );
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.synthesizeSpeech(request), expectedError);

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -476,7 +476,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.translateText(request, options, callback);
@@ -581,7 +581,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.detectLanguage(request, options, callback);
@@ -683,7 +683,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getSupportedLanguages(request, options, callback);
@@ -755,7 +755,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.getGlossary(request, options, callback);
@@ -885,7 +885,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.batchTranslateText(request, options, callback);
@@ -979,7 +979,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.createGlossary(request, options, callback);
@@ -1072,7 +1072,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'name': request.name || '',
+      'name': request.name ?? '',
     });
     this.initialize();
     return this.innerApiCalls.deleteGlossary(request, options, callback);
@@ -1179,7 +1179,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     this.initialize();
     return this.innerApiCalls.listGlossaries(request, options, callback);
@@ -1226,7 +1226,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listGlossaries'];
     const callSettings = defaultCallSettings.merge(options);
@@ -1282,7 +1282,7 @@ export class TranslationServiceClient {
     options.otherArgs.headers[
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
-      'parent': request.parent || '',
+      'parent': request.parent ?? '',
     });
     const defaultCallSettings = this._defaults['listGlossaries'];
     const callSettings = defaultCallSettings.merge(options);

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -27,6 +27,18 @@ import {PassThrough} from 'stream';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});
@@ -206,8 +218,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -230,8 +244,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -265,8 +281,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -288,7 +306,9 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.translateText(request), expectedError);
@@ -303,8 +323,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -327,8 +349,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -362,8 +386,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -385,7 +411,9 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.detectLanguage(request), expectedError);
@@ -400,8 +428,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -424,8 +454,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -459,8 +491,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -482,7 +516,9 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
-            request.parent = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+            request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getSupportedLanguages(request), expectedError);
@@ -497,8 +533,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -521,8 +559,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -556,8 +596,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -579,7 +621,9 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
-            request.name = '';
+            const defaultValue1 =
+              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+            request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
             await assert.rejects(client.getGlossary(request), expectedError);
@@ -594,8 +638,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -619,8 +665,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -657,8 +705,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -680,8 +730,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -738,8 +790,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -763,8 +817,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -801,8 +857,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -824,8 +882,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -882,8 +942,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -907,8 +969,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -945,8 +1009,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -968,8 +1034,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
-            request.name = '';
-            const expectedHeaderRequestParams = "name=";
+            const defaultValue1 =
+              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+            request.name = defaultValue1;
+            const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1026,8 +1094,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1054,8 +1124,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1093,8 +1165,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedOptions = {
                 otherArgs: {
                     headers: {
@@ -1116,8 +1190,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1155,8 +1231,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
             client.descriptors.page.listGlossaries.createStream = stubPageStreamingCall(undefined, expectedError);
             const stream = client.listGlossariesStream(request);
@@ -1189,8 +1267,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1220,8 +1300,10 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             client.initialize();
             const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
-            request.parent = '';
-            const expectedHeaderRequestParams = "parent=";const expectedError = new Error('expected');
+            const defaultValue1 =
+              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+            request.parent = defaultValue1;
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
             client.descriptors.page.listGlossaries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGlossariesAsync(request);
             await assert.rejects(async () => {

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -31,6 +31,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -217,24 +218,25 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextResponse()
+            );
             client.innerApiCalls.translateText = stubSimpleCall(expectedResponse);
             const [response] = await client.translateText(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.translateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes translateText without error using callback', async () => {
@@ -243,19 +245,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextResponse()
+            );
             client.innerApiCalls.translateText = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.translateText(
@@ -270,8 +269,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.translateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes translateText with error', async () => {
@@ -280,23 +283,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.translateText = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.translateText(request), expectedError);
-            assert((client.innerApiCalls.translateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.translateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes translateText with closed client', async () => {
@@ -305,7 +307,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.TranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
@@ -322,24 +326,25 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageResponse()
+            );
             client.innerApiCalls.detectLanguage = stubSimpleCall(expectedResponse);
             const [response] = await client.detectLanguage(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.detectLanguage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes detectLanguage without error using callback', async () => {
@@ -348,19 +353,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageResponse());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageResponse()
+            );
             client.innerApiCalls.detectLanguage = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.detectLanguage(
@@ -375,8 +377,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.detectLanguage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes detectLanguage with error', async () => {
@@ -385,23 +391,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.detectLanguage = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.detectLanguage(request), expectedError);
-            assert((client.innerApiCalls.detectLanguage as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.detectLanguage as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes detectLanguage with closed client', async () => {
@@ -410,7 +415,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DetectLanguageRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
@@ -427,24 +434,25 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.SupportedLanguages());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.SupportedLanguages()
+            );
             client.innerApiCalls.getSupportedLanguages = stubSimpleCall(expectedResponse);
             const [response] = await client.getSupportedLanguages(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSupportedLanguages as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSupportedLanguages without error using callback', async () => {
@@ -453,19 +461,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.SupportedLanguages());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.SupportedLanguages()
+            );
             client.innerApiCalls.getSupportedLanguages = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getSupportedLanguages(
@@ -480,8 +485,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getSupportedLanguages as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSupportedLanguages with error', async () => {
@@ -490,23 +499,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getSupportedLanguages = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getSupportedLanguages(request), expectedError);
-            assert((client.innerApiCalls.getSupportedLanguages as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getSupportedLanguages as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getSupportedLanguages with closed client', async () => {
@@ -515,7 +523,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -532,24 +542,25 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.Glossary()
+            );
             client.innerApiCalls.getGlossary = stubSimpleCall(expectedResponse);
             const [response] = await client.getGlossary(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGlossary without error using callback', async () => {
@@ -558,19 +569,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.Glossary()
+            );
             client.innerApiCalls.getGlossary = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.getGlossary(
@@ -585,8 +593,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.getGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGlossary with error', async () => {
@@ -595,23 +607,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.getGlossary = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.getGlossary(request), expectedError);
-            assert((client.innerApiCalls.getGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.getGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes getGlossary with closed client', async () => {
@@ -620,7 +631,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.GetGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
@@ -637,25 +650,26 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.batchTranslateText = stubLongRunningCall(expectedResponse);
             const [operation] = await client.batchTranslateText(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchTranslateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchTranslateText without error using callback', async () => {
@@ -664,19 +678,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.batchTranslateText = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.batchTranslateText(
@@ -694,8 +705,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.translation.v3beta1.IBatchTranslateResponse, protos.google.cloud.translation.v3beta1.IBatchTranslateMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.batchTranslateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchTranslateText with call error', async () => {
@@ -704,23 +719,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.batchTranslateText = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.batchTranslateText(request), expectedError);
-            assert((client.innerApiCalls.batchTranslateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes batchTranslateText with LRO error', async () => {
@@ -729,24 +743,23 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.batchTranslateText = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.batchTranslateText(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.batchTranslateText as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.batchTranslateText as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkBatchTranslateTextProgress without error', async () => {
@@ -755,7 +768,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -789,25 +804,26 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.createGlossary = stubLongRunningCall(expectedResponse);
             const [operation] = await client.createGlossary(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGlossary without error using callback', async () => {
@@ -816,19 +832,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.createGlossary = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.createGlossary(
@@ -846,8 +859,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.translation.v3beta1.IGlossary, protos.google.cloud.translation.v3beta1.ICreateGlossaryMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.createGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGlossary with call error', async () => {
@@ -856,23 +873,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createGlossary = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.createGlossary(request), expectedError);
-            assert((client.innerApiCalls.createGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes createGlossary with LRO error', async () => {
@@ -881,24 +897,23 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.createGlossary = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.createGlossary(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.createGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.createGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkCreateGlossaryProgress without error', async () => {
@@ -907,7 +922,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -941,25 +958,26 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.deleteGlossary = stubLongRunningCall(expectedResponse);
             const [operation] = await client.deleteGlossary(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGlossary without error using callback', async () => {
@@ -968,19 +986,16 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.deleteGlossary = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.deleteGlossary(
@@ -998,8 +1013,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.translation.v3beta1.IDeleteGlossaryResponse, protos.google.cloud.translation.v3beta1.IDeleteGlossaryMetadata>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.deleteGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGlossary with call error', async () => {
@@ -1008,23 +1027,22 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteGlossary = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.deleteGlossary(request), expectedError);
-            assert((client.innerApiCalls.deleteGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes deleteGlossary with LRO error', async () => {
@@ -1033,24 +1051,23 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.deleteGlossary = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.deleteGlossary(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.deleteGlossary as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.deleteGlossary as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes checkDeleteGlossaryProgress without error', async () => {
@@ -1059,7 +1076,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -1093,19 +1112,13 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1113,8 +1126,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             client.innerApiCalls.listGlossaries = stubSimpleCall(expectedResponse);
             const [response] = await client.listGlossaries(request);
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGlossaries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGlossaries without error using callback', async () => {
@@ -1123,19 +1140,13 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-            const expectedResponse = [
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1154,8 +1165,12 @@ describe('v3beta1.TranslationServiceClient', () => {
             });
             const response = await promise;
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.listGlossaries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            const actualRequest = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGlossaries with error', async () => {
@@ -1164,23 +1179,22 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
             const expectedError = new Error('expected');
             client.innerApiCalls.listGlossaries = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.listGlossaries(request), expectedError);
-            assert((client.innerApiCalls.listGlossaries as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            const actualRequest = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.listGlossaries as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
         });
 
         it('invokes listGlossariesStream without error', async () => {
@@ -1189,7 +1203,9 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1217,10 +1233,11 @@ describe('v3beta1.TranslationServiceClient', () => {
             assert.deepStrictEqual(responses, expectedResponse);
             assert((client.descriptors.page.listGlossaries.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGlossaries, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGlossaries.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1230,7 +1247,9 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1253,10 +1272,11 @@ describe('v3beta1.TranslationServiceClient', () => {
             await assert.rejects(promise, expectedError);
             assert((client.descriptors.page.listGlossaries.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.listGlossaries, request));
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGlossaries.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
         });
 
@@ -1266,7 +1286,9 @@ describe('v3beta1.TranslationServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
@@ -1286,10 +1308,11 @@ describe('v3beta1.TranslationServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGlossaries.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGlossaries.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
 
@@ -1299,11 +1322,14 @@ describe('v3beta1.TranslationServiceClient', () => {
                 projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.translation.v3beta1.ListGlossariesRequest());
+            const request = generateSampleMessage(
+              new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
+            );
             const defaultValue1 =
               getTypeDefaultValue('ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
-            const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedError = new Error('expected');
+            const expectedHeaderRequestParams = `parent=${defaultValue1}`;
+            const expectedError = new Error('expected');
             client.descriptors.page.listGlossaries.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.listGlossariesAsync(request);
             await assert.rejects(async () => {
@@ -1315,10 +1341,11 @@ describe('v3beta1.TranslationServiceClient', () => {
             assert.deepStrictEqual(
                 (client.descriptors.page.listGlossaries.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.listGlossaries.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -29,6 +29,7 @@ import {protobuf, LROperation, operationsProtos} from 'google-gax';
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
@@ -166,15 +167,16 @@ describe('v1.VideoIntelligenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.annotateVideo = stubLongRunningCall(expectedResponse);
             const [operation] = await client.annotateVideo(request);
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.annotateVideo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes annotateVideo without error using callback', async () => {
@@ -183,9 +185,12 @@ describe('v1.VideoIntelligenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
-            const expectedResponse = generateSampleMessage(new protos.google.longrunning.Operation());
+            const request = generateSampleMessage(
+              new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest()
+            );
+            const expectedResponse = generateSampleMessage(
+              new protos.google.longrunning.Operation()
+            );
             client.innerApiCalls.annotateVideo = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
                  client.annotateVideo(
@@ -203,8 +208,6 @@ describe('v1.VideoIntelligenceServiceClient', () => {
             const operation = await promise as LROperation<protos.google.cloud.videointelligence.v1.IAnnotateVideoResponse, protos.google.cloud.videointelligence.v1.IAnnotateVideoProgress>;
             const [response] = await operation.promise();
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.annotateVideo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
         });
 
         it('invokes annotateVideo with call error', async () => {
@@ -213,13 +216,12 @@ describe('v1.VideoIntelligenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.annotateVideo = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.annotateVideo(request), expectedError);
-            assert((client.innerApiCalls.annotateVideo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes annotateVideo with LRO error', async () => {
@@ -228,14 +230,13 @@ describe('v1.VideoIntelligenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const request = generateSampleMessage(new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest());
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const request = generateSampleMessage(
+              new protos.google.cloud.videointelligence.v1.AnnotateVideoRequest()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.annotateVideo = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.annotateVideo(request);
             await assert.rejects(operation.promise(), expectedError);
-            assert((client.innerApiCalls.annotateVideo as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
         });
 
         it('invokes checkAnnotateVideoProgress without error', async () => {
@@ -244,7 +245,9 @@ describe('v1.VideoIntelligenceServiceClient', () => {
               projectId: 'bogus',
             });
             client.initialize();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}

--- a/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -25,6 +25,18 @@ import * as videointelligenceserviceModule from '../src';
 
 import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -289,7 +289,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
       'x-goog-request-params'
     ] = this._gaxModule.routingHeader.fromParams({
 {%- for requestParam in method.headerRequestParams %}
-      '{{ requestParam.toSnakeCaseString(".") }}': request.{{ requestParam.toCamelCaseString("!.") }} || '',
+      '{{ requestParam.toSnakeCaseString(".") }}': request.{{ requestParam.toCamelCaseString("!.") }} ?? '',
 {%- endfor %}
     });
 {%- endif %}
@@ -300,22 +300,33 @@ request.{{ oneComment.paramName.toCamelCase() }}
             const request = generateSampleMessage(new protos{{ method.inputInterface }}());
 {%- if method.headerRequestParams.length > 0 %}
 {#- generated request object for implicit routing headers -#}
+{%- set requestType = method.inputInterface.replace(r/^.*\./, '') -%}
 {%- set expectedRequestParamJoiner = joiner("&") -%}
 {%- set expectedRequestParams = "" -%}
+{%- set valueCounter = 0 -%}
 {%- for requestParam in method.headerRequestParams %}
+{%- set valueCounter = valueCounter + 1 -%}
 {%- set chain = "request" -%}
 {%- set originalName = "" -%}
+{%- set fieldsJoiner = joiner(", ") -%}
+{%- set fields = "" -%}
 {%- for field in requestParam.slice(0, -1) %}
-            {{ chain }}.{{ field.toCamelCase() }} = {};
+            {{ chain }}.{{ field.toCamelCase() }} ??= {};
 {%- set chain = chain + "." + field.toCamelCase() -%}
 {%- set originalName = originalName + field + "." -%}
-{%- endfor %}
-            {{ chain }}.{{ requestParam.slice(-1)[0].toCamelCase() }} = '';
+{%- set fields = fields + fieldsJoiner() + "'" + field.toCamelCase() + "'" -%}
+{%- endfor -%}
+{%- set lastFieldName = requestParam.slice(-1)[0].toCamelCase() -%}
+{%- set fields = fields + fieldsJoiner() + "'" + lastFieldName + "'" %}
+            const defaultValue{{ valueCounter }} =
+              getTypeDefaultValue('{{ requestType }}', [{{ fields | safe }}]);
+            {{ chain }}.{{ lastFieldName }} = defaultValue{{ valueCounter }};
 {%- set expectedRequestParams = expectedRequestParams + expectedRequestParamJoiner() +
-                                originalName + requestParam.slice(-1)[0] + "=" -%}
+                                originalName + requestParam.slice(-1)[0] + "=" +
+                                  "${defaultValue" + valueCounter + "}" -%}
 {%- endfor %}
 {%- if not skipExpectedVariable %}
-            const expectedHeaderRequestParams = "{{ expectedRequestParams | safe }}";
+            const expectedHeaderRequestParams = `{{ expectedRequestParams | safe }}`;
 {%- endif %}
 {%- elif method.dynamicRoutingRequestParams.length > 0 %}
 {#- generated request object for dynamic routing headers -#}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -335,6 +335,8 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {#- for unit tests, only take the last template.
     TODO: figure out how to generate expected value for multiple, possibly overlapping, templates
 -#}
+{%- set expectedKey = "" -%}
+{%- set expectedValue = "" -%}
 {%- for paramArray in method.dynamicRoutingRequestParams.slice(-1) %}
 {%- for param in paramArray %}
 {%- set chain = "request" -%}
@@ -342,6 +344,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
             {{ chain }}.{{ field.toCamelCase() }} = {};
 {%- set chain = chain + "." + field.toCamelCase() -%}
 {%- endfor %}
+            {%- set expectedKey = param.fieldSend -%}
             {%- if param.pathTemplate %}
             // path template: {{ param.pathTemplate }}
             {#- generate real-looking value for the field that would match the path template -#}
@@ -351,12 +354,13 @@ request.{{ oneComment.paramName.toCamelCase() }}
             // path template is empty
             {%- set fieldValue = 'value' -%}
             {%- set parameterValue = 'value' -%}
-            {%- endif %}
+            {%- endif -%}
+            {%- set expectedValue = parameterValue %}
             {{ chain }}.{{ param.fieldRetrieve.slice(-1)[0].toCamelCase() }} = '{{ fieldValue }}';
 {%- endfor %}
 {%- endfor %}
 {%- if not skipExpectedVariable %}
-            const expectedHeaderRequestParams = '{{ param.fieldSend }}={{ parameterValue }}';
+            const expectedHeaderRequestParams = '{{ expectedKey }}={{ expectedValue }}';
 {%- endif %}
 {%- endif %}
 {%- endmacro -%}

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -297,7 +297,9 @@ request.{{ oneComment.paramName.toCamelCase() }}
 
 {%- macro initRequestWithHeaderParam(method, skipExpectedVariable='') -%}
 {# initializing request object for generated unit tests -#}
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
+            const request = generateSampleMessage(
+              new protos{{ method.inputInterface }}()
+            );
 {%- if method.headerRequestParams.length > 0 %}
 {#- generated request object for implicit routing headers -#}
 {%- set requestType = method.inputInterface.replace(r/^.*\./, '') -%}
@@ -330,10 +332,10 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- endif %}
 {%- elif method.dynamicRoutingRequestParams.length > 0 %}
 {#- generated request object for dynamic routing headers -#}
-{%- if not skipExpectedVariable %}
-            const expectedHeaderRequestParamsObj: {[key: string]: string} = {};
-{%- endif %}
-{%- for paramArray in method.dynamicRoutingRequestParams %}
+{#- for unit tests, only take the last template.
+    TODO: figure out how to generate expected value for multiple, possibly overlapping, templates
+-#}
+{%- for paramArray in method.dynamicRoutingRequestParams.slice(-1) %}
 {%- for param in paramArray %}
 {%- set chain = "request" -%}
 {%- for field in param.fieldRetrieve.slice(0, -1) %}
@@ -351,33 +353,29 @@ request.{{ oneComment.paramName.toCamelCase() }}
             {%- set parameterValue = 'value' -%}
             {%- endif %}
             {{ chain }}.{{ param.fieldRetrieve.slice(-1)[0].toCamelCase() }} = '{{ fieldValue }}';
-{%- if not skipExpectedVariable %}
-            expectedHeaderRequestParamsObj['{{ param.fieldSend }}'] = '{{ parameterValue }}';
-{%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- if not skipExpectedVariable %}
-            const expectedHeaderRequestParams = Object.entries(expectedHeaderRequestParamsObj).map(([key, value]) => `${key}=${value}`).join('&');
+            const expectedHeaderRequestParams = '{{ param.fieldSend }}={{ parameterValue }}';
 {%- endif %}
 {%- endif %}
 {%- endmacro -%}
 
-{%- macro initRequestOptions(method) -%}
+{%- macro verifyHeaderRequestParams(method) -%}
 {%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-            const expectedOptions = {
-                otherArgs: {
-                    headers: {
-                        'x-goog-request-params': expectedHeaderRequestParams,
-                    },
-                },
-            };
-{%- else %}
-            const expectedOptions = {otherArgs: {headers: {}}};;
+            const actualRequest = (client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
+                .getCall(0).args[0];
+            assert.deepStrictEqual(actualRequest, request);
+            const actualHeaderRequestParams = (client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
+                .getCall(0).args[1].otherArgs.headers['x-goog-request-params'];
+            assert(actualHeaderRequestParams.includes(expectedHeaderRequestParams));
 {%- endif %}
 {%- endmacro -%}
 
-{%- macro initResponse(method) -%}
-            const expectedResponse = generateSampleMessage(new protos{{ method.outputInterface }}());
+{%- macro initResponse(method) %}
+            const expectedResponse = generateSampleMessage(
+              new protos{{ method.outputInterface }}()
+            );
 {%- endmacro -%}
 
 {%- macro initPagingResponse(method) -%}

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -54,6 +54,7 @@ import {protobuf
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
 {%- endif %}
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTypeDefaultValue(typeName: string, fields: string[]) {
 {%- if not api.legacyProtoLoad %}
     let type = root.lookupType(typeName) as protobuf.Type;
@@ -303,7 +304,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
@@ -315,8 +315,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- else %}
             assert.deepStrictEqual(response, expectedResponse);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
@@ -328,7 +327,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -347,8 +345,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with error', async () => {
@@ -359,16 +356,14 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with closed client', async () => {
@@ -399,7 +394,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(expectedResponse);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
@@ -408,8 +402,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
@@ -419,7 +412,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -441,8 +433,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with call error', async () => {
@@ -451,16 +442,14 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with LRO error', async () => {
@@ -469,8 +458,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubLongRunningCall(undefined, undefined, expectedError);
             const [operation] = await client.{{ method.name.toCamelCase() }}(request);
@@ -478,8 +466,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ id.get("check" + method.name.toPascalCase() + "Progress") }} without error', async () => {
@@ -488,7 +475,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            const expectedResponse = generateSampleMessage(new operationsProtos.google.longrunning.Operation());
+            const expectedResponse = generateSampleMessage(
+              new operationsProtos.google.longrunning.Operation()
+            );
             expectedResponse.name = 'test';
             expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
             expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')}
@@ -531,7 +520,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(expectedResponse);
             const stream = client.{{ method.name.toCamelCase() }}(request);
@@ -548,8 +536,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with error', async () => {
@@ -558,8 +545,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubServerStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}(request);
@@ -575,8 +561,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with closed client', async () => {
@@ -613,7 +598,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
+            const request = generateSampleMessage(
+              new protos{{ method.inputInterface }}()
+            );
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubBidiStreamingCall(expectedResponse);
             const stream = client.{{ method.name.toCamelCase() }}();
@@ -644,7 +631,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
+            const request = generateSampleMessage(
+              new protos{{ method.inputInterface }}()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubBidiStreamingCall(undefined, expectedError);
             const stream = client.{{ method.name.toCamelCase() }}();
@@ -678,7 +667,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
+            const request = generateSampleMessage(
+              new protos{{ method.inputInterface }}()
+            );
             {{ util.initResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubClientStreamingCall(expectedResponse);
             let stream: PassThrough;
@@ -710,7 +701,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            const request = generateSampleMessage(new protos{{ method.inputInterface }}());
+            const request = generateSampleMessage(
+              new protos{{ method.inputInterface }}()
+            );
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubClientStreamingCall(undefined, expectedError);
             let stream: PassThrough;
@@ -749,7 +742,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(expectedResponse);
             const [response] = await client.{{ method.name.toCamelCase() }}(request);
@@ -757,8 +749,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} without error using callback', async () => {
@@ -771,7 +762,6 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
             {{ util.initPagingResponse(method) }}
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCallWithCallback(expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -790,8 +780,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert(stub.calledOnce);
             {%- endif %}
             assert.deepStrictEqual(response, expectedResponse);
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions /*, callback defined above */));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ method.name.toCamelCase() }} with error', async () => {
@@ -803,16 +792,14 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
-            {{ util.initRequestOptions(method) }}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.innerApiCalls.{{ method.name.toCamelCase(true) }} = stubSimpleCall(undefined, expectedError);
             await assert.rejects(client.{{ method.name.toCamelCase() }}(request), expectedError);
             {%- if method.options and method.options.deprecated %}
             assert(stub.calledOnce);
             {%- endif %}
-            assert((client.innerApiCalls.{{ method.name.toCamelCase(true) }} as SinonStub)
-                .getCall(0).calledWith(request, expectedOptions, undefined));
+            {{- util.verifyHeaderRequestParams(method) }}
         });
 
         it('invokes {{ id.get(method.name.toCamelCase() + "Stream") }} without error', async () => {
@@ -848,10 +835,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase(true) }}, request));
 {%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
 {%- endif %}
         });
@@ -888,10 +876,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert((client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
                 .getCall(0).calledWith(client.innerApiCalls.{{ method.name.toCamelCase(true) }}, request));
 {%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.createStream as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                         expectedHeaderRequestParams
+                    ) 
             );
 {%- endif %}
         });
@@ -927,10 +916,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
 {%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
 {%- endif %}
         });
@@ -944,7 +934,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             client.{{ id.get("initialize") }}();
-            {{ util.initRequestWithHeaderParam(method) -}}
+            {{ util.initRequestWithHeaderParam(method) }}
             const expectedError = new Error('expected');
             client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate = stubAsyncIterationCall(undefined, expectedError);
             const iterable = client.{{ id.get(method.name.toCamelCase() + "Async") }}(request);
@@ -965,10 +955,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
 {%- if method.headerRequestParams.length > 0 or method.dynamicRoutingRequestParams.length > 0 %}
-            assert.strictEqual(
+            assert(
                 (client.descriptors.page.{{ method.name.toCamelCase() }}.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
 {%- endif %}
         });
@@ -988,7 +979,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
+              new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1001,9 +992,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             };
             const expectedResponse = generateSampleMessage(
 {%- if method === 'testIamPermissions' %}
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
 {%- else %}
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
 {%- endif %}
             );
             client.iamClient.{{ method }} = stubSimpleCall(expectedResponse);
@@ -1022,7 +1013,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
+              new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1035,9 +1026,9 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             };
             const expectedResponse = generateSampleMessage(
 {%- if method === 'testIamPermissions' %}
-                new IamProtos.google.iam.v1.TestIamPermissionsResponse()
+              new IamProtos.google.iam.v1.TestIamPermissionsResponse()
 {%- else %}
-                new IamProtos.google.iam.v1.Policy()
+              new IamProtos.google.iam.v1.Policy()
 {%- endif %}
             );
             client.iamClient.{{ method }} = sinon.stub().callsArgWith(2, null, expectedResponse);
@@ -1072,7 +1063,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
+              new IamProtos.google.iam.v1.{{ method.toPascalCase() }}Request()
             );
             request.resource = '';
             const expectedHeaderRequestParams = 'resource=';
@@ -1107,7 +1098,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
+              new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1119,7 +1110,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.{{ method }} = stubSimpleCall(expectedResponse);
             const response = await client.{{ method }}(request, expectedOptions);
@@ -1137,7 +1128,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
+              new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1149,7 +1140,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
                 },
             };
             const expectedResponse = generateSampleMessage(
-                new LocationProtos.google.cloud.location.Location()
+              new LocationProtos.google.cloud.location.Location()
             );
             client.locationsClient.{{ method }} = sinon.stub().callsArgWith(2, null, expectedResponse);
             const promise = new Promise((resolve, reject) => {
@@ -1182,7 +1173,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
+              new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1240,10 +1231,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.{{ method }}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.{{ method }}.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
         it('uses async iteration with {{ method }} with error', async () => {
@@ -1256,7 +1248,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.initialize();
             const request = generateSampleMessage(
-                new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
+              new LocationProtos.google.cloud.location.{{ method.toPascalCase() }}Request()
             );
             request.name = '';
             const expectedHeaderRequestParams = 'name=';
@@ -1275,10 +1267,11 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             assert.deepStrictEqual(
                 (client.locationsClient.descriptors.page.{{method}}.asyncIterate as SinonStub)
                     .getCall(0).args[1], request);
-            assert.strictEqual(
+            assert(
                 (client.locationsClient.descriptors.page.{{method}}.asyncIterate as SinonStub)
-                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'],
-                expectedHeaderRequestParams
+                    .getCall(0).args[2].otherArgs.headers['x-goog-request-params'].includes(
+                        expectedHeaderRequestParams
+                    )
             );
         });
     });
@@ -1296,7 +1289,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.{{ id.get("initialize") }}();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
+              new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
             );
             const expectedResponse = generateSampleMessage(
             {%- if method === 'getOperation' %}
@@ -1321,7 +1314,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
+              new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
             );
             const expectedResponse = generateSampleMessage(
             {%- if method === 'getOperation' %}
@@ -1364,7 +1357,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
+              new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
             );
             const expectedError = new Error('expected');
             client.operationsClient.{{ method }} = stubSimpleCall(undefined, expectedError);
@@ -1385,7 +1378,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             const stub = sinon.stub(client, 'warn');
             {%- endif %}
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
+              new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
             );
             const expectedResponse = [
                 generateSampleMessage(
@@ -1422,7 +1415,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {%- endif %}
             client.initialize();
             const request = generateSampleMessage(
-                new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
+              new operationsProtos.google.longrunning.{{ method.toPascalCase() }}Request()
             );
             const expectedError = new Error('expected');
             client.operationsClient.descriptor.{{ method }}.asyncIterate = stubAsyncIterationCall(undefined, expectedError);

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -48,6 +48,18 @@ import {protobuf
 {%- if service.LocationMixin > 0 %}, LocationProtos{%- endif -%}
 } from 'google-gax';
 
+// Dynamically loaded proto JSON is needed to get the type information
+// to fill in default values for request objects
+const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+
+function getTypeDefaultValue(typeName: string, fields: string[]) {
+    let type = root.lookupType(typeName) as protobuf.Type;
+    for (const field of fields.slice(0, -1)) {
+        type = type.fields[field]?.resolvedType as protobuf.Type;
+    }
+    return type.fields[fields[fields.length - 1]]?.defaultValue;
+}
+
 function generateSampleMessage<T extends object>(instance: T) {
     const filledObject = (instance.constructor as typeof protobuf.Message)
         .toObject(instance as protobuf.Message<T>, {defaults: true});

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -47,17 +47,31 @@ import {protobuf
 {%- if service.IAMPolicyMixin > 0 %}, IamProtos{%- endif -%}
 {%- if service.LocationMixin > 0 %}, LocationProtos{%- endif -%}
 } from 'google-gax';
+{%- if not api.legacyProtoLoad %}
 
 // Dynamically loaded proto JSON is needed to get the type information
 // to fill in default values for request objects
 const root = protobuf.Root.fromJSON(require('../protos/protos.json')).resolveAll();
+{%- endif %}
 
 function getTypeDefaultValue(typeName: string, fields: string[]) {
+{%- if not api.legacyProtoLoad %}
     let type = root.lookupType(typeName) as protobuf.Type;
     for (const field of fields.slice(0, -1)) {
         type = type.fields[field]?.resolvedType as protobuf.Type;
     }
     return type.fields[fields[fields.length - 1]]?.defaultValue;
+{%- else %}
+    // non-string x-goog-request-param values are not supported;
+    // we always assume that it's a string.
+    return '';
+{#- should this need to change, one would need to create an instance of
+   protobuf.js Root and call loadSync, setting a custom resolver as in
+   https://github.com/grpc/grpc-node/blob/1a3600e2ec6e3aae77e5e13e7c93efba0bba8d8c/packages/proto-loader/src/util.ts#L67-L82
+   At this moment, we don't need it since we don't have any non-string
+   fields in x-goog-request-params header for APIs that use legacy proto load.
+#}
+{%- endif %}
 }
 
 function generateSampleMessage<T extends object>(instance: T) {


### PR DESCRIPTION
Note that this PR is against `update-showcase-baseline` branch, which, when merged, will make it green since the updated Showcase Compliance will now produce a valid library.

The three changes in this PR across all the baseline tests are:

1. In the generated client, in the place where we build `x-goog-request-params` header, use `??` instead of `||`. The difference is small: if a value is `0`, it's still _defined_, so should not be overridden by `''`. It suddenly becomes important when `x-goog-request-params` contains values that are not strings.

2. In tests, again, because some values to be placed in `x-goog-request-params` are not strings in `compliance.proto`, the whole idea of type-appropriate default value (to fill the fake request) appears, using some `protobuf.js` reflection type magic.

3. The new `echo.proto` shows how complicated the routing header settings could be, so I needed to simplify the generated unit tests to make it still check the logic but not becoming the change detector test.