### PR TITLE
fix: ensure links are prefixed with "protos."

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -365,7 +365,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.asset.v1.BatchGetAssetsHistoryResponse | BatchGetAssetsHistoryResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse|BatchGetAssetsHistoryResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -450,7 +450,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.asset.v1.Feed | Feed}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -524,7 +524,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.asset.v1.Feed | Feed}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -597,7 +597,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.asset.v1.ListFeedsResponse | ListFeedsResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.ListFeedsResponse|ListFeedsResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -676,7 +676,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.asset.v1.Feed | Feed}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -750,7 +750,7 @@ export class AssetServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -815,7 +815,7 @@ export class AssetServiceClient {
 /**
  * Exports assets with time and resource types to a given Cloud Storage
  * location. The output format is newline-delimited JSON.
- * This API implements the {@link google.longrunning.Operation|google.longrunning.Operation} API allowing you
+ * This API implements the {@link protos.google.longrunning.Operation|google.longrunning.Operation} API allowing you
  * to keep track of the export.
  *
  * @param {Object} request

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -357,7 +357,7 @@ export class BigQueryStorageClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.bigquery.storage.v1beta1.ReadSession | ReadSession}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.ReadSession|ReadSession}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -436,7 +436,7 @@ export class BigQueryStorageClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse | BatchCreateReadSessionStreamsResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse|BatchCreateReadSessionStreamsResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -520,7 +520,7 @@ export class BigQueryStorageClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -611,7 +611,7 @@ export class BigQueryStorageClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse | SplitReadStreamResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse|SplitReadStreamResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -693,7 +693,7 @@ export class BigQueryStorageClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.cloud.bigquery.storage.v1beta1.ReadRowsResponse | ReadRowsResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse|ReadRowsResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -526,7 +526,7 @@ export class AddressesClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   as tuple [string, {@link google.cloud.compute.v1.AddressesScopedList | AddressesScopedList}]. The API will be called under the hood as needed, once per the page,
+ *   as tuple [string, {@link protos.google.cloud.compute.v1.AddressesScopedList|AddressesScopedList}]. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -586,7 +586,7 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.compute.v1.Address | Address}.
+ *   The first element of the array is Array of {@link protos.google.cloud.compute.v1.Address|Address}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -683,7 +683,7 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.compute.v1.Address | Address} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.compute.v1.Address|Address} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listAsync()`
@@ -749,7 +749,7 @@ export class AddressesClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.compute.v1.Address | Address}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.compute.v1.Address|Address}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -303,7 +303,7 @@ export class RegionOperationsClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.compute.v1.Operation | Operation}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.compute.v1.Operation|Operation}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -384,7 +384,7 @@ export class RegionOperationsClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.compute.v1.Operation | Operation}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.compute.v1.Operation|Operation}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -298,7 +298,7 @@ export class DeprecatedServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -364,7 +364,7 @@ export class DeprecatedServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -348,7 +348,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -429,7 +429,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -509,7 +509,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -590,7 +590,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -678,7 +678,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -764,7 +764,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -849,7 +849,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -928,7 +928,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -999,7 +999,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EnumResponse | EnumResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1072,7 +1072,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EnumResponse | EnumResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -396,7 +396,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -556,7 +556,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.PagedExpandResponse | PagedExpandResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -629,7 +629,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.BlockResponse | BlockResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -699,7 +699,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.
@@ -726,7 +726,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
- * {@link google.showcase.v1beta1.EchoRequest | EchoRequest}.
+ * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
  *   for more details and examples.
@@ -774,8 +774,8 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.showcase.v1beta1.EchoRequest | EchoRequest} for write() method, and
- *   will emit objects representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -898,7 +898,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -973,7 +973,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
@@ -1017,7 +1017,7 @@ export class EchoClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.EchoResponse | EchoResponse}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -341,7 +341,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -407,7 +407,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -481,7 +481,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -552,7 +552,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -629,7 +629,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.User|User}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -705,7 +705,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.User | User} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
@@ -750,7 +750,7 @@ export class IdentityClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.User | User}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.User|User}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -389,7 +389,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -455,7 +455,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -529,7 +529,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -600,7 +600,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -676,7 +676,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -747,7 +747,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -821,7 +821,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -892,7 +892,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -967,7 +967,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.showcase.v1beta1.StreamBlurbsResponse | StreamBlurbsResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.
@@ -998,7 +998,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
- * {@link google.showcase.v1beta1.CreateBlurbRequest | CreateBlurbRequest}.
+ * {@link protos.google.showcase.v1beta1.CreateBlurbRequest|CreateBlurbRequest}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
  *   for more details and examples.
@@ -1047,8 +1047,8 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.showcase.v1beta1.ConnectRequest | ConnectRequest} for write() method, and
- *   will emit objects representing {@link google.showcase.v1beta1.StreamBlurbsResponse | StreamBlurbsResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.showcase.v1beta1.ConnectRequest|ConnectRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -1183,7 +1183,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Room|Room}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1259,7 +1259,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Room | Room} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
@@ -1304,7 +1304,7 @@ export class MessagingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Room | Room}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Room|Room}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1348,7 +1348,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1432,7 +1432,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Blurb | Blurb} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
@@ -1485,7 +1485,7 @@ export class MessagingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Blurb | Blurb}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Blurb|Blurb}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -330,7 +330,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Sequence | Sequence}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Sequence|Sequence}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -395,7 +395,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.SequenceReport | SequenceReport}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.SequenceReport|SequenceReport}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -465,7 +465,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -346,7 +346,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -412,7 +412,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -483,7 +483,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -556,7 +556,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.ReportSessionResponse | ReportSessionResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.ReportSessionResponse|ReportSessionResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -632,7 +632,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -710,7 +710,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.VerifyTestResponse | VerifyTestResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.VerifyTestResponse|VerifyTestResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -784,7 +784,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Session|Session}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -857,7 +857,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Session | Session} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
@@ -899,7 +899,7 @@ export class TestingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Session | Session}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Session|Session}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -938,7 +938,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Test | Test}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Test|Test}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1018,7 +1018,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Test | Test} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
@@ -1067,7 +1067,7 @@ export class TestingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Test | Test}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Test|Test}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -378,7 +378,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.InspectContentResponse | InspectContentResponse}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectContentResponse|InspectContentResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -469,7 +469,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.RedactImageResponse | RedactImageResponse}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.RedactImageResponse|RedactImageResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -573,7 +573,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DeidentifyContentResponse | DeidentifyContentResponse}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyContentResponse|DeidentifyContentResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -679,7 +679,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.ReidentifyContentResponse | ReidentifyContentResponse}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.ReidentifyContentResponse|ReidentifyContentResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -761,7 +761,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.ListInfoTypesResponse | ListInfoTypesResponse}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.ListInfoTypesResponse|ListInfoTypesResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -845,7 +845,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -924,7 +924,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -998,7 +998,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1072,7 +1072,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1157,7 +1157,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1237,7 +1237,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1312,7 +1312,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1387,7 +1387,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1470,7 +1470,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.JobTrigger | JobTrigger}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1548,7 +1548,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.JobTrigger | JobTrigger}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1621,7 +1621,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.JobTrigger | JobTrigger}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1694,7 +1694,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1767,7 +1767,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DlpJob | DlpJob}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1856,7 +1856,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DlpJob | DlpJob}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1930,7 +1930,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.DlpJob | DlpJob}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2005,7 +2005,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2080,7 +2080,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2164,7 +2164,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2247,7 +2247,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2322,7 +2322,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType}.
+ *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2397,7 +2397,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2494,7 +2494,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate}.
+ *   The first element of the array is Array of {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2595,7 +2595,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listInspectTemplatesAsync()`
@@ -2665,7 +2665,7 @@ export class DlpServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.privacy.dlp.v2.InspectTemplate | InspectTemplate}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2732,7 +2732,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate}.
+ *   The first element of the array is Array of {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2833,7 +2833,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listDeidentifyTemplatesAsync()`
@@ -2903,7 +2903,7 @@ export class DlpServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.privacy.dlp.v2.DeidentifyTemplate | DeidentifyTemplate}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2995,7 +2995,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.privacy.dlp.v2.JobTrigger | JobTrigger}.
+ *   The first element of the array is Array of {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -3122,7 +3122,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.privacy.dlp.v2.JobTrigger | JobTrigger} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listJobTriggersAsync()`
@@ -3218,7 +3218,7 @@ export class DlpServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.privacy.dlp.v2.JobTrigger | JobTrigger}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -3313,7 +3313,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.privacy.dlp.v2.DlpJob | DlpJob}.
+ *   The first element of the array is Array of {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -3442,7 +3442,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.privacy.dlp.v2.DlpJob | DlpJob} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listDlpJobsAsync()`
@@ -3540,7 +3540,7 @@ export class DlpServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.privacy.dlp.v2.DlpJob | DlpJob}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -3608,7 +3608,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType}.
+ *   The first element of the array is Array of {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -3710,7 +3710,7 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listStoredInfoTypesAsync()`
@@ -3781,7 +3781,7 @@ export class DlpServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.privacy.dlp.v2.StoredInfoType | StoredInfoType}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -36,9 +36,9 @@ const version = require('../../../package.json').version;
  *  Manages cryptographic keys and operations using those keys. Implements a REST
  *  model with the following objects:
  *
- *  * {@link google.cloud.kms.v1.KeyRing|KeyRing}
- *  * {@link google.cloud.kms.v1.CryptoKey|CryptoKey}
- *  * {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}
+ *  * {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}
+ *  * {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}
+ *  * {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}
  *
  *  If you are using manual gRPC libraries, see
  *  [Using gRPC with Cloud KMS](https://cloud.google.com/kms/docs/grpc).
@@ -314,16 +314,16 @@ export class KeyManagementServiceClient {
   // -- Service calls --
   // -------------------
 /**
- * Returns metadata for a given {@link google.cloud.kms.v1.KeyRing|KeyRing}.
+ * Returns metadata for a given {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The {@link google.cloud.kms.v1.KeyRing.name|name} of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to get.
+ *   The {@link protos.google.cloud.kms.v1.KeyRing.name|name} of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.KeyRing | KeyRing}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -385,17 +385,17 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getKeyRing(request, options, callback);
   }
 /**
- * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKey|CryptoKey}, as well as its
- * {@link google.cloud.kms.v1.CryptoKey.primary|primary} {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
+ * Returns metadata for a given {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}, as well as its
+ * {@link protos.google.cloud.kms.v1.CryptoKey.primary|primary} {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The {@link google.cloud.kms.v1.CryptoKey.name|name} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to get.
+ *   The {@link protos.google.cloud.kms.v1.CryptoKey.name|name} of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKey | CryptoKey}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -457,16 +457,16 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getCryptoKey(request, options, callback);
   }
 /**
- * Returns metadata for a given {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
+ * Returns metadata for a given {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The {@link google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to get.
+ *   The {@link protos.google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -528,20 +528,20 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getCryptoKeyVersion(request, options, callback);
   }
 /**
- * Returns the public key for the given {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}. The
- * {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
- * {@link google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN|ASYMMETRIC_SIGN} or
- * {@link google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT|ASYMMETRIC_DECRYPT}.
+ * Returns the public key for the given {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}. The
+ * {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
+ * {@link protos.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN|ASYMMETRIC_SIGN} or
+ * {@link protos.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT|ASYMMETRIC_DECRYPT}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The {@link google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} public key to
+ *   The {@link protos.google.cloud.kms.v1.CryptoKeyVersion.name|name} of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} public key to
  *   get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.PublicKey | PublicKey}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.PublicKey|PublicKey}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -603,16 +603,16 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getPublicKey(request, options, callback);
   }
 /**
- * Returns metadata for a given {@link google.cloud.kms.v1.ImportJob|ImportJob}.
+ * Returns metadata for a given {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The {@link google.cloud.kms.v1.ImportJob.name|name} of the {@link google.cloud.kms.v1.ImportJob|ImportJob} to get.
+ *   The {@link protos.google.cloud.kms.v1.ImportJob.name|name} of the {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} to get.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.ImportJob | ImportJob}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -674,22 +674,22 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.getImportJob(request, options, callback);
   }
 /**
- * Create a new {@link google.cloud.kms.v1.KeyRing|KeyRing} in a given Project and Location.
+ * Create a new {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} in a given Project and Location.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. The resource name of the location associated with the
- *   {@link google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
+ *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
  * @param {string} request.keyRingId
  *   Required. It must be unique within a location and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
  * @param {google.cloud.kms.v1.KeyRing} request.keyRing
- *   A {@link google.cloud.kms.v1.KeyRing|KeyRing} with initial field values.
+ *   A {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.KeyRing | KeyRing}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -751,32 +751,32 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createKeyRing(request, options, callback);
   }
 /**
- * Create a new {@link google.cloud.kms.v1.CryptoKey|CryptoKey} within a {@link google.cloud.kms.v1.KeyRing|KeyRing}.
+ * Create a new {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} within a {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *
- * {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} and
- * {@link google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm|CryptoKey.version_template.algorithm}
+ * {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} and
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm|CryptoKey.version_template.algorithm}
  * are required.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The {@link google.cloud.kms.v1.KeyRing.name|name} of the KeyRing associated with the
- *   {@link google.cloud.kms.v1.CryptoKey|CryptoKeys}.
+ *   Required. The {@link protos.google.cloud.kms.v1.KeyRing.name|name} of the KeyRing associated with the
+ *   {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys}.
  * @param {string} request.cryptoKeyId
  *   Required. It must be unique within a KeyRing and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
  * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
- *   A {@link google.cloud.kms.v1.CryptoKey|CryptoKey} with initial field values.
+ *   A {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} with initial field values.
  * @param {boolean} request.skipInitialVersionCreation
- *   If set to true, the request will create a {@link google.cloud.kms.v1.CryptoKey|CryptoKey} without any
- *   {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}. You must manually call
- *   {@link google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion|CreateCryptoKeyVersion} or
- *   {@link google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion|ImportCryptoKeyVersion}
- *   before you can use this {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
+ *   If set to true, the request will create a {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} without any
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}. You must manually call
+ *   {@link protos.google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion|CreateCryptoKeyVersion} or
+ *   {@link protos.google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion|ImportCryptoKeyVersion}
+ *   before you can use this {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKey | CryptoKey}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -838,23 +838,23 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createCryptoKey(request, options, callback);
   }
 /**
- * Create a new {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in a {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
+ * Create a new {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in a {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *
  * The server will assign the next sequential id. If unset,
- * {@link google.cloud.kms.v1.CryptoKeyVersion.state|state} will be set to
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED|ENABLED}.
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.state|state} will be set to
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED|ENABLED}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The {@link google.cloud.kms.v1.CryptoKey.name|name} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} associated with
- *   the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}.
+ *   Required. The {@link protos.google.cloud.kms.v1.CryptoKey.name|name} of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} associated with
+ *   the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion
- *   A {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with initial field values.
+ *   A {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -916,35 +916,35 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createCryptoKeyVersion(request, options, callback);
   }
 /**
- * Imports a new {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} into an existing {@link google.cloud.kms.v1.CryptoKey|CryptoKey} using the
+ * Imports a new {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} into an existing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} using the
  * wrapped key material provided in the request.
  *
  * The version ID will be assigned the next sequential id within the
- * {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
+ * {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The {@link google.cloud.kms.v1.CryptoKey.name|name} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to
+ *   Required. The {@link protos.google.cloud.kms.v1.CryptoKey.name|name} of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to
  *   be imported into.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm} request.algorithm
- *   Required. The {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm|algorithm} of
+ *   Required. The {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm|algorithm} of
  *   the key being imported. This does not need to match the
- *   {@link google.cloud.kms.v1.CryptoKey.version_template|version_template} of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} this
+ *   {@link protos.google.cloud.kms.v1.CryptoKey.version_template|version_template} of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} this
  *   version imports into.
  * @param {string} request.importJob
- *   Required. The {@link google.cloud.kms.v1.ImportJob.name|name} of the {@link google.cloud.kms.v1.ImportJob|ImportJob} that was used to
+ *   Required. The {@link protos.google.cloud.kms.v1.ImportJob.name|name} of the {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} that was used to
  *   wrap this key material.
  * @param {Buffer} request.rsaAesWrappedKey
  *   Wrapped key material produced with
- *   {@link google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256|RSA_OAEP_3072_SHA1_AES_256}
+ *   {@link protos.google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256|RSA_OAEP_3072_SHA1_AES_256}
  *   or
- *   {@link google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256|RSA_OAEP_4096_SHA1_AES_256}.
+ *   {@link protos.google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256|RSA_OAEP_4096_SHA1_AES_256}.
  *
  *   This field contains the concatenation of two wrapped keys:
  *   <ol>
  *     <li>An ephemeral AES-256 wrapping key wrapped with the
- *         {@link google.cloud.kms.v1.ImportJob.public_key|public_key} using RSAES-OAEP with SHA-1,
+ *         {@link protos.google.cloud.kms.v1.ImportJob.public_key|public_key} using RSAES-OAEP with SHA-1,
  *         MGF1 with SHA-1, and an empty label.
  *     </li>
  *     <li>The key to be imported, wrapped with the ephemeral AES-256 key
@@ -957,7 +957,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1019,24 +1019,24 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.importCryptoKeyVersion(request, options, callback);
   }
 /**
- * Create a new {@link google.cloud.kms.v1.ImportJob|ImportJob} within a {@link google.cloud.kms.v1.KeyRing|KeyRing}.
+ * Create a new {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} within a {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *
- * {@link google.cloud.kms.v1.ImportJob.import_method|ImportJob.import_method} is required.
+ * {@link protos.google.cloud.kms.v1.ImportJob.import_method|ImportJob.import_method} is required.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The {@link google.cloud.kms.v1.KeyRing.name|name} of the {@link google.cloud.kms.v1.KeyRing|KeyRing} associated with the
- *   {@link google.cloud.kms.v1.ImportJob|ImportJobs}.
+ *   Required. The {@link protos.google.cloud.kms.v1.KeyRing.name|name} of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} associated with the
+ *   {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs}.
  * @param {string} request.importJobId
  *   Required. It must be unique within a KeyRing and match the regular
  *   expression `[a-zA-Z0-9_-]{1,63}`
  * @param {google.cloud.kms.v1.ImportJob} request.importJob
- *   Required. An {@link google.cloud.kms.v1.ImportJob|ImportJob} with initial field values.
+ *   Required. An {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} with initial field values.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.ImportJob | ImportJob}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1098,18 +1098,18 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.createImportJob(request, options, callback);
   }
 /**
- * Update a {@link google.cloud.kms.v1.CryptoKey|CryptoKey}.
+ * Update a {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {google.cloud.kms.v1.CryptoKey} request.cryptoKey
- *   {@link google.cloud.kms.v1.CryptoKey|CryptoKey} with updated values.
+ *   {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} with updated values.
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required list of fields to be updated in this request.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKey | CryptoKey}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1171,24 +1171,24 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKey(request, options, callback);
   }
 /**
- * Update a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}'s metadata.
+ * Update a {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}'s metadata.
  *
- * {@link google.cloud.kms.v1.CryptoKeyVersion.state|state} may be changed between
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED|ENABLED} and
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED|DISABLED} using this
- * method. See {@link google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion|DestroyCryptoKeyVersion} and {@link google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion|RestoreCryptoKeyVersion} to
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.state|state} may be changed between
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED|ENABLED} and
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED|DISABLED} using this
+ * method. See {@link protos.google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion|DestroyCryptoKeyVersion} and {@link protos.google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion|RestoreCryptoKeyVersion} to
  * move between other states.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {google.cloud.kms.v1.CryptoKeyVersion} request.cryptoKeyVersion
- *   {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with updated values.
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with updated values.
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required list of fields to be updated in this request.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1250,41 +1250,41 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKeyVersion(request, options, callback);
   }
 /**
- * Encrypts data, so that it can only be recovered by a call to {@link google.cloud.kms.v1.KeyManagementService.Decrypt|Decrypt}.
- * The {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
- * {@link google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT|ENCRYPT_DECRYPT}.
+ * Encrypts data, so that it can only be recovered by a call to {@link protos.google.cloud.kms.v1.KeyManagementService.Decrypt|Decrypt}.
+ * The {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} must be
+ * {@link protos.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT|ENCRYPT_DECRYPT}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} or {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} or {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}
  *   to use for encryption.
  *
- *   If a {@link google.cloud.kms.v1.CryptoKey|CryptoKey} is specified, the server will use its
- *   {@link google.cloud.kms.v1.CryptoKey.primary|primary version}.
+ *   If a {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} is specified, the server will use its
+ *   {@link protos.google.cloud.kms.v1.CryptoKey.primary|primary version}.
  * @param {Buffer} request.plaintext
  *   Required. The data to encrypt. Must be no larger than 64KiB.
  *
  *   The maximum size depends on the key version's
- *   {@link google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level|protection_level}. For
- *   {@link google.cloud.kms.v1.ProtectionLevel.SOFTWARE|SOFTWARE} keys, the plaintext must be no larger
- *   than 64KiB. For {@link google.cloud.kms.v1.ProtectionLevel.HSM|HSM} keys, the combined length of the
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level|protection_level}. For
+ *   {@link protos.google.cloud.kms.v1.ProtectionLevel.SOFTWARE|SOFTWARE} keys, the plaintext must be no larger
+ *   than 64KiB. For {@link protos.google.cloud.kms.v1.ProtectionLevel.HSM|HSM} keys, the combined length of the
  *   plaintext and additional_authenticated_data fields must be no larger than
  *   8KiB.
  * @param {Buffer} request.additionalAuthenticatedData
  *   Optional data that, if specified, must also be provided during decryption
- *   through {@link google.cloud.kms.v1.DecryptRequest.additional_authenticated_data|DecryptRequest.additional_authenticated_data}.
+ *   through {@link protos.google.cloud.kms.v1.DecryptRequest.additional_authenticated_data|DecryptRequest.additional_authenticated_data}.
  *
  *   The maximum size depends on the key version's
- *   {@link google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level|protection_level}. For
- *   {@link google.cloud.kms.v1.ProtectionLevel.SOFTWARE|SOFTWARE} keys, the AAD must be no larger than
- *   64KiB. For {@link google.cloud.kms.v1.ProtectionLevel.HSM|HSM} keys, the combined length of the
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level|protection_level}. For
+ *   {@link protos.google.cloud.kms.v1.ProtectionLevel.SOFTWARE|SOFTWARE} keys, the AAD must be no larger than
+ *   64KiB. For {@link protos.google.cloud.kms.v1.ProtectionLevel.HSM|HSM} keys, the combined length of the
  *   plaintext and additional_authenticated_data fields must be no larger than
  *   8KiB.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.EncryptResponse | EncryptResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.EncryptResponse|EncryptResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1346,24 +1346,24 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.encrypt(request, options, callback);
   }
 /**
- * Decrypts data that was protected by {@link google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}. The {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
- * must be {@link google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT|ENCRYPT_DECRYPT}.
+ * Decrypts data that was protected by {@link protos.google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}. The {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
+ * must be {@link protos.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT|ENCRYPT_DECRYPT}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to use for decryption.
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to use for decryption.
  *   The server will choose the appropriate version.
  * @param {Buffer} request.ciphertext
  *   Required. The encrypted data originally returned in
- *   {@link google.cloud.kms.v1.EncryptResponse.ciphertext|EncryptResponse.ciphertext}.
+ *   {@link protos.google.cloud.kms.v1.EncryptResponse.ciphertext|EncryptResponse.ciphertext}.
  * @param {Buffer} request.additionalAuthenticatedData
  *   Optional data that must match the data originally supplied in
- *   {@link google.cloud.kms.v1.EncryptRequest.additional_authenticated_data|EncryptRequest.additional_authenticated_data}.
+ *   {@link protos.google.cloud.kms.v1.EncryptRequest.additional_authenticated_data|EncryptRequest.additional_authenticated_data}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.DecryptResponse | DecryptResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.DecryptResponse|DecryptResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1425,22 +1425,22 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.decrypt(request, options, callback);
   }
 /**
- * Signs data using a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
+ * Signs data using a {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose}
  * ASYMMETRIC_SIGN, producing a signature that can be verified with the public
- * key retrieved from {@link google.cloud.kms.v1.KeyManagementService.GetPublicKey|GetPublicKey}.
+ * key retrieved from {@link protos.google.cloud.kms.v1.KeyManagementService.GetPublicKey|GetPublicKey}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use for signing.
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use for signing.
  * @param {google.cloud.kms.v1.Digest} request.digest
  *   Required. The digest of the data to sign. The digest must be produced with
  *   the same digest algorithm as specified by the key version's
- *   {@link google.cloud.kms.v1.CryptoKeyVersion.algorithm|algorithm}.
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersion.algorithm|algorithm}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.AsymmetricSignResponse | AsymmetricSignResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.AsymmetricSignResponse|AsymmetricSignResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1503,21 +1503,21 @@ export class KeyManagementServiceClient {
   }
 /**
  * Decrypts data that was encrypted with a public key retrieved from
- * {@link google.cloud.kms.v1.KeyManagementService.GetPublicKey|GetPublicKey} corresponding to a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with
- * {@link google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} ASYMMETRIC_DECRYPT.
+ * {@link protos.google.cloud.kms.v1.KeyManagementService.GetPublicKey|GetPublicKey} corresponding to a {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} with
+ * {@link protos.google.cloud.kms.v1.CryptoKey.purpose|CryptoKey.purpose} ASYMMETRIC_DECRYPT.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use for
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use for
  *   decryption.
  * @param {Buffer} request.ciphertext
- *   Required. The data encrypted with the named {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}'s public
+ *   Required. The data encrypted with the named {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}'s public
  *   key using OAEP.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.AsymmetricDecryptResponse | AsymmetricDecryptResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.AsymmetricDecryptResponse|AsymmetricDecryptResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1579,20 +1579,20 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.asymmetricDecrypt(request, options, callback);
   }
 /**
- * Update the version of a {@link google.cloud.kms.v1.CryptoKey|CryptoKey} that will be used in {@link google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}.
+ * Update the version of a {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} that will be used in {@link protos.google.cloud.kms.v1.KeyManagementService.Encrypt|Encrypt}.
  *
  * Returns an error if called on an asymmetric key.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to update.
+ *   The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to update.
  * @param {string} request.cryptoKeyVersionId
- *   The id of the child {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use as primary.
+ *   The id of the child {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to use as primary.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKey | CryptoKey}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1654,27 +1654,27 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.updateCryptoKeyPrimaryVersion(request, options, callback);
   }
 /**
- * Schedule a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} for destruction.
+ * Schedule a {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} for destruction.
  *
- * Upon calling this method, {@link google.cloud.kms.v1.CryptoKeyVersion.state|CryptoKeyVersion.state} will be set to
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED|DESTROY_SCHEDULED}
- * and {@link google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} will be set to a time 24
- * hours in the future, at which point the {@link google.cloud.kms.v1.CryptoKeyVersion.state|state}
+ * Upon calling this method, {@link protos.google.cloud.kms.v1.CryptoKeyVersion.state|CryptoKeyVersion.state} will be set to
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED|DESTROY_SCHEDULED}
+ * and {@link protos.google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} will be set to a time 24
+ * hours in the future, at which point the {@link protos.google.cloud.kms.v1.CryptoKeyVersion.state|state}
  * will be changed to
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED|DESTROYED}, and the key
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED|DESTROYED}, and the key
  * material will be irrevocably destroyed.
  *
- * Before the {@link google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} is reached,
- * {@link google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion|RestoreCryptoKeyVersion} may be called to reverse the process.
+ * Before the {@link protos.google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} is reached,
+ * {@link protos.google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion|RestoreCryptoKeyVersion} may be called to reverse the process.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The resource name of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to destroy.
+ *   The resource name of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to destroy.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1736,22 +1736,22 @@ export class KeyManagementServiceClient {
     return this.innerApiCalls.destroyCryptoKeyVersion(request, options, callback);
   }
 /**
- * Restore a {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in the
- * {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED|DESTROY_SCHEDULED}
+ * Restore a {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} in the
+ * {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED|DESTROY_SCHEDULED}
  * state.
  *
- * Upon restoration of the CryptoKeyVersion, {@link google.cloud.kms.v1.CryptoKeyVersion.state|state}
- * will be set to {@link google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED|DISABLED},
- * and {@link google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} will be cleared.
+ * Upon restoration of the CryptoKeyVersion, {@link protos.google.cloud.kms.v1.CryptoKeyVersion.state|state}
+ * will be set to {@link protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED|DISABLED},
+ * and {@link protos.google.cloud.kms.v1.CryptoKeyVersion.destroy_time|destroy_time} will be cleared.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.name
- *   The resource name of the {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to restore.
+ *   The resource name of the {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} to restore.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1814,21 +1814,21 @@ export class KeyManagementServiceClient {
   }
 
  /**
- * Lists {@link google.cloud.kms.v1.KeyRing|KeyRings}.
+ * Lists {@link protos.google.cloud.kms.v1.KeyRing|KeyRings}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. The resource name of the location associated with the
- *   {@link google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
+ *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.KeyRing|KeyRings} to include in the
- *   response.  Further {@link google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -1837,7 +1837,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.kms.v1.KeyRing | KeyRing}.
+ *   The first element of the array is Array of {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1910,15 +1910,15 @@ export class KeyManagementServiceClient {
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. The resource name of the location associated with the
- *   {@link google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
+ *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.KeyRing|KeyRings} to include in the
- *   response.  Further {@link google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -1927,7 +1927,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.kms.v1.KeyRing | KeyRing} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listKeyRingsAsync()`
@@ -1967,15 +1967,15 @@ export class KeyManagementServiceClient {
  *   The request object that will be sent.
  * @param {string} request.parent
  *   Required. The resource name of the location associated with the
- *   {@link google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
+ *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRings}, in the format `projects/* /locations/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.KeyRing|KeyRings} to include in the
- *   response.  Further {@link google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.KeyRing|KeyRings} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListKeyRingsResponse.next_page_token|ListKeyRingsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -1986,7 +1986,7 @@ export class KeyManagementServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.kms.v1.KeyRing | KeyRing}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2017,21 +2017,21 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.IKeyRing>;
   }
  /**
- * Lists {@link google.cloud.kms.v1.CryptoKey|CryptoKeys}.
+ * Lists {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
- *   response.  Further {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView
  *   The fields of the primary version to include in the response.
  * @param {string} request.filter
@@ -2042,7 +2042,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.kms.v1.CryptoKey | CryptoKey}.
+ *   The first element of the array is Array of {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2114,16 +2114,16 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
- *   response.  Further {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView
  *   The fields of the primary version to include in the response.
  * @param {string} request.filter
@@ -2134,7 +2134,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.kms.v1.CryptoKey | CryptoKey} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listCryptoKeysAsync()`
@@ -2173,16 +2173,16 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
- *   response.  Further {@link google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} to include in the
+ *   response.  Further {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKeys} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token} in a subsequent
  *   request.  If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeysResponse.next_page_token|ListCryptoKeysResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.versionView
  *   The fields of the primary version to include in the response.
  * @param {string} request.filter
@@ -2195,7 +2195,7 @@ export class KeyManagementServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.kms.v1.CryptoKey | CryptoKey}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2226,22 +2226,22 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKey>;
   }
  /**
- * Lists {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}.
+ * Lists {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
  *   `projects/* /locations/* /keyRings/* /cryptoKeys/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
- *   include in the response. Further {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
+ *   include in the response. Further {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
  *   subsequently be obtained by including the
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
  *   If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view
  *   The fields to include in the response.
  * @param {string} request.filter
@@ -2252,7 +2252,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}.
+ *   The first element of the array is Array of {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2324,17 +2324,17 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
  *   `projects/* /locations/* /keyRings/* /cryptoKeys/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
- *   include in the response. Further {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
+ *   include in the response. Further {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
  *   subsequently be obtained by including the
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
  *   If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view
  *   The fields to include in the response.
  * @param {string} request.filter
@@ -2345,7 +2345,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listCryptoKeyVersionsAsync()`
@@ -2384,17 +2384,17 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey} to list, in the format
  *   `projects/* /locations/* /keyRings/* /cryptoKeys/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
- *   include in the response. Further {@link google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} to
+ *   include in the response. Further {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersions} can
  *   subsequently be obtained by including the
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token} in a subsequent request.
  *   If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListCryptoKeyVersionsResponse.next_page_token|ListCryptoKeyVersionsResponse.next_page_token}.
  * @param {google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView} request.view
  *   The fields to include in the response.
  * @param {string} request.filter
@@ -2407,7 +2407,7 @@ export class KeyManagementServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.kms.v1.CryptoKeyVersion | CryptoKeyVersion}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2438,21 +2438,21 @@ export class KeyManagementServiceClient {
     ) as AsyncIterable<protos.google.cloud.kms.v1.ICryptoKeyVersion>;
   }
  /**
- * Lists {@link google.cloud.kms.v1.ImportJob|ImportJobs}.
+ * Lists {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs}.
  *
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
- *   response. Further {@link google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
+ *   response. Further {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
  *   request. If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -2461,7 +2461,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.kms.v1.ImportJob | ImportJob}.
+ *   The first element of the array is Array of {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2533,16 +2533,16 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
- *   response. Further {@link google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
+ *   response. Further {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
  *   request. If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -2551,7 +2551,7 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.kms.v1.ImportJob | ImportJob} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listImportJobsAsync()`
@@ -2590,16 +2590,16 @@ export class KeyManagementServiceClient {
  * @param {Object} request
  *   The request object that will be sent.
  * @param {string} request.parent
- *   Required. The resource name of the {@link google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
+ *   Required. The resource name of the {@link protos.google.cloud.kms.v1.KeyRing|KeyRing} to list, in the format
  *   `projects/* /locations/* /keyRings/*`.
  * @param {number} request.pageSize
- *   Optional limit on the number of {@link google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
- *   response. Further {@link google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
- *   including the {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
+ *   Optional limit on the number of {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} to include in the
+ *   response. Further {@link protos.google.cloud.kms.v1.ImportJob|ImportJobs} can subsequently be obtained by
+ *   including the {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token} in a subsequent
  *   request. If unspecified, the server will pick an appropriate default.
  * @param {string} request.pageToken
  *   Optional pagination token, returned earlier via
- *   {@link google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
+ *   {@link protos.google.cloud.kms.v1.ListImportJobsResponse.next_page_token|ListImportJobsResponse.next_page_token}.
  * @param {string} request.filter
  *   Optional. Only include resources that match the filter in the response.
  * @param {string} request.orderBy
@@ -2610,7 +2610,7 @@ export class KeyManagementServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.kms.v1.ImportJob | ImportJob}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -448,7 +448,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogBucket | LogBucket}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -534,7 +534,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogBucket | LogBucket}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -634,7 +634,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogBucket | LogBucket}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -718,7 +718,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -799,7 +799,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -876,7 +876,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogView | LogView}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -958,7 +958,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogView | LogView}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1050,7 +1050,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogView | LogView}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1130,7 +1130,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1210,7 +1210,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogSink | LogSink}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1305,11 +1305,11 @@ export class ConfigServiceV2Client {
  *   If this field is set to true, or if the sink is owned by a non-project
  *   resource such as an organization, then the value of `writer_identity` will
  *   be a unique service account used only for exports from the new sink. For
- *   more information, see `writer_identity` in {@link google.logging.v2.LogSink|LogSink}.
+ *   more information, see `writer_identity` in {@link protos.google.logging.v2.LogSink|LogSink}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogSink | LogSink}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1395,7 +1395,7 @@ export class ConfigServiceV2Client {
  *   Required. The updated sink, whose name is the same identifier that appears as part
  *   of `sink_name`.
  * @param {boolean} [request.uniqueWriterIdentity]
- *   Optional. See {@link google.logging.v2.ConfigServiceV2.CreateSink|sinks.create}
+ *   Optional. See {@link protos.google.logging.v2.ConfigServiceV2.CreateSink|sinks.create}
  *   for a description of this field. When updating a sink, the effect of this
  *   field on the value of `writer_identity` in the updated sink depends on both
  *   the old and new values of this field:
@@ -1426,7 +1426,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogSink | LogSink}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1508,7 +1508,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1588,7 +1588,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogExclusion | LogExclusion}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1674,7 +1674,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogExclusion | LogExclusion}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1758,7 +1758,7 @@ export class ConfigServiceV2Client {
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required. A non-empty list of fields to change in the existing exclusion. New values
  *   for the fields are taken from the corresponding fields in the
- *   {@link google.logging.v2.LogExclusion|LogExclusion} included in this request. Fields not mentioned in
+ *   {@link protos.google.logging.v2.LogExclusion|LogExclusion} included in this request. Fields not mentioned in
  *   `update_mask` are not changed and are ignored in the request.
  *
  *   For example, to change the filter and description of an exclusion,
@@ -1766,7 +1766,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogExclusion | LogExclusion}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1846,7 +1846,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1940,7 +1940,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.CmekSettings | CmekSettings}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.CmekSettings|CmekSettings}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2008,7 +2008,7 @@ export class ConfigServiceV2Client {
  * Cloud organizations. Once configured, it applies to all projects and
  * folders in the Google Cloud organization.
  *
- * {@link google.logging.v2.ConfigServiceV2.UpdateCmekSettings|UpdateCmekSettings}
+ * {@link protos.google.logging.v2.ConfigServiceV2.UpdateCmekSettings|UpdateCmekSettings}
  * will fail if 1) `kms_key_name` is invalid, or 2) the associated service
  * account does not have the required
  * `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
@@ -2046,13 +2046,13 @@ export class ConfigServiceV2Client {
  *   be updated. A field will be overwritten if and only if it is in the update
  *   mask. Output only fields cannot be updated.
  *
- *   See {@link google.protobuf.FieldMask|FieldMask} for more information.
+ *   See {@link protos.google.protobuf.FieldMask|FieldMask} for more information.
  *
  *   For example: `"updateMask=kmsKeyName"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.CmekSettings | CmekSettings}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.CmekSettings|CmekSettings}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2146,7 +2146,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.Settings | Settings}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.Settings|Settings}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2214,7 +2214,7 @@ export class ConfigServiceV2Client {
  * Google Cloud organizations. Once configured, it applies to all projects and
  * folders in the Google Cloud organization.
  *
- * {@link google.logging.v2.ConfigServiceV2.UpdateSettings|UpdateSettings}
+ * {@link protos.google.logging.v2.ConfigServiceV2.UpdateSettings|UpdateSettings}
  * will fail if 1) `kms_key_name` is invalid, or 2) the associated service
  * account does not have the required
  * `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
@@ -2250,13 +2250,13 @@ export class ConfigServiceV2Client {
  *   be updated. A field will be overwritten if and only if it is in the update
  *   mask. Output only fields cannot be updated.
  *
- *   See {@link google.protobuf.FieldMask|FieldMask} for more information.
+ *   See {@link protos.google.protobuf.FieldMask|FieldMask} for more information.
  *
  *   For example: `"updateMask=kmsKeyName"`
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.Settings | Settings}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.Settings|Settings}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -2441,7 +2441,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogBucket | LogBucket}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogBucket|LogBucket}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2535,7 +2535,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogBucket | LogBucket} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogBucket|LogBucket} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBucketsAsync()`
@@ -2598,7 +2598,7 @@ export class ConfigServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogBucket | LogBucket}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogBucket|LogBucket}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2650,7 +2650,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogView | LogView}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogView|LogView}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2738,7 +2738,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogView | LogView} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogView|LogView} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listViewsAsync()`
@@ -2795,7 +2795,7 @@ export class ConfigServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogView | LogView}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogView|LogView}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -2849,7 +2849,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogSink | LogSink}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogSink|LogSink}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -2939,7 +2939,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogSink | LogSink} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogSink|LogSink} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSinksAsync()`
@@ -2998,7 +2998,7 @@ export class ConfigServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogSink | LogSink}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogSink|LogSink}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -3052,7 +3052,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogExclusion | LogExclusion}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -3142,7 +3142,7 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogExclusion | LogExclusion} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listExclusionsAsync()`
@@ -3201,7 +3201,7 @@ export class ConfigServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogExclusion | LogExclusion}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogExclusion|LogExclusion}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -450,11 +450,11 @@ export class LoggingServiceV2Client {
  *   `"organizations/123/logs/cloudaudit.googleapis.com%2Factivity"`.
  *
  *   For more information about log names, see
- *   {@link google.logging.v2.LogEntry|LogEntry}.
+ *   {@link protos.google.logging.v2.LogEntry|LogEntry}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -552,19 +552,19 @@ export class LoggingServiceV2Client {
  *         "labels": {
  *           "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
  *
- *   See {@link google.logging.v2.LogEntry|LogEntry}.
+ *   See {@link protos.google.logging.v2.LogEntry|LogEntry}.
  * @param {number[]} [request.labels]
  *   Optional. Default labels that are added to the `labels` field of all log
  *   entries in `entries`. If a log entry already has a label with the same key
  *   as a label in this parameter, then the log entry's label is not changed.
- *   See {@link google.logging.v2.LogEntry|LogEntry}.
+ *   See {@link protos.google.logging.v2.LogEntry|LogEntry}.
  * @param {number[]} request.entries
  *   Required. The log entries to send to Logging. The order of log
  *   entries in this list does not matter. Values supplied in this method's
  *   `log_name`, `resource`, and `labels` fields are copied into those log
  *   entries in this list that do not include values for their corresponding
  *   fields. For more information, see the
- *   {@link google.logging.v2.LogEntry|LogEntry} type.
+ *   {@link protos.google.logging.v2.LogEntry|LogEntry} type.
  *
  *   If the `timestamp` or `insert_id` fields are missing in log entries, then
  *   this method supplies the current time or a unique identifier, respectively.
@@ -596,7 +596,7 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.WriteLogEntriesResponse | WriteLogEntriesResponse}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.WriteLogEntriesResponse|WriteLogEntriesResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -661,8 +661,8 @@ export class LoggingServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.logging.v2.TailLogEntriesRequest | TailLogEntriesRequest} for write() method, and
- *   will emit objects representing {@link google.logging.v2.TailLogEntriesResponse | TailLogEntriesResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.logging.v2.TailLogEntriesRequest|TailLogEntriesRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.logging.v2.TailLogEntriesResponse|TailLogEntriesResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -729,7 +729,7 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogEntry | LogEntry}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogEntry|LogEntry}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -840,7 +840,7 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogEntry | LogEntry} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogEntry|LogEntry} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listLogEntriesAsync()`
@@ -920,7 +920,7 @@ export class LoggingServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogEntry | LogEntry}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogEntry|LogEntry}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -962,7 +962,7 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor}.
+ *   The first element of the array is Array of {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1040,7 +1040,7 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
@@ -1087,7 +1087,7 @@ export class LoggingServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -406,7 +406,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogMetric | LogMetric}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -484,7 +484,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogMetric | LogMetric}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -563,7 +563,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.logging.v2.LogMetric | LogMetric}.
+ *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -636,7 +636,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -719,7 +719,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.logging.v2.LogMetric | LogMetric}.
+ *   The first element of the array is Array of {@link protos.google.logging.v2.LogMetric|LogMetric}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -806,7 +806,7 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.logging.v2.LogMetric | LogMetric} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.logging.v2.LogMetric|LogMetric} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listLogMetricsAsync()`
@@ -862,7 +862,7 @@ export class MetricsServiceV2Client {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.logging.v2.LogMetric | LogMetric}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.logging.v2.LogMetric|LogMetric}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -394,7 +394,7 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.AlertPolicy | AlertPolicy}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -476,7 +476,7 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.AlertPolicy | AlertPolicy}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -547,11 +547,11 @@ export class AlertPolicyServiceClient {
  *
  *       projects/[PROJECT_ID]/alertPolicies/[ALERT_POLICY_ID]
  *
- *   For more information, see {@link google.monitoring.v3.AlertPolicy|AlertPolicy}.
+ *   For more information, see {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -650,7 +650,7 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.AlertPolicy | AlertPolicy}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -725,7 +725,7 @@ export class AlertPolicyServiceClient {
  *   Note that this field names the parent container in which the alerting
  *   policies to be listed are stored. To retrieve a single alerting policy
  *   by name, use the
- *   {@link google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
+ *   {@link protos.google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
  *   operation, instead.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -749,7 +749,7 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.AlertPolicy | AlertPolicy}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -828,7 +828,7 @@ export class AlertPolicyServiceClient {
  *   Note that this field names the parent container in which the alerting
  *   policies to be listed are stored. To retrieve a single alerting policy
  *   by name, use the
- *   {@link google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
+ *   {@link protos.google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
  *   operation, instead.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -852,7 +852,7 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.AlertPolicy | AlertPolicy} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listAlertPoliciesAsync()`
@@ -898,7 +898,7 @@ export class AlertPolicyServiceClient {
  *   Note that this field names the parent container in which the alerting
  *   policies to be listed are stored. To retrieve a single alerting policy
  *   by name, use the
- *   {@link google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
+ *   {@link protos.google.monitoring.v3.AlertPolicyService.GetAlertPolicy|GetAlertPolicy}
  *   operation, instead.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -924,7 +924,7 @@ export class AlertPolicyServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.AlertPolicy | AlertPolicy}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -398,7 +398,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Group | Group}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -475,7 +475,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Group | Group}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -550,7 +550,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Group | Group}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -626,7 +626,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -720,7 +720,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.Group | Group}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.Group|Group}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -818,7 +818,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.Group | Group} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Group|Group} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGroupsAsync()`
@@ -885,7 +885,7 @@ export class GroupServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.Group | Group}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.Group|Group}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -945,7 +945,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.api.MonitoredResource | MonitoredResource}.
+ *   The first element of the array is Array of {@link protos.google.api.MonitoredResource|MonitoredResource}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1041,7 +1041,7 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.api.MonitoredResource | MonitoredResource} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.api.MonitoredResource|MonitoredResource} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGroupMembersAsync()`
@@ -1106,7 +1106,7 @@ export class GroupServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.api.MonitoredResource | MonitoredResource}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.api.MonitoredResource|MonitoredResource}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -411,7 +411,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor}.
+ *   The first element of the array is an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -485,7 +485,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.api.MetricDescriptor | MetricDescriptor}.
+ *   The first element of the array is an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -562,7 +562,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.api.MetricDescriptor | MetricDescriptor}.
+ *   The first element of the array is an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -637,7 +637,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -720,7 +720,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -807,7 +807,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor}.
+ *   The first element of the array is Array of {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -898,7 +898,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
@@ -958,7 +958,7 @@ export class MetricServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.api.MonitoredResourceDescriptor | MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1014,7 +1014,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.api.MetricDescriptor | MetricDescriptor}.
+ *   The first element of the array is Array of {@link protos.google.api.MetricDescriptor|MetricDescriptor}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1106,7 +1106,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.api.MetricDescriptor | MetricDescriptor} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMetricDescriptorsAsync()`
@@ -1167,7 +1167,7 @@ export class MetricServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.api.MetricDescriptor | MetricDescriptor}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.api.MetricDescriptor|MetricDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1241,7 +1241,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.TimeSeries | TimeSeries}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.TimeSeries|TimeSeries}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1351,7 +1351,7 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.TimeSeries | TimeSeries} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.TimeSeries|TimeSeries} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTimeSeriesAsync()`
@@ -1430,7 +1430,7 @@ export class MetricServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.TimeSeries | TimeSeries}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.TimeSeries|TimeSeries}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -389,7 +389,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.NotificationChannelDescriptor | NotificationChannelDescriptor}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -465,7 +465,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.NotificationChannel | NotificationChannel}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -546,7 +546,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.NotificationChannel | NotificationChannel}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -623,7 +623,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.NotificationChannel | NotificationChannel}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -700,7 +700,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -772,7 +772,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -875,7 +875,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.GetNotificationChannelVerificationCodeResponse | GetNotificationChannelVerificationCodeResponse}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse|GetNotificationChannelVerificationCodeResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -956,7 +956,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.NotificationChannel | NotificationChannel}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1032,7 +1032,7 @@ export class NotificationChannelServiceClient {
  *
  *   Note that this names the parent container in which to look for the
  *   descriptors; to retrieve a single descriptor by name, use the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
  *   operation, instead.
  * @param {number} request.pageSize
  *   The maximum number of results to return in a single response. If
@@ -1045,7 +1045,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.NotificationChannelDescriptor | NotificationChannelDescriptor}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1124,7 +1124,7 @@ export class NotificationChannelServiceClient {
  *
  *   Note that this names the parent container in which to look for the
  *   descriptors; to retrieve a single descriptor by name, use the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
  *   operation, instead.
  * @param {number} request.pageSize
  *   The maximum number of results to return in a single response. If
@@ -1137,7 +1137,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.NotificationChannelDescriptor | NotificationChannelDescriptor} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listNotificationChannelDescriptorsAsync()`
@@ -1183,7 +1183,7 @@ export class NotificationChannelServiceClient {
  *
  *   Note that this names the parent container in which to look for the
  *   descriptors; to retrieve a single descriptor by name, use the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor|GetNotificationChannelDescriptor}
  *   operation, instead.
  * @param {number} request.pageSize
  *   The maximum number of results to return in a single response. If
@@ -1198,7 +1198,7 @@ export class NotificationChannelServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.NotificationChannelDescriptor | NotificationChannelDescriptor}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1239,7 +1239,7 @@ export class NotificationChannelServiceClient {
  *   in which to look for the notification channels; it does not name a
  *   specific channel. To query a specific channel by REST resource name, use
  *   the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
  *   operation.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -1265,7 +1265,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.NotificationChannel | NotificationChannel}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1342,7 +1342,7 @@ export class NotificationChannelServiceClient {
  *   in which to look for the notification channels; it does not name a
  *   specific channel. To query a specific channel by REST resource name, use
  *   the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
  *   operation.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -1368,7 +1368,7 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.NotificationChannel | NotificationChannel} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listNotificationChannelsAsync()`
@@ -1412,7 +1412,7 @@ export class NotificationChannelServiceClient {
  *   in which to look for the notification channels; it does not name a
  *   specific channel. To query a specific channel by REST resource name, use
  *   the
- *   {@link google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
+ *   {@link protos.google.monitoring.v3.NotificationChannelService.GetNotificationChannel|`GetNotificationChannel`}
  *   operation.
  * @param {string} request.filter
  *   If provided, this field specifies the criteria that must be met by
@@ -1440,7 +1440,7 @@ export class NotificationChannelServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.NotificationChannel | NotificationChannel}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -395,7 +395,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Service | Service}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -467,7 +467,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Service | Service}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -541,7 +541,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.Service | Service}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -613,7 +613,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -693,7 +693,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -771,7 +771,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -845,7 +845,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -918,7 +918,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1014,7 +1014,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.Service | Service}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.Service|Service}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1114,7 +1114,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.Service | Service} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.Service|Service} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listServicesAsync()`
@@ -1183,7 +1183,7 @@ export class ServiceMonitoringServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.Service | Service}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.Service|Service}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1238,7 +1238,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1329,7 +1329,7 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listServiceLevelObjectivesAsync()`
@@ -1389,7 +1389,7 @@ export class ServiceMonitoringServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.ServiceLevelObjective | ServiceLevelObjective}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -394,7 +394,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -468,7 +468,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -557,7 +557,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig}.
+ *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -631,7 +631,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -714,7 +714,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -800,7 +800,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUptimeCheckConfigsAsync()`
@@ -855,7 +855,7 @@ export class UptimeCheckServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.UptimeCheckConfig | UptimeCheckConfig}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -904,7 +904,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.monitoring.v3.UptimeCheckIp | UptimeCheckIp}.
+ *   The first element of the array is Array of {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -984,7 +984,7 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.monitoring.v3.UptimeCheckIp | UptimeCheckIp} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUptimeCheckIpsAsync()`
@@ -1033,7 +1033,7 @@ export class UptimeCheckServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.monitoring.v3.UptimeCheckIp | UptimeCheckIp}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -338,7 +338,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -401,7 +401,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -464,7 +464,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -528,7 +528,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -591,7 +591,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -654,7 +654,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -717,7 +717,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -780,7 +780,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -843,7 +843,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -907,7 +907,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.naming.v1beta1.ReservedWord | ReservedWord}.
+ *   The first element of the array is an object representing {@link protos.google.naming.v1beta1.ReservedWord|ReservedWord}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -970,7 +970,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1123,7 +1123,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is Array of {@link protos.google.protobuf.Empty|Empty}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1195,7 +1195,7 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.protobuf.Empty | Empty} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.protobuf.Empty|Empty} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `paginatedMethodAsync1()`
@@ -1236,7 +1236,7 @@ export class NamingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.protobuf.Empty | Empty}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.protobuf.Empty|Empty}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -399,7 +399,7 @@ export class CloudRedisClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.redis.v1beta1.Instance | Instance}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.redis.v1beta1.Instance|Instance}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -588,7 +588,7 @@ export class CloudRedisClient {
  * @param {google.protobuf.FieldMask} request.updateMask
  *   Required. Mask of fields to update. At least one path must be supplied in
  *   this field. The elements of the repeated paths field may only include these
- *   fields from {@link google.cloud.redis.v1beta1.Instance|Instance}:
+ *   fields from {@link protos.google.cloud.redis.v1beta1.Instance|Instance}:
  *
  *    *   `displayName`
  *    *   `labels`
@@ -1096,7 +1096,7 @@ export class CloudRedisClient {
  *   If not specified, a default value of 1000 will be used by the service.
  *   Regardless of the page_size value, the response may include a partial list
  *   and a caller should only rely on response's
- *   {@link CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
+ *   {@link protos.CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
  *   to determine if there are more instances left to be queried.
  * @param {string} request.pageToken
  *   The next_page_token value returned from a previous List request,
@@ -1104,7 +1104,7 @@ export class CloudRedisClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.redis.v1beta1.Instance | Instance}.
+ *   The first element of the array is Array of {@link protos.google.cloud.redis.v1beta1.Instance|Instance}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1185,7 +1185,7 @@ export class CloudRedisClient {
  *   If not specified, a default value of 1000 will be used by the service.
  *   Regardless of the page_size value, the response may include a partial list
  *   and a caller should only rely on response's
- *   {@link CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
+ *   {@link protos.CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
  *   to determine if there are more instances left to be queried.
  * @param {string} request.pageToken
  *   The next_page_token value returned from a previous List request,
@@ -1193,7 +1193,7 @@ export class CloudRedisClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.redis.v1beta1.Instance | Instance} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.redis.v1beta1.Instance|Instance} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listInstancesAsync()`
@@ -1241,7 +1241,7 @@ export class CloudRedisClient {
  *   If not specified, a default value of 1000 will be used by the service.
  *   Regardless of the page_size value, the response may include a partial list
  *   and a caller should only rely on response's
- *   {@link CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
+ *   {@link protos.CloudRedis.ListInstancesResponse.next_page_token|next_page_token}
  *   to determine if there are more instances left to be queried.
  * @param {string} request.pageToken
  *   The next_page_token value returned from a previous List request,
@@ -1251,7 +1251,7 @@ export class CloudRedisClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.redis.v1beta1.Instance | Instance}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.redis.v1beta1.Instance|Instance}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -301,7 +301,7 @@ export class TestServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -389,7 +389,7 @@ export class TestServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -487,7 +487,7 @@ export class TestServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -334,7 +334,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -494,7 +494,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.PagedExpandResponse | PagedExpandResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -567,7 +567,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.BlockResponse | BlockResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -637,7 +637,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.
@@ -664,7 +664,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
- * {@link google.showcase.v1beta1.EchoRequest | EchoRequest}.
+ * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
  *   for more details and examples.
@@ -712,8 +712,8 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.showcase.v1beta1.EchoRequest | EchoRequest} for write() method, and
- *   will emit objects representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -836,7 +836,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -911,7 +911,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
@@ -955,7 +955,7 @@ export class EchoClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.EchoResponse | EchoResponse}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -351,7 +351,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -432,7 +432,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -512,7 +512,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -593,7 +593,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -681,7 +681,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -767,7 +767,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -852,7 +852,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -931,7 +931,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.RepeatResponse | RepeatResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1002,7 +1002,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EnumResponse | EnumResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1075,7 +1075,7 @@ export class ComplianceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EnumResponse | EnumResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -402,7 +402,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -562,7 +562,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.PagedExpandResponse | PagedExpandResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -635,7 +635,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.BlockResponse | BlockResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -705,7 +705,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.
@@ -732,7 +732,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
- * {@link google.showcase.v1beta1.EchoRequest | EchoRequest}.
+ * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
  *   for more details and examples.
@@ -780,8 +780,8 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.showcase.v1beta1.EchoRequest | EchoRequest} for write() method, and
- *   will emit objects representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -904,7 +904,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.EchoResponse | EchoResponse}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -979,7 +979,7 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.EchoResponse | EchoResponse} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
@@ -1023,7 +1023,7 @@ export class EchoClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.EchoResponse | EchoResponse}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -344,7 +344,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -410,7 +410,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -484,7 +484,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -555,7 +555,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -632,7 +632,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.User | User}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.User|User}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -708,7 +708,7 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.User | User} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.User|User} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
@@ -753,7 +753,7 @@ export class IdentityClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.User | User}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.User|User}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -395,7 +395,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -461,7 +461,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -535,7 +535,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -606,7 +606,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -682,7 +682,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -753,7 +753,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -827,7 +827,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -898,7 +898,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -973,7 +973,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits {@link google.showcase.v1beta1.StreamBlurbsResponse | StreamBlurbsResponse} on 'data' event.
+ *   An object stream which emits {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
  *   for more details and examples.
@@ -1004,7 +1004,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
- * {@link google.showcase.v1beta1.CreateBlurbRequest | CreateBlurbRequest}.
+ * {@link protos.google.showcase.v1beta1.CreateBlurbRequest|CreateBlurbRequest}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
  *   for more details and examples.
@@ -1053,8 +1053,8 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing {@link google.showcase.v1beta1.ConnectRequest | ConnectRequest} for write() method, and
- *   will emit objects representing {@link google.showcase.v1beta1.StreamBlurbsResponse | StreamBlurbsResponse} on 'data' event asynchronously.
+ *   representing {@link protos.google.showcase.v1beta1.ConnectRequest|ConnectRequest} for write() method, and
+ *   will emit objects representing {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event asynchronously.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
  *   for more details and examples.
@@ -1189,7 +1189,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Room | Room}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Room|Room}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1265,7 +1265,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Room | Room} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Room|Room} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
@@ -1310,7 +1310,7 @@ export class MessagingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Room | Room}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Room|Room}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1354,7 +1354,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Blurb | Blurb}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1438,7 +1438,7 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Blurb | Blurb} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
@@ -1491,7 +1491,7 @@ export class MessagingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Blurb | Blurb}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Blurb|Blurb}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -333,7 +333,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Sequence | Sequence}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Sequence|Sequence}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -398,7 +398,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.SequenceReport | SequenceReport}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.SequenceReport|SequenceReport}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -468,7 +468,7 @@ export class SequenceServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -349,7 +349,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -415,7 +415,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -486,7 +486,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -559,7 +559,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.ReportSessionResponse | ReportSessionResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.ReportSessionResponse|ReportSessionResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -635,7 +635,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -713,7 +713,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.showcase.v1beta1.VerifyTestResponse | VerifyTestResponse}.
+ *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.VerifyTestResponse|VerifyTestResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -787,7 +787,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Session | Session}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Session|Session}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -860,7 +860,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Session | Session} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Session|Session} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
@@ -902,7 +902,7 @@ export class TestingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Session | Session}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Session|Session}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -941,7 +941,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.showcase.v1beta1.Test | Test}.
+ *   The first element of the array is Array of {@link protos.google.showcase.v1beta1.Test|Test}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1021,7 +1021,7 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.showcase.v1beta1.Test | Test} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.showcase.v1beta1.Test|Test} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
@@ -1070,7 +1070,7 @@ export class TestingClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.showcase.v1beta1.Test | Test}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.showcase.v1beta1.Test|Test}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -320,7 +320,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -403,15 +403,15 @@ export class CloudTasksClient {
  *
  *   The list of allowed locations can be obtained by calling Cloud
  *   Tasks' implementation of
- *   {@link google.cloud.location.Locations.ListLocations|ListLocations}.
+ *   {@link protos.google.cloud.location.Locations.ListLocations|ListLocations}.
  * @param {google.cloud.tasks.v2.Queue} request.queue
  *   Required. The queue to create.
  *
- *   {@link google.cloud.tasks.v2.Queue.name|Queue's name} cannot be the same as an existing queue.
+ *   {@link protos.google.cloud.tasks.v2.Queue.name|Queue's name} cannot be the same as an existing queue.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -494,11 +494,11 @@ export class CloudTasksClient {
  * @param {google.cloud.tasks.v2.Queue} request.queue
  *   Required. The queue to create or update.
  *
- *   The queue's {@link google.cloud.tasks.v2.Queue.name|name} must be specified.
+ *   The queue's {@link protos.google.cloud.tasks.v2.Queue.name|name} must be specified.
  *
  *   Output only fields cannot be modified using UpdateQueue.
  *   Any value specified for an output only field will be ignored.
- *   The queue's {@link google.cloud.tasks.v2.Queue.name|name} cannot be changed.
+ *   The queue's {@link protos.google.cloud.tasks.v2.Queue.name|name} cannot be changed.
  * @param {google.protobuf.FieldMask} request.updateMask
  *   A mask used to specify which fields of the queue are being updated.
  *
@@ -506,7 +506,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -590,7 +590,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -667,7 +667,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -733,9 +733,9 @@ export class CloudTasksClient {
  *
  * If a queue is paused then the system will stop dispatching tasks
  * until the queue is resumed via
- * {@link google.cloud.tasks.v2.CloudTasks.ResumeQueue|ResumeQueue}. Tasks can still be added
+ * {@link protos.google.cloud.tasks.v2.CloudTasks.ResumeQueue|ResumeQueue}. Tasks can still be added
  * when the queue is paused. A queue is paused if its
- * {@link google.cloud.tasks.v2.Queue.state|state} is {@link google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED}.
+ * {@link protos.google.cloud.tasks.v2.Queue.state|state} is {@link protos.google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED}.
  *
  * @param {Object} request
  *   The request object that will be sent.
@@ -745,7 +745,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -810,10 +810,10 @@ export class CloudTasksClient {
  * Resume a queue.
  *
  * This method resumes a queue after it has been
- * {@link google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED} or
- * {@link google.cloud.tasks.v2.Queue.State.DISABLED|DISABLED}. The state of a queue is stored
- * in the queue's {@link google.cloud.tasks.v2.Queue.state|state}; after calling this method it
- * will be set to {@link google.cloud.tasks.v2.Queue.State.RUNNING|RUNNING}.
+ * {@link protos.google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED} or
+ * {@link protos.google.cloud.tasks.v2.Queue.State.DISABLED|DISABLED}. The state of a queue is stored
+ * in the queue's {@link protos.google.cloud.tasks.v2.Queue.state|state}; after calling this method it
+ * will be set to {@link protos.google.cloud.tasks.v2.Queue.State.RUNNING|RUNNING}.
  *
  * WARNING: Resuming many high-QPS queues at the same time can
  * lead to target overloading. If you are resuming high-QPS
@@ -829,7 +829,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -891,7 +891,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.resumeQueue(request, options, callback);
   }
 /**
- * Gets the access control policy for a {@link google.cloud.tasks.v2.Queue|Queue}.
+ * Gets the access control policy for a {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  * Returns an empty policy if the resource exists and does not have a policy
  * set.
  *
@@ -912,7 +912,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.iam.v1.Policy | Policy}.
+ *   The first element of the array is an object representing {@link protos.google.iam.v1.Policy|Policy}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -974,7 +974,7 @@ export class CloudTasksClient {
     return this.innerApiCalls.getIamPolicy(request, options, callback);
   }
 /**
- * Sets the access control policy for a {@link google.cloud.tasks.v2.Queue|Queue}. Replaces any existing
+ * Sets the access control policy for a {@link protos.google.cloud.tasks.v2.Queue|Queue}. Replaces any existing
  * policy.
  *
  * Note: The Cloud Console does not check queue-level IAM permissions yet.
@@ -999,7 +999,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.iam.v1.Policy | Policy}.
+ *   The first element of the array is an object representing {@link protos.google.iam.v1.Policy|Policy}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1061,9 +1061,9 @@ export class CloudTasksClient {
     return this.innerApiCalls.setIamPolicy(request, options, callback);
   }
 /**
- * Returns permissions that a caller has on a {@link google.cloud.tasks.v2.Queue|Queue}.
+ * Returns permissions that a caller has on a {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  * If the resource does not exist, this will return an empty set of
- * permissions, not a {@link google.rpc.Code.NOT_FOUND|NOT_FOUND} error.
+ * permissions, not a {@link protos.google.rpc.Code.NOT_FOUND|NOT_FOUND} error.
  *
  * Note: This operation is designed to be used for building permission-aware
  * UIs and command-line tools, not for authorization checking. This operation
@@ -1082,7 +1082,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.iam.v1.TestIamPermissionsResponse | TestIamPermissionsResponse}.
+ *   The first element of the array is an object representing {@link protos.google.iam.v1.TestIamPermissionsResponse|TestIamPermissionsResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1152,22 +1152,22 @@ export class CloudTasksClient {
  *   Required. The task name. For example:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Task | Task}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1247,12 +1247,12 @@ export class CloudTasksClient {
  *
  *   Task names have the following format:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
- *   The user can optionally specify a task {@link google.cloud.tasks.v2.Task.name|name}. If a
+ *   The user can optionally specify a task {@link protos.google.cloud.tasks.v2.Task.name|name}. If a
  *   name is not specified then the system will generate a random
  *   unique task id, which will be set in the task returned in the
- *   {@link google.cloud.tasks.v2.Task.name|response}.
+ *   {@link protos.google.cloud.tasks.v2.Task.name|response}.
  *
- *   If {@link google.cloud.tasks.v2.Task.schedule_time|schedule_time} is not set or is in the
+ *   If {@link protos.google.cloud.tasks.v2.Task.schedule_time|schedule_time} is not set or is in the
  *   past then Cloud Tasks will set it to the current time.
  *
  *   Task De-duplication:
@@ -1260,7 +1260,7 @@ export class CloudTasksClient {
  *   Explicitly specifying a task ID enables task de-duplication.  If
  *   a task's ID is identical to that of an existing task or a task
  *   that was deleted or executed recently then the call will fail
- *   with {@link google.rpc.Code.ALREADY_EXISTS|ALREADY_EXISTS}.
+ *   with {@link protos.google.rpc.Code.ALREADY_EXISTS|ALREADY_EXISTS}.
  *   If the task's queue was created using Cloud Tasks, then another task with
  *   the same name can't be created for ~1hour after the original task was
  *   deleted or executed. If the task's queue was created using queue.yaml or
@@ -1268,7 +1268,7 @@ export class CloudTasksClient {
  *   for ~9days after the original task was deleted or executed.
  *
  *   Because there is an extra lookup cost to identify duplicate task
- *   names, these {@link google.cloud.tasks.v2.CloudTasks.CreateTask|CreateTask} calls have significantly
+ *   names, these {@link protos.google.cloud.tasks.v2.CloudTasks.CreateTask|CreateTask} calls have significantly
  *   increased latency. Using hashed strings for the task id or for
  *   the prefix of the task id is recommended. Choosing task ids that
  *   are sequential or have sequential prefixes, for example using a
@@ -1277,22 +1277,22 @@ export class CloudTasksClient {
  *   uniform distribution of task ids to store and serve tasks
  *   efficiently.
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Task | Task}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1368,7 +1368,7 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.protobuf.Empty | Empty}.
+ *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1433,26 +1433,26 @@ export class CloudTasksClient {
  * Forces a task to run now.
  *
  * When this method is called, Cloud Tasks will dispatch the task, even if
- * the task is already running, the queue has reached its {@link google.cloud.tasks.v2.RateLimits|RateLimits} or
- * is {@link google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED}.
+ * the task is already running, the queue has reached its {@link protos.google.cloud.tasks.v2.RateLimits|RateLimits} or
+ * is {@link protos.google.cloud.tasks.v2.Queue.State.PAUSED|PAUSED}.
  *
  * This command is meant to be used for manual debugging. For
- * example, {@link google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} can be used to retry a failed
+ * example, {@link protos.google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} can be used to retry a failed
  * task after a fix has been made or to manually force a task to be
  * dispatched now.
  *
  * The dispatched task is returned. That is, the task that is returned
- * contains the {@link Task.status|status} after the task is dispatched but
+ * contains the {@link protos.Task.status|status} after the task is dispatched but
  * before the task is received by its target.
  *
  * If Cloud Tasks receives a successful response from the task's
  * target, then the task will be deleted; otherwise the task's
- * {@link google.cloud.tasks.v2.Task.schedule_time|schedule_time} will be reset to the time that
- * {@link google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} was called plus the retry delay specified
- * in the queue's {@link google.cloud.tasks.v2.RetryConfig|RetryConfig}.
+ * {@link protos.google.cloud.tasks.v2.Task.schedule_time|schedule_time} will be reset to the time that
+ * {@link protos.google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} was called plus the retry delay specified
+ * in the queue's {@link protos.google.cloud.tasks.v2.RetryConfig|RetryConfig}.
  *
- * {@link google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} returns
- * {@link google.rpc.Code.NOT_FOUND|NOT_FOUND} when it is called on a
+ * {@link protos.google.cloud.tasks.v2.CloudTasks.RunTask|RunTask} returns
+ * {@link protos.google.rpc.Code.NOT_FOUND|NOT_FOUND} when it is called on a
  * task that has already succeeded or permanently failed.
  *
  * @param {Object} request
@@ -1461,22 +1461,22 @@ export class CloudTasksClient {
  *   Required. The task name. For example:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.tasks.v2.Task | Task}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1549,7 +1549,7 @@ export class CloudTasksClient {
  *   Required. The location name.
  *   For example: `projects/PROJECT_ID/locations/LOCATION_ID`
  * @param {string} request.filter
- *   `filter` can be used to specify a subset of queues. Any {@link google.cloud.tasks.v2.Queue|Queue}
+ *   `filter` can be used to specify a subset of queues. Any {@link protos.google.cloud.tasks.v2.Queue|Queue}
  *   field can be used as a filter and several operators as supported.
  *   For example: `<=, <, >=, >, !=, =, :`. The filter syntax is the same as
  *   described in
@@ -1566,21 +1566,21 @@ export class CloudTasksClient {
  *   The maximum page size is 9800. If unspecified, the page size will
  *   be the maximum. Fewer queues than requested might be returned,
  *   even if more queues exist; use the
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
  *   response to determine if more queues exist.
  * @param {string} request.pageToken
  *   A token identifying the page of results to return.
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
  *   method. It is an error to switch the value of the
- *   {@link google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.tasks.v2.Queue | Queue}.
+ *   The first element of the array is Array of {@link protos.google.cloud.tasks.v2.Queue|Queue}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1655,7 +1655,7 @@ export class CloudTasksClient {
  *   Required. The location name.
  *   For example: `projects/PROJECT_ID/locations/LOCATION_ID`
  * @param {string} request.filter
- *   `filter` can be used to specify a subset of queues. Any {@link google.cloud.tasks.v2.Queue|Queue}
+ *   `filter` can be used to specify a subset of queues. Any {@link protos.google.cloud.tasks.v2.Queue|Queue}
  *   field can be used as a filter and several operators as supported.
  *   For example: `<=, <, >=, >, !=, =, :`. The filter syntax is the same as
  *   described in
@@ -1672,21 +1672,21 @@ export class CloudTasksClient {
  *   The maximum page size is 9800. If unspecified, the page size will
  *   be the maximum. Fewer queues than requested might be returned,
  *   even if more queues exist; use the
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
  *   response to determine if more queues exist.
  * @param {string} request.pageToken
  *   A token identifying the page of results to return.
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
  *   method. It is an error to switch the value of the
- *   {@link google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.tasks.v2.Queue | Queue} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listQueuesAsync()`
@@ -1728,7 +1728,7 @@ export class CloudTasksClient {
  *   Required. The location name.
  *   For example: `projects/PROJECT_ID/locations/LOCATION_ID`
  * @param {string} request.filter
- *   `filter` can be used to specify a subset of queues. Any {@link google.cloud.tasks.v2.Queue|Queue}
+ *   `filter` can be used to specify a subset of queues. Any {@link protos.google.cloud.tasks.v2.Queue|Queue}
  *   field can be used as a filter and several operators as supported.
  *   For example: `<=, <, >=, >, !=, =, :`. The filter syntax is the same as
  *   described in
@@ -1745,23 +1745,23 @@ export class CloudTasksClient {
  *   The maximum page size is 9800. If unspecified, the page size will
  *   be the maximum. Fewer queues than requested might be returned,
  *   even if more queues exist; use the
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} in the
  *   response to determine if more queues exist.
  * @param {string} request.pageToken
  *   A token identifying the page of results to return.
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListQueues|ListQueues}
  *   method. It is an error to switch the value of the
- *   {@link google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
+ *   {@link protos.google.cloud.tasks.v2.ListQueuesRequest.filter|filter} while iterating through pages.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.tasks.v2.Queue | Queue}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.tasks.v2.Queue|Queue}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
@@ -1794,9 +1794,9 @@ export class CloudTasksClient {
  /**
  * Lists the tasks in a queue.
  *
- * By default, only the {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC} view is retrieved
+ * By default, only the {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC} view is retrieved
  * due to performance considerations;
- * {@link google.cloud.tasks.v2.ListTasksRequest.response_view|response_view} controls the
+ * {@link protos.google.cloud.tasks.v2.ListTasksRequest.response_view|response_view} controls the
  * subset of information which is returned.
  *
  * The tasks may be returned in any order. The ordering may change at any
@@ -1808,23 +1808,23 @@ export class CloudTasksClient {
  *   Required. The queue name. For example:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {number} request.pageSize
  *   Maximum page size.
  *
  *   Fewer tasks than requested might be returned, even if more tasks exist; use
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
  *   determine if more tasks exist.
  *
  *   The maximum page size is 1000. If unspecified, the page size will be the
@@ -1834,15 +1834,15 @@ export class CloudTasksClient {
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
  *   method.
  *
  *   The page token is valid for only 2 hours.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.tasks.v2.Task | Task}.
+ *   The first element of the array is Array of {@link protos.google.cloud.tasks.v2.Task|Task}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1917,23 +1917,23 @@ export class CloudTasksClient {
  *   Required. The queue name. For example:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {number} request.pageSize
  *   Maximum page size.
  *
  *   Fewer tasks than requested might be returned, even if more tasks exist; use
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
  *   determine if more tasks exist.
  *
  *   The maximum page size is 1000. If unspecified, the page size will be the
@@ -1943,15 +1943,15 @@ export class CloudTasksClient {
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
  *   method.
  *
  *   The page token is valid for only 2 hours.
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.tasks.v2.Task | Task} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.tasks.v2.Task|Task} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTasksAsync()`
@@ -1993,23 +1993,23 @@ export class CloudTasksClient {
  *   Required. The queue name. For example:
  *   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
  * @param {google.cloud.tasks.v2.Task.View} request.responseView
- *   The response_view specifies which subset of the {@link google.cloud.tasks.v2.Task|Task} will be
+ *   The response_view specifies which subset of the {@link protos.google.cloud.tasks.v2.Task|Task} will be
  *   returned.
  *
- *   By default response_view is {@link google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
+ *   By default response_view is {@link protos.google.cloud.tasks.v2.Task.View.BASIC|BASIC}; not all
  *   information is retrieved by default because some data, such as
  *   payloads, might be desirable to return only when needed because
  *   of its large size or because of the sensitivity of data that it
  *   contains.
  *
- *   Authorization for {@link google.cloud.tasks.v2.Task.View.FULL|FULL} requires
+ *   Authorization for {@link protos.google.cloud.tasks.v2.Task.View.FULL|FULL} requires
  *   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
- *   permission on the {@link google.cloud.tasks.v2.Task|Task} resource.
+ *   permission on the {@link protos.google.cloud.tasks.v2.Task|Task} resource.
  * @param {number} request.pageSize
  *   Maximum page size.
  *
  *   Fewer tasks than requested might be returned, even if more tasks exist; use
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} in the response to
  *   determine if more tasks exist.
  *
  *   The maximum page size is 1000. If unspecified, the page size will be the
@@ -2019,8 +2019,8 @@ export class CloudTasksClient {
  *
  *   To request the first page results, page_token must be empty. To
  *   request the next page of results, page_token must be the value of
- *   {@link google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
- *   from the previous call to {@link google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
+ *   {@link protos.google.cloud.tasks.v2.ListTasksResponse.next_page_token|next_page_token} returned
+ *   from the previous call to {@link protos.google.cloud.tasks.v2.CloudTasks.ListTasks|ListTasks}
  *   method.
  *
  *   The page token is valid for only 2 hours.
@@ -2029,7 +2029,7 @@ export class CloudTasksClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.tasks.v2.Task | Task}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.tasks.v2.Task|Task}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -301,7 +301,7 @@ export class TextToSpeechClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.texttospeech.v1.ListVoicesResponse | ListVoicesResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.texttospeech.v1.ListVoicesResponse|ListVoicesResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -372,7 +372,7 @@ export class TextToSpeechClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.texttospeech.v1.SynthesizeSpeechResponse | SynthesizeSpeechResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse|SynthesizeSpeechResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -420,7 +420,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.translation.v3beta1.TranslateTextResponse | TranslateTextResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.TranslateTextResponse|TranslateTextResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -525,7 +525,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.translation.v3beta1.DetectLanguageResponse | DetectLanguageResponse}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.DetectLanguageResponse|DetectLanguageResponse}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -627,7 +627,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.translation.v3beta1.SupportedLanguages | SupportedLanguages}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.SupportedLanguages|SupportedLanguages}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -699,7 +699,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing {@link google.cloud.translation.v3beta1.Glossary | Glossary}.
+ *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary}.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
  *   for more details and examples.
@@ -1118,7 +1118,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of {@link google.cloud.translation.v3beta1.Glossary | Glossary}.
+ *   The first element of the array is Array of {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary}.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed and will merge results from all the pages into this array.
  *   Note that it can affect your quota.
@@ -1206,7 +1206,7 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
- *   An object stream which emits an object representing {@link google.cloud.translation.v3beta1.Glossary | Glossary} on 'data' event.
+ *   An object stream which emits an object representing {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary} on 'data' event.
  *   The client library will perform auto-pagination by default: it will call the API as many
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGlossariesAsync()`
@@ -1263,7 +1263,7 @@ export class TranslationServiceClient {
  * @returns {Object}
  *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
  *   When you iterate the returned iterable, each element will be an object representing
- *   {@link google.cloud.translation.v3beta1.Glossary | Glossary}. The API will be called under the hood as needed, once per the page,
+ *   {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
  *   Please see the
  *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -325,7 +325,7 @@ export class VideoIntelligenceServiceClient {
  *   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
  *   supported, which must be specified in the following format:
  *   `gs://bucket-id/object-id` (other URI formats return
- *   {@link google.rpc.Code.INVALID_ARGUMENT|google.rpc.Code.INVALID_ARGUMENT}). For more information, see
+ *   {@link protos.google.rpc.Code.INVALID_ARGUMENT|google.rpc.Code.INVALID_ARGUMENT}). For more information, see
  *   [Request URIs](https://cloud.google.com/storage/docs/request-endpoints).
  *   A video URI may include wildcards in `object-id`, and thus identify
  *   multiple videos. Supported wildcards: '*' to match 0 or more characters;
@@ -344,7 +344,7 @@ export class VideoIntelligenceServiceClient {
  *   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
  *   URIs are supported, which must be specified in the following format:
  *   `gs://bucket-id/object-id` (other URI formats return
- *   {@link google.rpc.Code.INVALID_ARGUMENT|google.rpc.Code.INVALID_ARGUMENT}). For more information, see
+ *   {@link protos.google.rpc.Code.INVALID_ARGUMENT|google.rpc.Code.INVALID_ARGUMENT}). For more information, see
  *   [Request URIs](https://cloud.google.com/storage/docs/request-endpoints).
  * @param {string} [request.locationId]
  *   Optional. Cloud region where annotation should take place. Supported cloud

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -58,7 +58,7 @@ limitations under the License.
 {% for line in lines %}
 {%- set trimmed = line.replace(r/\s+$/, '') -%}
 {%- if trimmed.length > 0 %}
- * {{ trimmed.replaceAll('*/', '* /') | replace(markdownReferenceRegex, '{@link $2|$1}') | safe }}
+ * {{ trimmed.replaceAll('*/', '* /') | replace(markdownReferenceRegex, replaceMarkdownLink('$2', '$1')) | safe }}
 {%- else %}
  *
 {%- endif %}
@@ -68,7 +68,7 @@ limitations under the License.
 {%- macro printCommentsForMethod(method) -%}
 {%- set lines = method.comments -%}
 {% for line in lines %}
- *{{ line.replaceAll('*/', '* /').replace(r/\s+$/, '') | replace(markdownReferenceRegex, '{@link $2|$1}') | safe }}
+ *{{ line.replaceAll('*/', '* /').replace(r/\s+$/, '') | replace(markdownReferenceRegex, replaceMarkdownLink('$2', '$1')) | safe }}
 {%- endfor %}
 {%- endmacro -%}
 
@@ -108,7 +108,7 @@ limitations under the License.
 {%- for line in lines %}
 {%- set trimmed = line.replace(r/\s+$/, '') -%}
 {%- if trimmed.length > 0 %}
- *  {{ trimmed.replaceAll('*/', '* /') | replace(markdownReferenceRegex, '{@link $2|$1}') | safe }}
+ *  {{ trimmed.replaceAll('*/', '* /') | replace(markdownReferenceRegex, replaceMarkdownLink('$2', '$1')) | safe }}
 {%- else %}
  *
 {%- endif -%}
@@ -248,7 +248,11 @@ request.{{ oneComment.paramName.toCamelCase() }}
 {%- if tsType.length > 0 -%}
 {{ tsType }}
 {%- else -%}
-{@link {{ type.substring(1) }} | {{ toMessageName(type) -}}}
+{%- if type.startsWith('.') -%}
+{@link protos{{ type }}|{{ toMessageName(type) }}}
+{%- else -%}
+{@link protos.{{ type }}|{{ toMessageName(type) }}}
+{%- endif -%}
 {%- endif -%}
 {%- endmacro -%}
 
@@ -477,4 +481,13 @@ protos{{ method.pagingResponseType }}
   }
 {%- endfor -%}
 ]
+{%- endmacro -%}
+
+{%- macro replaceMarkdownLink(type, typeName) -%}
+{%- set tsType = typescriptType(type) -%}
+{%- if tsType.length > 0 -%}
+{@link {{ type }}|{{ typeName }}}
+{%- else -%}
+{@link protos.{{ type }}|{{ typeName }}}
+{%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
This will fix links to protos, which are currently unresolvable without this prefix.