### PR TITLE
refactor: do not use .forEach

### DIFF
--- a/typescript/src/generator.ts
+++ b/typescript/src/generator.ts
@@ -279,14 +279,19 @@ export class Generator {
 
   private buildAPIObject(): API {
     const protoPackagesToGenerate = new Set<string>();
-    API.filterOutIgnoredServices(
-      this.request.protoFile.filter(
-        fd =>
-          this.request.fileToGenerate.includes(fd.name!) &&
+
+    const fdsWithServicesToGenerate: protos.google.protobuf.IFileDescriptorProto[] = [];
+    for (const fd of this.request.protoFile) {
+      if (this.request.fileToGenerate.includes(fd.name!) &&
           fd.service &&
-          fd.service.length > 0
-      )
-    ).forEach(fd => protoPackagesToGenerate.add(fd.package || ''));
+          fd.service.length > 0) {
+        fdsWithServicesToGenerate.push(fd);
+      }
+    }
+    const withoutIgnored = API.filterOutIgnoredServices(fdsWithServicesToGenerate);
+    for (const fd of withoutIgnored) {
+      protoPackagesToGenerate.add(fd.package || '');
+    }
     const packageNamesToGenerate = Array.from(protoPackagesToGenerate);
     const packageName = commonPrefix(packageNamesToGenerate).replace(/\.$/, '');
     if (packageName === '') {

--- a/typescript/src/schema/comments.ts
+++ b/typescript/src/schema/comments.ts
@@ -61,7 +61,7 @@ export class CommentsMap {
     for (const fd of fds) {
       if (fd && fd.sourceCodeInfo && fd.sourceCodeInfo.location) {
         const locations = fd.sourceCodeInfo.location;
-        locations.forEach(location => {
+        for (const location of locations) {
           if (location.leadingComments !== null) {
             // p is an array with format [f1, i1, f2, i2, ...]
             // - f1 refers to the protobuf field tag
@@ -164,7 +164,7 @@ export class CommentsMap {
               }
             }
           }
-        });
+        }
         this.comments = commentsMap;
       }
     }

--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -637,13 +637,13 @@ export function getHeaderRequestParams(
 
 // Parses the routing annotation and sets headerRequest for a method. This assumes the routing annotations
 // are in a sorted order (e.g. all the annotations for a single parameter are next to each other).
-
 export function getDynamicHeaderRequestParams(
   rules: protos.google.api.IRoutingParameter[]
 ) {
   const params: DynamicRoutingParameters[][] = [[]];
   let countOfParameters = 0;
-  rules.forEach((rule, index) => {
+  for (let index = 0; index < rules.length; ++index) {
+    const rule = rules[index];
     // Add the first rule to the first array
     if (index === 0) {
       params[countOfParameters].push(getSingleRoutingHeaderParam(rule));
@@ -659,7 +659,7 @@ export function getDynamicHeaderRequestParams(
       params[countOfParameters] = [];
       params[countOfParameters].push(getSingleRoutingHeaderParam(rule));
     }
-  });
+  }
   return params;
 }
 
@@ -682,9 +682,9 @@ export function convertFieldToCamelCase(field: string) {
     return camelCaseFields;
   }
   const fieldsToRetrieve = field.split('.');
-  fieldsToRetrieve.forEach(field => {
+  for (const field of fieldsToRetrieve) {
     camelCaseFields.push(field.toCamelCase());
-  });
+  }
   return camelCaseFields;
 }
 
@@ -867,9 +867,9 @@ function augmentService(parameters: AugmentServiceParameters) {
         resourceReference?.childType,
         errorLocation
       );
-      parentResources.forEach(
-        resource => (uniqueResources[resource.name] = resource)
-      );
+      for (const resource of parentResources) {
+        uniqueResources[resource.name] = resource;
+      }
 
       // 2. If this resource reference has .type, we should have a known resource with this type, check two maps.
       if (!resourceReference || !resourceReference.type) continue;

--- a/typescript/src/templater.ts
+++ b/typescript/src/templater.ts
@@ -81,9 +81,9 @@ async function createSnippetMetadata(
     for (const method of service.method) {
       const paramNameAndTypes: protos.google.cloud.tools.snippetgen.snippetindex.v1.ClientMethod.IParameter[] = [];
 
-      method.paramComment?.forEach(x =>
-        paramNameAndTypes.push({name: x.paramName, type: x.paramType})
-      );
+      for (const paramComment of method.paramComment ?? []) {
+        paramNameAndTypes.push({name: paramComment.paramName, type: paramComment.paramType});
+      }
 
       const startRegionTag = await countRegionTagLines(
         'samples/generated/$version/$service.$method.js.njk',


### PR DESCRIPTION
Refactor the code to get rid of `.forEach` and other code that is too functional. It's just much harder to debug by inserting debug print statements.