### PR TITLE
fix: mixins override command line processing

### DIFF
--- a/typescript/src/gapic-generator-typescript.ts
+++ b/typescript/src/gapic-generator-typescript.ts
@@ -111,8 +111,9 @@ yargs.boolean('rest-numeric-enums');
 yargs.alias('rest-numeric-enums', 'rest_numeric_enums');
 yargs.describe(
   'mixins',
-  'Override the list of mixins to use. Comma-separated list of API names to mixin, e.g. google.longrunning.Operations. Use "none" to disable all mixins.'
+  'Override the list of mixins to use. Semicolon-separated list of API names to mixin, e.g. google.longrunning.Operations. Use "none" to disable all mixins.'
 );
+yargs.string('mixins');
 yargs.describe('protoc', 'Path to protoc binary');
 yargs.usage('Usage: $0 -I /path/to/googleapis');
 yargs.usage('  --output_dir /path/to/output_directory');
@@ -139,6 +140,7 @@ export interface IArguments {
   handwrittenLayer?: boolean;
   legacyProtoLoad?: boolean;
   restNumericEnums?: boolean;
+  mixins?: string;
   _: string[];
   $0: string;
 }

--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -172,7 +172,7 @@ export class Generator {
       this.serviceYaml.apis = serviceMixins;
     }
     // override if needed
-    if (this.mixinsOverride) {
+    if (this.mixinsOverride !== undefined) {
       if (!this.serviceYaml) {
         this.serviceYaml = {title: '', apis: [], http: {rules: []}};
       }
@@ -234,7 +234,7 @@ export class Generator {
 
   private readMixins() {
     if (this.paramMap['mixins']) {
-      this.mixinsOverride = this.paramMap['mixins'].split(',');
+      this.mixinsOverride = this.paramMap['mixins'].split(';');
     }
   }
 
@@ -299,6 +299,7 @@ export class Generator {
       handwrittenLayer: this.handwrittenLayer,
       legacyProtoLoad: this.legacyProtoLoad,
       restNumericEnums: this.restNumericEnums,
+      mixinsOverridden: this.mixinsOverride !== undefined,
     });
     return api;
   }

--- a/typescript/src/schema/naming.ts
+++ b/typescript/src/schema/naming.ts
@@ -29,6 +29,7 @@ export interface Options {
   handwrittenLayer?: boolean;
   legacyProtoLoad?: boolean;
   restNumericEnums?: boolean;
+  mixinsOverridden?: boolean;
 }
 
 export class Naming {

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -812,7 +812,8 @@ function augmentService(parameters: AugmentServiceParameters) {
     parameters.options.serviceYaml?.apis.includes(
       'google.longrunning.Operations'
     ) &&
-    hasLroMethods
+    // enable LRO mixin if either LRO methods exist, or overridden by an option
+    (hasLroMethods || parameters.options.mixinsOverridden)
   ) {
     augmentedService.LongRunningOperationsMixin = 1;
   }


### PR DESCRIPTION
Several fixes for the previous mixins override feature (#1266):

- for LRO, if a mixin is overridden, do not check if API has LRO (the whole reason of overriding things);
- mixins must be separated by semicolons and not commas because of the protoc plugin option syntax.