### PR TITLE
fix: do not fail if service yaml does not list any apis

### DIFF
--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -158,7 +158,7 @@ export class Generator {
       const info = yaml.load(content) as ServiceYaml;
       this.serviceYaml = info;
       const serviceMixins = [];
-      for (let i = 0; i < info.apis.length; i++) {
+      for (let i = 0; i < info.apis?.length ?? 0; i++) {
         const api = info.apis[i];
         for (const [, value] of Object.entries(api)) {
           serviceMixins.push(value);


### PR DESCRIPTION
Single line fix: we only need list of `apis` in service YAML for mixins, so there is no reason to fail if it's not provided. Internal bug 267803628.