### PR TITLE
fix: use fully qualified request type name in tests

### DIFF
--- a/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -175,7 +175,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -202,7 +202,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -240,7 +240,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -264,7 +264,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.BatchGetAssetsHistoryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchGetAssetsHistoryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.BatchGetAssetsHistoryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -283,7 +283,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.CreateFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -310,7 +310,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.CreateFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -348,7 +348,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.CreateFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -372,7 +372,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.CreateFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateFeedRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.CreateFeedRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -391,7 +391,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.GetFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -418,7 +418,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.GetFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -456,7 +456,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.GetFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -480,7 +480,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.GetFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.GetFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -499,7 +499,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ListFeedsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -526,7 +526,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ListFeedsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -564,7 +564,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ListFeedsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -588,7 +588,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ListFeedsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListFeedsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ListFeedsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -608,7 +608,7 @@ describe('v1.AssetServiceClient', () => {
             );
             request.feed ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -636,7 +636,7 @@ describe('v1.AssetServiceClient', () => {
             );
             request.feed ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -675,7 +675,7 @@ describe('v1.AssetServiceClient', () => {
             );
             request.feed ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedHeaderRequestParams = `feed.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -700,7 +700,7 @@ describe('v1.AssetServiceClient', () => {
             );
             request.feed ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateFeedRequest', ['feed', 'name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.UpdateFeedRequest', ['feed', 'name']);
             request.feed.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -719,7 +719,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.DeleteFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -746,7 +746,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.DeleteFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -784,7 +784,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.DeleteFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -808,7 +808,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.DeleteFeedRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteFeedRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.asset.v1.DeleteFeedRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -827,7 +827,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ExportAssetsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -855,7 +855,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ExportAssetsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -896,7 +896,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ExportAssetsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -920,7 +920,7 @@ describe('v1.AssetServiceClient', () => {
               new protos.google.cloud.asset.v1.ExportAssetsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportAssetsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.asset.v1.ExportAssetsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -174,11 +174,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.tableReference ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'projectId']);
             request.tableReference.projectId = defaultValue1;
             request.tableReference ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -206,11 +206,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.tableReference ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'projectId']);
             request.tableReference.projectId = defaultValue1;
             request.tableReference ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -249,11 +249,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.tableReference ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'projectId']);
             request.tableReference.projectId = defaultValue1;
             request.tableReference ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedHeaderRequestParams = `table_reference.project_id=${defaultValue1}&table_reference.dataset_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -278,11 +278,11 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.tableReference ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'projectId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'projectId']);
             request.tableReference.projectId = defaultValue1;
             request.tableReference ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('CreateReadSessionRequest', ['tableReference', 'datasetId']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.CreateReadSessionRequest', ['tableReference', 'datasetId']);
             request.tableReference.datasetId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -302,7 +302,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.session ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -330,7 +330,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.session ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -369,7 +369,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.session ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedHeaderRequestParams = `session.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -394,7 +394,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.session ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('BatchCreateReadSessionStreamsRequest', ['session', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsRequest', ['session', 'name']);
             request.session.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -414,7 +414,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -442,7 +442,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -481,7 +481,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `stream.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -506,7 +506,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('FinalizeStreamRequest', ['stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.FinalizeStreamRequest', ['stream', 'name']);
             request.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -526,7 +526,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.originalStream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -554,7 +554,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.originalStream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -593,7 +593,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.originalStream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedHeaderRequestParams = `original_stream.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -618,7 +618,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             );
             request.originalStream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('SplitReadStreamRequest', ['originalStream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.SplitReadStreamRequest', ['originalStream', 'name']);
             request.originalStream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -639,7 +639,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest', ['readPosition', 'stream', 'name']);
             request.readPosition.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -677,7 +677,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest', ['readPosition', 'stream', 'name']);
             request.readPosition.stream.name = defaultValue1;
             const expectedHeaderRequestParams = `read_position.stream.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -712,7 +712,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition ??= {};
             request.readPosition.stream ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('ReadRowsRequest', ['readPosition', 'stream', 'name']);
+              getTypeDefaultValue('.google.cloud.bigquery.storage.v1beta1.ReadRowsRequest', ['readPosition', 'stream', 'name']);
             request.readPosition.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -217,13 +217,13 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.DeleteAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -250,13 +250,13 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.DeleteAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -294,13 +294,13 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.DeleteAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&address=${defaultValue3}`;
             const expectedError = new Error('expected');
@@ -324,13 +324,13 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.DeleteAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeleteAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('DeleteAddressRequest', ['address']);
+              getTypeDefaultValue('.google.cloud.compute.v1.DeleteAddressRequest', ['address']);
             request.address = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -349,10 +349,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.InsertAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InsertAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InsertAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -379,10 +379,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.InsertAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InsertAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InsertAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -420,10 +420,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.InsertAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InsertAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InsertAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -447,10 +447,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.InsertAddressRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InsertAddressRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InsertAddressRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.InsertAddressRequest', ['region']);
             request.region = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -470,7 +470,7 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.AggregatedListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.AggregatedListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const expectedHeaderRequestParams = `project=${defaultValue1}`;
             const expectedResponse = [
@@ -506,7 +506,7 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.AggregatedListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AggregatedListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.AggregatedListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const expectedHeaderRequestParams = `project=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -541,10 +541,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -572,10 +572,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.compute.v1.Address()),
@@ -614,10 +614,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -641,10 +641,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = [
@@ -688,10 +688,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -730,10 +730,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedResponse = [
@@ -769,10 +769,10 @@ describe('v1.AddressesClient', () => {
               new protos.google.cloud.compute.v1.ListAddressesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAddressesRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListAddressesRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.ListAddressesRequest', ['region']);
             request.region = defaultValue2;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}`;
             const expectedError = new Error('expected');

--- a/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -170,13 +170,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.GetRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -203,13 +203,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.GetRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -247,13 +247,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.GetRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedError = new Error('expected');
@@ -277,13 +277,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.GetRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('GetRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.GetRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -302,13 +302,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -335,13 +335,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -379,13 +379,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedHeaderRequestParams = `project=${defaultValue1}&region=${defaultValue2}&operation=${defaultValue3}`;
             const expectedError = new Error('expected');
@@ -409,13 +409,13 @@ describe('v1.RegionOperationsClient', () => {
               new protos.google.cloud.compute.v1.WaitRegionOperationRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['project']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['project']);
             request.project = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['region']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['region']);
             request.region = defaultValue2;
             const defaultValue3 =
-              getTypeDefaultValue('WaitRegionOperationRequest', ['operation']);
+              getTypeDefaultValue('.google.cloud.compute.v1.WaitRegionOperationRequest', ['operation']);
             request.operation = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -385,23 +385,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedResponse = generateSampleMessage(
@@ -429,23 +429,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedResponse = generateSampleMessage(
@@ -484,23 +484,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedError = new Error('expected');
@@ -525,23 +525,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -561,16 +561,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -598,16 +598,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -646,16 +646,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedError = new Error('expected');
@@ -680,16 +680,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -709,12 +709,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -742,12 +742,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -786,12 +786,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -816,12 +816,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -281,7 +281,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -308,7 +308,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -346,7 +346,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -370,7 +370,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -390,7 +390,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -418,7 +418,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -457,7 +457,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -482,7 +482,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -501,7 +501,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -528,7 +528,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -566,7 +566,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -590,7 +590,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -330,7 +330,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -357,7 +357,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -395,7 +395,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -419,7 +419,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -439,7 +439,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -467,7 +467,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -506,7 +506,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -531,7 +531,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -550,7 +550,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -577,7 +577,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -615,7 +615,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -639,7 +639,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -658,7 +658,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -685,7 +685,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -723,7 +723,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -747,7 +747,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -766,7 +766,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -793,7 +793,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -831,7 +831,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -855,7 +855,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -875,7 +875,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -903,7 +903,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -942,7 +942,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -967,7 +967,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -986,7 +986,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1013,7 +1013,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1051,7 +1051,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1075,7 +1075,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1094,7 +1094,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1122,7 +1122,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1163,7 +1163,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1187,7 +1187,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1248,7 +1248,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1284,7 +1284,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1317,7 +1317,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1649,7 +1649,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1677,7 +1677,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1716,7 +1716,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1740,7 +1740,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1784,7 +1784,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1823,7 +1823,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1859,7 +1859,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -234,7 +234,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -261,7 +261,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -299,7 +299,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -323,7 +323,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -342,7 +342,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -369,7 +369,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -407,7 +407,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -431,7 +431,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -281,7 +281,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -308,7 +308,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -346,7 +346,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -370,7 +370,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -389,7 +389,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -416,7 +416,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -454,7 +454,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -478,7 +478,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -497,7 +497,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -524,7 +524,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -562,7 +562,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -586,7 +586,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -605,7 +605,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -632,7 +632,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -670,7 +670,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -694,7 +694,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -713,7 +713,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -740,7 +740,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -778,7 +778,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -802,7 +802,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -996,7 +996,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1024,7 +1024,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1063,7 +1063,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1087,7 +1087,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1131,7 +1131,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1170,7 +1170,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1206,7 +1206,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -206,10 +206,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.InspectContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InspectContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -236,10 +236,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.InspectContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InspectContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -277,10 +277,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.InspectContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InspectContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -304,10 +304,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.InspectContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('InspectContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('InspectContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.InspectContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -326,10 +326,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.RedactImageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RedactImageRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -356,10 +356,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.RedactImageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RedactImageRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -397,10 +397,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.RedactImageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RedactImageRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -424,10 +424,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.RedactImageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RedactImageRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('RedactImageRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.RedactImageRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -446,10 +446,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -476,10 +476,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -517,10 +517,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -544,10 +544,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('DeidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -566,10 +566,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -596,10 +596,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -637,10 +637,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -664,10 +664,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ReidentifyContentRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ReidentifyContentRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ReidentifyContentRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -686,7 +686,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -713,7 +713,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -751,7 +751,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedHeaderRequestParams = `location_id=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -775,7 +775,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -794,10 +794,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -824,10 +824,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -865,10 +865,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -892,10 +892,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateInspectTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateInspectTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -914,7 +914,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -941,7 +941,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -979,7 +979,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1003,7 +1003,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1022,7 +1022,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1049,7 +1049,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1087,7 +1087,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1111,7 +1111,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1130,7 +1130,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1157,7 +1157,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1195,7 +1195,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1219,7 +1219,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteInspectTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInspectTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteInspectTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1238,10 +1238,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -1268,10 +1268,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -1309,10 +1309,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -1336,10 +1336,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDeidentifyTemplateRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1358,7 +1358,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1385,7 +1385,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1423,7 +1423,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1447,7 +1447,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1466,7 +1466,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1493,7 +1493,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1531,7 +1531,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1555,7 +1555,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1574,7 +1574,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1601,7 +1601,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1639,7 +1639,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1663,7 +1663,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDeidentifyTemplateRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1682,10 +1682,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -1712,10 +1712,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -1753,10 +1753,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -1780,10 +1780,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateJobTriggerRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateJobTriggerRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1802,7 +1802,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1829,7 +1829,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1867,7 +1867,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1891,7 +1891,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1910,7 +1910,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1937,7 +1937,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1975,7 +1975,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1999,7 +1999,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2018,7 +2018,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2045,7 +2045,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2083,7 +2083,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2107,7 +2107,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2126,7 +2126,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2153,7 +2153,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2191,7 +2191,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2215,7 +2215,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ActivateJobTriggerRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ActivateJobTriggerRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ActivateJobTriggerRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2234,10 +2234,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -2264,10 +2264,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -2305,10 +2305,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -2332,10 +2332,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateDlpJobRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateDlpJobRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2354,7 +2354,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2381,7 +2381,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2419,7 +2419,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2443,7 +2443,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2462,7 +2462,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2489,7 +2489,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2527,7 +2527,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2551,7 +2551,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2570,7 +2570,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2597,7 +2597,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2635,7 +2635,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2659,7 +2659,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CancelDlpJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CancelDlpJobRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CancelDlpJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2678,10 +2678,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -2708,10 +2708,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -2749,10 +2749,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -2776,10 +2776,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.CreateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('CreateStoredInfoTypeRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.CreateStoredInfoTypeRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2798,7 +2798,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2825,7 +2825,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2863,7 +2863,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2887,7 +2887,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.UpdateStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2906,7 +2906,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2933,7 +2933,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2971,7 +2971,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2995,7 +2995,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.GetStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.GetStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -3014,7 +3014,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -3041,7 +3041,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -3079,7 +3079,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3103,7 +3103,7 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteStoredInfoTypeRequest', ['name']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.DeleteStoredInfoTypeRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -3122,10 +3122,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -3153,10 +3153,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.InspectTemplate()),
@@ -3195,10 +3195,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3222,10 +3222,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3269,10 +3269,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3311,10 +3311,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3350,10 +3350,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListInspectTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListInspectTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListInspectTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3388,10 +3388,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3419,10 +3419,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DeidentifyTemplate()),
@@ -3461,10 +3461,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3488,10 +3488,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3535,10 +3535,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3577,10 +3577,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3616,10 +3616,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDeidentifyTemplatesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDeidentifyTemplatesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3654,10 +3654,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3685,10 +3685,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.JobTrigger()),
@@ -3727,10 +3727,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3754,10 +3754,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3801,10 +3801,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3843,10 +3843,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -3882,10 +3882,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListJobTriggersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListJobTriggersRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListJobTriggersRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -3920,10 +3920,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3951,10 +3951,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.DlpJob()),
@@ -3993,10 +3993,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -4020,10 +4020,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -4067,10 +4067,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -4109,10 +4109,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -4148,10 +4148,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListDlpJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListDlpJobsRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListDlpJobsRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -4186,10 +4186,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -4217,10 +4217,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;const expectedResponse = [
               generateSampleMessage(new protos.google.privacy.dlp.v2.StoredInfoType()),
@@ -4259,10 +4259,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -4286,10 +4286,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -4333,10 +4333,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -4375,10 +4375,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedResponse = [
@@ -4414,10 +4414,10 @@ describe('v2.DlpServiceClient', () => {
               new protos.google.privacy.dlp.v2.ListStoredInfoTypesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['parent']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['parent']);
             request.parent = defaultValue1;
             const defaultValue2 =
-              getTypeDefaultValue('ListStoredInfoTypesRequest', ['locationId']);
+              getTypeDefaultValue('.google.privacy.dlp.v2.ListStoredInfoTypesRequest', ['locationId']);
             request.locationId = defaultValue2;
             const expectedHeaderRequestParams = `parent=${defaultValue1}&location_id=${defaultValue2}`;
             const expectedError = new Error('expected');

--- a/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -206,7 +206,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetKeyRingRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetKeyRingRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -422,7 +422,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -449,7 +449,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -487,7 +487,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -511,7 +511,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -530,7 +530,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetPublicKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -557,7 +557,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetPublicKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -595,7 +595,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetPublicKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -619,7 +619,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetPublicKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetPublicKeyRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetPublicKeyRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -638,7 +638,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetImportJobRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -665,7 +665,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetImportJobRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -703,7 +703,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetImportJobRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -727,7 +727,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.GetImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetImportJobRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.GetImportJobRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -746,7 +746,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -773,7 +773,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -811,7 +811,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -835,7 +835,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateKeyRingRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateKeyRingRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateKeyRingRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -854,7 +854,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -881,7 +881,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -919,7 +919,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -943,7 +943,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -962,7 +962,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -989,7 +989,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1027,7 +1027,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1051,7 +1051,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1070,7 +1070,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1097,7 +1097,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1135,7 +1135,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1159,7 +1159,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ImportCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportCryptoKeyVersionRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ImportCryptoKeyVersionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1178,7 +1178,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1205,7 +1205,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1243,7 +1243,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1267,7 +1267,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.CreateImportJobRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateImportJobRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.CreateImportJobRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1287,7 +1287,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKey ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1315,7 +1315,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKey ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1354,7 +1354,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKey ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1379,7 +1379,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKey ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyRequest', ['cryptoKey', 'name']);
             request.cryptoKey.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1399,7 +1399,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1427,7 +1427,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1466,7 +1466,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedHeaderRequestParams = `crypto_key_version.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1491,7 +1491,7 @@ describe('v1.KeyManagementServiceClient', () => {
             );
             request.cryptoKeyVersion ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyVersionRequest', ['cryptoKeyVersion', 'name']);
             request.cryptoKeyVersion.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1510,7 +1510,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.EncryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('EncryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1537,7 +1537,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.EncryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('EncryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1575,7 +1575,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.EncryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('EncryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1599,7 +1599,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.EncryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('EncryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.EncryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1618,7 +1618,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1645,7 +1645,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1683,7 +1683,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1707,7 +1707,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1726,7 +1726,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricSignRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1753,7 +1753,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricSignRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1791,7 +1791,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricSignRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1815,7 +1815,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricSignRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricSignRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricSignRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1834,7 +1834,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1861,7 +1861,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1899,7 +1899,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1923,7 +1923,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.AsymmetricDecryptRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AsymmetricDecryptRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.AsymmetricDecryptRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1942,7 +1942,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1969,7 +1969,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2007,7 +2007,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2031,7 +2031,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCryptoKeyPrimaryVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.UpdateCryptoKeyPrimaryVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2050,7 +2050,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2077,7 +2077,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2115,7 +2115,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2139,7 +2139,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DestroyCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.DestroyCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2158,7 +2158,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2185,7 +2185,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2223,7 +2223,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2247,7 +2247,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RestoreCryptoKeyVersionRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.kms.v1.RestoreCryptoKeyVersionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2266,7 +2266,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2294,7 +2294,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.KeyRing()),
@@ -2333,7 +2333,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2357,7 +2357,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2401,7 +2401,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2440,7 +2440,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2476,7 +2476,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListKeyRingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListKeyRingsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListKeyRingsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2511,7 +2511,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2539,7 +2539,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKey()),
@@ -2578,7 +2578,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2602,7 +2602,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2646,7 +2646,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2685,7 +2685,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2721,7 +2721,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeysRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeysRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeysRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2756,7 +2756,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2784,7 +2784,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.CryptoKeyVersion()),
@@ -2823,7 +2823,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2847,7 +2847,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2891,7 +2891,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2930,7 +2930,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2966,7 +2966,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListCryptoKeyVersionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListCryptoKeyVersionsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListCryptoKeyVersionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3001,7 +3001,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -3029,7 +3029,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.kms.v1.ImportJob()),
@@ -3068,7 +3068,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3092,7 +3092,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3136,7 +3136,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3175,7 +3175,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3211,7 +3211,7 @@ describe('v1.KeyManagementServiceClient', () => {
               new protos.google.cloud.kms.v1.ListImportJobsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListImportJobsRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.kms.v1.ListImportJobsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -222,7 +222,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -249,7 +249,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -287,7 +287,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -311,7 +311,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -330,7 +330,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -357,7 +357,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -395,7 +395,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -419,7 +419,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBucketRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateBucketRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -438,7 +438,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -465,7 +465,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -503,7 +503,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -527,7 +527,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -546,7 +546,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -573,7 +573,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -611,7 +611,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -635,7 +635,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -654,7 +654,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UndeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -681,7 +681,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UndeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -719,7 +719,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UndeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -743,7 +743,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UndeleteBucketRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UndeleteBucketRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UndeleteBucketRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -762,7 +762,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -789,7 +789,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -827,7 +827,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -851,7 +851,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -870,7 +870,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateViewRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -897,7 +897,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateViewRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -935,7 +935,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateViewRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -959,7 +959,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateViewRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateViewRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -978,7 +978,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1005,7 +1005,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1043,7 +1043,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1067,7 +1067,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1086,7 +1086,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1113,7 +1113,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1151,7 +1151,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1175,7 +1175,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteViewRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteViewRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteViewRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1194,7 +1194,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1221,7 +1221,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1259,7 +1259,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1283,7 +1283,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.GetSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1302,7 +1302,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1329,7 +1329,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1367,7 +1367,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1391,7 +1391,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateSinkRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateSinkRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1410,7 +1410,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1437,7 +1437,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1475,7 +1475,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1499,7 +1499,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1518,7 +1518,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1545,7 +1545,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1583,7 +1583,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedHeaderRequestParams = `sink_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1607,7 +1607,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteSinkRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSinkRequest', ['sinkName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteSinkRequest', ['sinkName']);
             request.sinkName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1626,7 +1626,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1653,7 +1653,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1691,7 +1691,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1715,7 +1715,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1734,7 +1734,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1761,7 +1761,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1799,7 +1799,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1823,7 +1823,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.CreateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateExclusionRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateExclusionRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1842,7 +1842,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1869,7 +1869,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1907,7 +1907,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1931,7 +1931,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1950,7 +1950,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1977,7 +1977,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2015,7 +2015,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2039,7 +2039,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.DeleteExclusionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteExclusionRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.DeleteExclusionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2058,7 +2058,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2085,7 +2085,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2123,7 +2123,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2147,7 +2147,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2166,7 +2166,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2193,7 +2193,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2231,7 +2231,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2255,7 +2255,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateCmekSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateCmekSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateCmekSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2274,7 +2274,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2301,7 +2301,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2339,7 +2339,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2363,7 +2363,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.GetSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.GetSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2382,7 +2382,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2409,7 +2409,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -2447,7 +2447,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2471,7 +2471,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.UpdateSettingsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateSettingsRequest', ['name']);
+              getTypeDefaultValue('.google.logging.v2.UpdateSettingsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -2604,7 +2604,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2632,7 +2632,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogBucket()),
@@ -2671,7 +2671,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2695,7 +2695,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2739,7 +2739,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2778,7 +2778,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2814,7 +2814,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListBucketsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBucketsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListBucketsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2849,7 +2849,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2877,7 +2877,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogView()),
@@ -2916,7 +2916,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2940,7 +2940,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2984,7 +2984,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3023,7 +3023,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3059,7 +3059,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListViewsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListViewsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListViewsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3094,7 +3094,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -3122,7 +3122,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogSink()),
@@ -3161,7 +3161,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3185,7 +3185,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3229,7 +3229,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3268,7 +3268,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3304,7 +3304,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListSinksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListSinksRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListSinksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3339,7 +3339,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3367,7 +3367,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogExclusion()),
@@ -3406,7 +3406,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3430,7 +3430,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3474,7 +3474,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -3513,7 +3513,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -3549,7 +3549,7 @@ describe('v2.ConfigServiceV2Client', () => {
               new protos.google.logging.v2.ListExclusionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListExclusionsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListExclusionsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -215,7 +215,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -242,7 +242,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -280,7 +280,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedHeaderRequestParams = `log_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -304,7 +304,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogRequest', ['logName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogRequest', ['logName']);
             request.logName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -812,7 +812,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCall(expectedResponse);
@@ -836,7 +836,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [new String(), new String(), new String()];
             client.innerApiCalls.listLogs = stubSimpleCallWithCallback(expectedResponse);
@@ -871,7 +871,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -895,7 +895,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [new String(), new String(), new String()];
@@ -935,7 +935,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -974,7 +974,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [new String(), new String(), new String()];
@@ -1006,7 +1006,7 @@ describe('v2.LoggingServiceV2Client', () => {
               new protos.google.logging.v2.ListLogsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -206,7 +206,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.GetLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.GetLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.GetLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.GetLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.GetLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.CreateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.CreateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.CreateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.CreateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateLogMetricRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.CreateLogMetricRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -422,7 +422,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.UpdateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -449,7 +449,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.UpdateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -487,7 +487,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.UpdateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -511,7 +511,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.UpdateLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('UpdateLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.UpdateLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -530,7 +530,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -557,7 +557,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -595,7 +595,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedHeaderRequestParams = `metric_name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -619,7 +619,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.DeleteLogMetricRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteLogMetricRequest', ['metricName']);
+              getTypeDefaultValue('.google.logging.v2.DeleteLogMetricRequest', ['metricName']);
             request.metricName = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -638,7 +638,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -666,7 +666,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.logging.v2.LogMetric()),
@@ -705,7 +705,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -729,7 +729,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -773,7 +773,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -812,7 +812,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -848,7 +848,7 @@ describe('v2.MetricsServiceV2Client', () => {
               new protos.google.logging.v2.ListLogMetricsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListLogMetricsRequest', ['parent']);
+              getTypeDefaultValue('.google.logging.v2.ListLogMetricsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.GetAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.GetAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.GetAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.GetAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.CreateAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.CreateAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.CreateAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.CreateAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -422,7 +422,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -449,7 +449,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -487,7 +487,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -511,7 +511,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.DeleteAlertPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteAlertPolicyRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteAlertPolicyRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -531,7 +531,7 @@ describe('v3.AlertPolicyServiceClient', () => {
             );
             request.alertPolicy ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -559,7 +559,7 @@ describe('v3.AlertPolicyServiceClient', () => {
             );
             request.alertPolicy ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -598,7 +598,7 @@ describe('v3.AlertPolicyServiceClient', () => {
             );
             request.alertPolicy ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedHeaderRequestParams = `alert_policy.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v3.AlertPolicyServiceClient', () => {
             );
             request.alertPolicy ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateAlertPolicyRequest', ['alertPolicy', 'name']);
             request.alertPolicy.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -670,7 +670,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.AlertPolicy()),
@@ -709,7 +709,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -733,7 +733,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -777,7 +777,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -816,7 +816,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -852,7 +852,7 @@ describe('v3.AlertPolicyServiceClient', () => {
               new protos.google.monitoring.v3.ListAlertPoliciesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListAlertPoliciesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListAlertPoliciesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.GetGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.GetGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.GetGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.GetGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.CreateGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.CreateGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.CreateGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.CreateGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -423,7 +423,7 @@ describe('v3.GroupServiceClient', () => {
             );
             request.group ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -451,7 +451,7 @@ describe('v3.GroupServiceClient', () => {
             );
             request.group ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -490,7 +490,7 @@ describe('v3.GroupServiceClient', () => {
             );
             request.group ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedHeaderRequestParams = `group.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -515,7 +515,7 @@ describe('v3.GroupServiceClient', () => {
             );
             request.group ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateGroupRequest', ['group', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateGroupRequest', ['group', 'name']);
             request.group.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -534,7 +534,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.DeleteGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -561,7 +561,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.DeleteGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -599,7 +599,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.DeleteGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.DeleteGroupRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGroupRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteGroupRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -670,7 +670,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Group()),
@@ -709,7 +709,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -733,7 +733,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -777,7 +777,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -816,7 +816,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -852,7 +852,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -887,7 +887,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -915,7 +915,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResource()),
@@ -954,7 +954,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -978,7 +978,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1022,7 +1022,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1061,7 +1061,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1097,7 +1097,7 @@ describe('v3.GroupServiceClient', () => {
               new protos.google.monitoring.v3.ListGroupMembersRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGroupMembersRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListGroupMembersRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMonitoredResourceDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMonitoredResourceDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMonitoredResourceDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.GetMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -422,7 +422,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -449,7 +449,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -487,7 +487,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -511,7 +511,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -530,7 +530,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -557,7 +557,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -595,7 +595,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -619,7 +619,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.DeleteMetricDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteMetricDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteMetricDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -638,7 +638,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -665,7 +665,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -703,7 +703,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -727,7 +727,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.CreateTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -746,7 +746,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -774,7 +774,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MonitoredResourceDescriptor()),
@@ -813,7 +813,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -837,7 +837,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -881,7 +881,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -920,7 +920,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -956,7 +956,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMonitoredResourceDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMonitoredResourceDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -991,7 +991,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -1019,7 +1019,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.api.MetricDescriptor()),
@@ -1058,7 +1058,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1082,7 +1082,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1126,7 +1126,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1165,7 +1165,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1201,7 +1201,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListMetricDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListMetricDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListMetricDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1236,7 +1236,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1264,7 +1264,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.TimeSeries()),
@@ -1303,7 +1303,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1327,7 +1327,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1371,7 +1371,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1410,7 +1410,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1446,7 +1446,7 @@ describe('v3.MetricServiceClient', () => {
               new protos.google.monitoring.v3.ListTimeSeriesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTimeSeriesRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListTimeSeriesRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelDescriptorRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelDescriptorRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelDescriptorRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -422,7 +422,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.CreateNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -449,7 +449,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.CreateNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -487,7 +487,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.CreateNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -511,7 +511,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.CreateNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -531,7 +531,7 @@ describe('v3.NotificationChannelServiceClient', () => {
             );
             request.notificationChannel ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -559,7 +559,7 @@ describe('v3.NotificationChannelServiceClient', () => {
             );
             request.notificationChannel ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -598,7 +598,7 @@ describe('v3.NotificationChannelServiceClient', () => {
             );
             request.notificationChannel ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedHeaderRequestParams = `notification_channel.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v3.NotificationChannelServiceClient', () => {
             );
             request.notificationChannel ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateNotificationChannelRequest', ['notificationChannel', 'name']);
             request.notificationChannel.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -669,7 +669,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -707,7 +707,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -731,7 +731,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.DeleteNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -750,7 +750,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -777,7 +777,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -815,7 +815,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -839,7 +839,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SendNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.SendNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -858,7 +858,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -885,7 +885,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -923,7 +923,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -947,7 +947,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetNotificationChannelVerificationCodeRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetNotificationChannelVerificationCodeRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -966,7 +966,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -993,7 +993,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1031,7 +1031,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1055,7 +1055,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.VerifyNotificationChannelRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyNotificationChannelRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.VerifyNotificationChannelRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1074,7 +1074,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1102,7 +1102,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannelDescriptor()),
@@ -1141,7 +1141,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1165,7 +1165,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1209,7 +1209,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1248,7 +1248,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1284,7 +1284,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelDescriptorsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelDescriptorsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelDescriptorsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1319,7 +1319,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1347,7 +1347,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.NotificationChannel()),
@@ -1386,7 +1386,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1410,7 +1410,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1454,7 +1454,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1493,7 +1493,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = [
@@ -1529,7 +1529,7 @@ describe('v3.NotificationChannelServiceClient', () => {
               new protos.google.monitoring.v3.ListNotificationChannelsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListNotificationChannelsRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.ListNotificationChannelsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -423,7 +423,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.service ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -451,7 +451,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.service ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -490,7 +490,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.service ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedHeaderRequestParams = `service.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -515,7 +515,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.service ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceRequest', ['service', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceRequest', ['service', 'name']);
             request.service.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -534,7 +534,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -561,7 +561,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -599,7 +599,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -669,7 +669,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -707,7 +707,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -731,7 +731,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.CreateServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateServiceLevelObjectiveRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateServiceLevelObjectiveRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -750,7 +750,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -777,7 +777,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -815,7 +815,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -839,7 +839,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.GetServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -859,7 +859,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -887,7 +887,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -926,7 +926,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedHeaderRequestParams = `service_level_objective.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -951,7 +951,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
             );
             request.serviceLevelObjective ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateServiceLevelObjectiveRequest', ['serviceLevelObjective', 'name']);
             request.serviceLevelObjective.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -970,7 +970,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -997,7 +997,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1035,7 +1035,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1059,7 +1059,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.DeleteServiceLevelObjectiveRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteServiceLevelObjectiveRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteServiceLevelObjectiveRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1078,7 +1078,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1106,7 +1106,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.Service()),
@@ -1145,7 +1145,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1169,7 +1169,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1213,7 +1213,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1252,7 +1252,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1288,7 +1288,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServicesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServicesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServicesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1323,7 +1323,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1351,7 +1351,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.ServiceLevelObjective()),
@@ -1390,7 +1390,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1414,7 +1414,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1458,7 +1458,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1497,7 +1497,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1533,7 +1533,7 @@ describe('v3.ServiceMonitoringServiceClient', () => {
               new protos.google.monitoring.v3.ListServiceLevelObjectivesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListServiceLevelObjectivesRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListServiceLevelObjectivesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -206,7 +206,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.GetUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.GetUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.CreateUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateUptimeCheckConfigRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.CreateUptimeCheckConfigRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -423,7 +423,7 @@ describe('v3.UptimeCheckServiceClient', () => {
             );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -451,7 +451,7 @@ describe('v3.UptimeCheckServiceClient', () => {
             );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -490,7 +490,7 @@ describe('v3.UptimeCheckServiceClient', () => {
             );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedHeaderRequestParams = `uptime_check_config.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -515,7 +515,7 @@ describe('v3.UptimeCheckServiceClient', () => {
             );
             request.uptimeCheckConfig ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
+              getTypeDefaultValue('.google.monitoring.v3.UpdateUptimeCheckConfigRequest', ['uptimeCheckConfig', 'name']);
             request.uptimeCheckConfig.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -534,7 +534,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -561,7 +561,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -599,7 +599,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.DeleteUptimeCheckConfigRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUptimeCheckConfigRequest', ['name']);
+              getTypeDefaultValue('.google.monitoring.v3.DeleteUptimeCheckConfigRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -670,7 +670,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.monitoring.v3.UptimeCheckConfig()),
@@ -709,7 +709,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -733,7 +733,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -777,7 +777,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -816,7 +816,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -852,7 +852,7 @@ describe('v3.UptimeCheckServiceClient', () => {
               new protos.google.monitoring.v3.ListUptimeCheckConfigsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListUptimeCheckConfigsRequest', ['parent']);
+              getTypeDefaultValue('.google.monitoring.v3.ListUptimeCheckConfigsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -222,7 +222,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -249,7 +249,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -287,7 +287,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -311,7 +311,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.GetInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.GetInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -330,7 +330,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -358,7 +358,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -399,7 +399,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -423,7 +423,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.CreateInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateInstanceRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.CreateInstanceRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -485,7 +485,7 @@ describe('v1beta1.CloudRedisClient', () => {
             );
             request.instance ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -514,7 +514,7 @@ describe('v1beta1.CloudRedisClient', () => {
             );
             request.instance ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -556,7 +556,7 @@ describe('v1beta1.CloudRedisClient', () => {
             );
             request.instance ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -581,7 +581,7 @@ describe('v1beta1.CloudRedisClient', () => {
             );
             request.instance ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateInstanceRequest', ['instance', 'name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.UpdateInstanceRequest', ['instance', 'name']);
             request.instance.name = defaultValue1;
             const expectedHeaderRequestParams = `instance.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -642,7 +642,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -670,7 +670,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -711,7 +711,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -735,7 +735,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ImportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ImportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ImportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -796,7 +796,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -824,7 +824,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -865,7 +865,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -889,7 +889,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ExportInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ExportInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ExportInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -950,7 +950,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -978,7 +978,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1019,7 +1019,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1043,7 +1043,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.FailoverInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('FailoverInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.FailoverInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1104,7 +1104,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1132,7 +1132,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1173,7 +1173,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1197,7 +1197,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.DeleteInstanceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteInstanceRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.DeleteInstanceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1258,7 +1258,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1286,7 +1286,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.redis.v1beta1.Instance()),
@@ -1325,7 +1325,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1349,7 +1349,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1393,7 +1393,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1432,7 +1432,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1468,7 +1468,7 @@ describe('v1beta1.CloudRedisClient', () => {
               new protos.google.cloud.redis.v1beta1.ListInstancesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListInstancesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.redis.v1beta1.ListInstancesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -385,23 +385,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedResponse = generateSampleMessage(
@@ -429,23 +429,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedResponse = generateSampleMessage(
@@ -484,23 +484,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_int32=${defaultValue2}&info.f_double=${defaultValue3}&info.f_bool=${defaultValue4}&info.f_kingdom=${defaultValue5}`;
             const expectedError = new Error('expected');
@@ -525,23 +525,23 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fInt32']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fInt32']);
             request.info.fInt32 = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fDouble']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fDouble']);
             request.info.fDouble = defaultValue3;
             request.info ??= {};
             const defaultValue4 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue4;
             request.info ??= {};
             const defaultValue5 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fKingdom']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fKingdom']);
             request.info.fKingdom = defaultValue5;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -561,16 +561,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -598,16 +598,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedResponse = generateSampleMessage(
@@ -646,16 +646,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}&info.f_bool=${defaultValue3}`;
             const expectedError = new Error('expected');
@@ -680,16 +680,16 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             request.info ??= {};
             const defaultValue3 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fBool']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fBool']);
             request.info.fBool = defaultValue3;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -709,12 +709,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -742,12 +742,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedResponse = generateSampleMessage(
@@ -786,12 +786,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedHeaderRequestParams = `info.f_string=${defaultValue1}&info.f_child.f_string=${defaultValue2}`;
             const expectedError = new Error('expected');
@@ -816,12 +816,12 @@ describe('v1beta1.ComplianceClient', () => {
             );
             request.info ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fString']);
             request.info.fString = defaultValue1;
             request.info ??= {};
             request.info.fChild ??= {};
             const defaultValue2 =
-              getTypeDefaultValue('RepeatRequest', ['info', 'fChild', 'fString']);
+              getTypeDefaultValue('.google.showcase.v1beta1.RepeatRequest', ['info', 'fChild', 'fString']);
             request.info.fChild.fString = defaultValue2;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -281,7 +281,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -308,7 +308,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -346,7 +346,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -370,7 +370,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.GetUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -390,7 +390,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -418,7 +418,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -457,7 +457,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedHeaderRequestParams = `user.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -482,7 +482,7 @@ describe('v1beta1.IdentityClient', () => {
             );
             request.user ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateUserRequest', ['user', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateUserRequest', ['user', 'name']);
             request.user.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -501,7 +501,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -528,7 +528,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -566,7 +566,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -590,7 +590,7 @@ describe('v1beta1.IdentityClient', () => {
               new protos.google.showcase.v1beta1.DeleteUserRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteUserRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteUserRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -330,7 +330,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -357,7 +357,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -395,7 +395,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -419,7 +419,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -439,7 +439,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -467,7 +467,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -506,7 +506,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedHeaderRequestParams = `room.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -531,7 +531,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.room ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateRoomRequest', ['room', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateRoomRequest', ['room', 'name']);
             request.room.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -550,7 +550,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -577,7 +577,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -615,7 +615,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -639,7 +639,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteRoomRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteRoomRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteRoomRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -658,7 +658,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -685,7 +685,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -723,7 +723,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -747,7 +747,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.CreateBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateBlurbRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.CreateBlurbRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -766,7 +766,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -793,7 +793,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -831,7 +831,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -855,7 +855,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.GetBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -875,7 +875,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -903,7 +903,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -942,7 +942,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedHeaderRequestParams = `blurb.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -967,7 +967,7 @@ describe('v1beta1.MessagingClient', () => {
             );
             request.blurb ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateBlurbRequest', ['blurb', 'name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.UpdateBlurbRequest', ['blurb', 'name']);
             request.blurb.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -986,7 +986,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1013,7 +1013,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1051,7 +1051,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1075,7 +1075,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.DeleteBlurbRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteBlurbRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteBlurbRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1094,7 +1094,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1122,7 +1122,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1163,7 +1163,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1187,7 +1187,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.SearchBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SearchBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.SearchBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1248,7 +1248,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1284,7 +1284,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1317,7 +1317,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.StreamBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('StreamBlurbsRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.StreamBlurbsRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1649,7 +1649,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1677,7 +1677,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Blurb()),
@@ -1716,7 +1716,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1740,7 +1740,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1784,7 +1784,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1823,7 +1823,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1859,7 +1859,7 @@ describe('v1beta1.MessagingClient', () => {
               new protos.google.showcase.v1beta1.ListBlurbsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListBlurbsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListBlurbsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -234,7 +234,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -261,7 +261,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -299,7 +299,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -323,7 +323,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.GetSequenceReportRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSequenceReportRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSequenceReportRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -342,7 +342,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -369,7 +369,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -407,7 +407,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -431,7 +431,7 @@ describe('v1beta1.SequenceServiceClient', () => {
               new protos.google.showcase.v1beta1.AttemptSequenceRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('AttemptSequenceRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.AttemptSequenceRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();

--- a/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -281,7 +281,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -308,7 +308,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -346,7 +346,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -370,7 +370,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.GetSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.GetSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -389,7 +389,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -416,7 +416,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -454,7 +454,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -478,7 +478,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -497,7 +497,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -524,7 +524,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -562,7 +562,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -586,7 +586,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ReportSessionRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ReportSessionRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ReportSessionRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -605,7 +605,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -632,7 +632,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -670,7 +670,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -694,7 +694,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.DeleteTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.DeleteTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -713,7 +713,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -740,7 +740,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -778,7 +778,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -802,7 +802,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.VerifyTestRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('VerifyTestRequest', ['name']);
+              getTypeDefaultValue('.google.showcase.v1beta1.VerifyTestRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -996,7 +996,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1024,7 +1024,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.showcase.v1beta1.Test()),
@@ -1063,7 +1063,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1087,7 +1087,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1131,7 +1131,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1170,7 +1170,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1206,7 +1206,7 @@ describe('v1beta1.TestingClient', () => {
               new protos.google.showcase.v1beta1.ListTestsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTestsRequest', ['parent']);
+              getTypeDefaultValue('.google.showcase.v1beta1.ListTestsRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -206,7 +206,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -233,7 +233,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -271,7 +271,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -295,7 +295,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -314,7 +314,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -341,7 +341,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -379,7 +379,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -403,7 +403,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateQueueRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateQueueRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -423,7 +423,7 @@ describe('v2.CloudTasksClient', () => {
             );
             request.queue ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -451,7 +451,7 @@ describe('v2.CloudTasksClient', () => {
             );
             request.queue ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -490,7 +490,7 @@ describe('v2.CloudTasksClient', () => {
             );
             request.queue ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedHeaderRequestParams = `queue.name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -515,7 +515,7 @@ describe('v2.CloudTasksClient', () => {
             );
             request.queue ??= {};
             const defaultValue1 =
-              getTypeDefaultValue('UpdateQueueRequest', ['queue', 'name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.UpdateQueueRequest', ['queue', 'name']);
             request.queue.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -534,7 +534,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -561,7 +561,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -599,7 +599,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -623,7 +623,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -642,7 +642,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PurgeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -669,7 +669,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PurgeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -707,7 +707,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PurgeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -731,7 +731,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PurgeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PurgeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PurgeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -750,7 +750,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PauseQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PauseQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -777,7 +777,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PauseQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PauseQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -815,7 +815,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PauseQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PauseQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -839,7 +839,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.PauseQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('PauseQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.PauseQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -858,7 +858,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ResumeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -885,7 +885,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ResumeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -923,7 +923,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ResumeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -947,7 +947,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ResumeQueueRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ResumeQueueRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ResumeQueueRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -966,7 +966,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.GetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -993,7 +993,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.GetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1031,7 +1031,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.GetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1055,7 +1055,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.GetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.GetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1074,7 +1074,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.SetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1101,7 +1101,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.SetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1139,7 +1139,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.SetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1163,7 +1163,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.SetIamPolicyRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('SetIamPolicyRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.SetIamPolicyRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1182,7 +1182,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.TestIamPermissionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1209,7 +1209,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.TestIamPermissionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1247,7 +1247,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.TestIamPermissionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedHeaderRequestParams = `resource=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1271,7 +1271,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.iam.v1.TestIamPermissionsRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TestIamPermissionsRequest', ['resource']);
+              getTypeDefaultValue('.google.iam.v1.TestIamPermissionsRequest', ['resource']);
             request.resource = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1290,7 +1290,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1317,7 +1317,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1355,7 +1355,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1379,7 +1379,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.GetTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.GetTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1398,7 +1398,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1425,7 +1425,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1463,7 +1463,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1487,7 +1487,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.CreateTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateTaskRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.CreateTaskRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1506,7 +1506,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1533,7 +1533,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1571,7 +1571,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1595,7 +1595,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.DeleteTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.DeleteTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1614,7 +1614,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.RunTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RunTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1641,7 +1641,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.RunTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RunTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1679,7 +1679,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.RunTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RunTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1703,7 +1703,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.RunTaskRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('RunTaskRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.RunTaskRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -1722,7 +1722,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1750,7 +1750,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Queue()),
@@ -1789,7 +1789,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1813,7 +1813,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1857,7 +1857,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1896,7 +1896,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1932,7 +1932,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListQueuesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListQueuesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListQueuesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1967,7 +1967,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -1995,7 +1995,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.tasks.v2.Task()),
@@ -2034,7 +2034,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2058,7 +2058,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2102,7 +2102,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -2141,7 +2141,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -2177,7 +2177,7 @@ describe('v2.CloudTasksClient', () => {
               new protos.google.cloud.tasks.v2.ListTasksRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListTasksRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.tasks.v2.ListTasksRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -222,7 +222,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -249,7 +249,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -287,7 +287,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -311,7 +311,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.TranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('TranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.TranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -330,7 +330,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -357,7 +357,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -395,7 +395,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -419,7 +419,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DetectLanguageRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DetectLanguageRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DetectLanguageRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -438,7 +438,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -465,7 +465,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -503,7 +503,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -527,7 +527,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetSupportedLanguagesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetSupportedLanguagesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -546,7 +546,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -573,7 +573,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -611,7 +611,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -635,7 +635,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.GetGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('GetGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.GetGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
@@ -654,7 +654,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -682,7 +682,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -723,7 +723,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -747,7 +747,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.BatchTranslateTextRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('BatchTranslateTextRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.BatchTranslateTextRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -808,7 +808,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -836,7 +836,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -877,7 +877,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -901,7 +901,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.CreateGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('CreateGlossaryRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.CreateGlossaryRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -962,7 +962,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -990,7 +990,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedResponse = generateSampleMessage(
@@ -1031,7 +1031,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1055,7 +1055,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.DeleteGlossaryRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('DeleteGlossaryRequest', ['name']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.DeleteGlossaryRequest', ['name']);
             request.name = defaultValue1;
             const expectedHeaderRequestParams = `name=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1116,7 +1116,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1144,7 +1144,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;const expectedResponse = [
               generateSampleMessage(new protos.google.cloud.translation.v3beta1.Glossary()),
@@ -1183,7 +1183,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1207,7 +1207,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1251,7 +1251,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');
@@ -1290,7 +1290,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedResponse = [
@@ -1326,7 +1326,7 @@ describe('v3beta1.TranslationServiceClient', () => {
               new protos.google.cloud.translation.v3beta1.ListGlossariesRequest()
             );
             const defaultValue1 =
-              getTypeDefaultValue('ListGlossariesRequest', ['parent']);
+              getTypeDefaultValue('.google.cloud.translation.v3beta1.ListGlossariesRequest', ['parent']);
             request.parent = defaultValue1;
             const expectedHeaderRequestParams = `parent=${defaultValue1}`;
             const expectedError = new Error('expected');

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -302,7 +302,6 @@ request.{{ oneComment.paramName.toCamelCase() }}
             );
 {%- if method.headerRequestParams.length > 0 %}
 {#- generated request object for implicit routing headers -#}
-{%- set requestType = method.inputInterface.replace(r/^.*\./, '') -%}
 {%- set expectedRequestParamJoiner = joiner("&") -%}
 {%- set expectedRequestParams = "" -%}
 {%- set valueCounter = 0 -%}
@@ -321,7 +320,7 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- set lastFieldName = requestParam.slice(-1)[0].toCamelCase() -%}
 {%- set fields = fields + fieldsJoiner() + "'" + lastFieldName + "'" %}
             const defaultValue{{ valueCounter }} =
-              getTypeDefaultValue('{{ requestType }}', [{{ fields | safe }}]);
+              getTypeDefaultValue('{{ method.inputInterface }}', [{{ fields | safe }}]);
             {{ chain }}.{{ lastFieldName }} = defaultValue{{ valueCounter }};
 {%- set expectedRequestParams = expectedRequestParams + expectedRequestParamJoiner() +
                                 originalName + requestParam.slice(-1)[0] + "=" +


### PR DESCRIPTION
In some APIs request messages differ between versions (e.g. compare [`v1.UpdateInstanceRequest`](https://github.com/googleapis/googleapis/blob/532289228eaebe77c42438f74b8a5afa85fee1b6/google/cloud/memcache/v1/cloud_memcache.proto#L390-L398) with [`v1beta2.UpdateInstanceRequest`](https://github.com/googleapis/googleapis/blob/532289228eaebe77c42438f74b8a5afa85fee1b6/google/cloud/memcache/v1beta2/cloud_memcache.proto#L410-L418): the field is called `instance` in `v1` and `resource` in `v1beta2`).

The unit test code that generates a "type default" value for the URI component to use in the unit test, that I added in #1250, used just the last segment of the request type to load the protobuf type. It broke the unit tests in cases like the one described above.

Let's always use the fully qualified type name.