### PR TITLE
fix: minify proto JSONs in the build folder of the generated library

### DIFF
--- a/baselines/asset/package.json
+++ b/baselines/asset/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/bigquery-storage/package.json
+++ b/baselines/bigquery-storage/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/compute/package.json
+++ b/baselines/compute/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/deprecatedtest/package.json
+++ b/baselines/deprecatedtest/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/disable-packing-test/package.json
+++ b/baselines/disable-packing-test/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/dlp/package.json
+++ b/baselines/dlp/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/kms/package.json
+++ b/baselines/kms/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/logging/package.json
+++ b/baselines/logging/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/monitoring/package.json
+++ b/baselines/monitoring/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/naming/package.json
+++ b/baselines/naming/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/redis/package.json
+++ b/baselines/redis/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/routingtest/package.json
+++ b/baselines/routingtest/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/showcase/package.json
+++ b/baselines/showcase/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/tasks/package.json
+++ b/baselines/tasks/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/texttospeech/package.json
+++ b/baselines/texttospeech/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/translate/package.json
+++ b/baselines/translate/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/baselines/videointelligence/package.json
+++ b/baselines/videointelligence/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/ && minifyProtoJson",
     "compile-protos": "compileProtos src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",

--- a/templates/typescript_gapic/package.json
+++ b/templates/typescript_gapic/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r protos build/",
+    "compile": "tsc -p . && cp -r protos build/{% if not api.legacyProtoLoad %} && minifyProtoJson{% endif %}",
     "compile-protos": "compileProtos {% if api.legacyProtoLoad %}--skip-json {% endif %}src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",


### PR DESCRIPTION
Add a call to `minifyProtoJson` to the `compile` script of the generated libraries to minify the `protos.json` in the `build/protos` folder (which is the default folder for `minifyProtoJson`).

This will only affect the new libraries, since we never regenerate `package.json` for already published libraries. For existing libraries, I'll make this change manually across the repositories.

`minifyProtoJson` source is [here](https://github.com/googleapis/gax-nodejs/blob/main/tools/minify.ts) in `google-gax`, exported [here](https://github.com/googleapis/gax-nodejs/blob/fc7e03f7a3d3f805d0e9b132c1b34b814d3ac598/package.json#L15).