### PR TITLE
fix: replace markdown links with tsdoc compatible link tags

### DIFF
--- a/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -366,8 +366,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.BatchGetAssetsHistoryResponse|BatchGetAssetsHistoryResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.batch_get_assets_history.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_BatchGetAssetsHistory_async
@@ -451,8 +450,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.create_feed.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_CreateFeed_async
@@ -525,8 +523,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.get_feed.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_GetFeed_async
@@ -598,8 +595,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.ListFeedsResponse|ListFeedsResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.list_feeds.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_ListFeeds_async
@@ -677,8 +673,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.asset.v1.Feed|Feed}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.update_feed.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_UpdateFeed_async
@@ -751,8 +746,7 @@ export class AssetServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.delete_feed.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_DeleteFeed_async
@@ -849,8 +843,7 @@ export class AssetServiceClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.export_assets.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_ExportAssets_async
@@ -915,8 +908,7 @@ export class AssetServiceClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/asset_service.export_assets.js</caption>
  * region_tag:cloudasset_v1_generated_AssetService_ExportAssets_async

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -358,8 +358,7 @@ export class BigQueryStorageClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.ReadSession|ReadSession}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/big_query_storage.create_read_session.js</caption>
  * region_tag:bigquerystorage_v1beta1_generated_BigQueryStorage_CreateReadSession_async
@@ -437,8 +436,7 @@ export class BigQueryStorageClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.BatchCreateReadSessionStreamsResponse|BatchCreateReadSessionStreamsResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js</caption>
  * region_tag:bigquerystorage_v1beta1_generated_BigQueryStorage_BatchCreateReadSessionStreams_async
@@ -521,8 +519,7 @@ export class BigQueryStorageClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/big_query_storage.finalize_stream.js</caption>
  * region_tag:bigquerystorage_v1beta1_generated_BigQueryStorage_FinalizeStream_async
@@ -612,8 +609,7 @@ export class BigQueryStorageClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.bigquery.storage.v1beta1.SplitReadStreamResponse|SplitReadStreamResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/big_query_storage.split_read_stream.js</caption>
  * region_tag:bigquerystorage_v1beta1_generated_BigQueryStorage_SplitReadStream_async
@@ -694,8 +690,7 @@ export class BigQueryStorageClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse|ReadRowsResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/big_query_storage.read_rows.js</caption>
  * region_tag:bigquerystorage_v1beta1_generated_BigQueryStorage_ReadRows_async

--- a/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -324,8 +324,7 @@ export class AddressesClient {
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing
  *   a long running operation.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  *   This method is considered to be in beta. This means while
  *   stable it is still a work-in-progress and under active development,
@@ -419,8 +418,7 @@ export class AddressesClient {
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing
  *   a long running operation.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  *   This method is considered to be in beta. This means while
  *   stable it is still a work-in-progress and under active development,
@@ -524,12 +522,11 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   as tuple [string, {@link protos.google.cloud.compute.v1.AddressesScopedList|AddressesScopedList}]. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/addresses.aggregated_list.js</caption>
  * region_tag:compute_v1_generated_Addresses_AggregatedList_async
@@ -592,8 +589,7 @@ export class AddressesClient {
  *   Note that it can affect your quota.
  *   We recommend using `listAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   list(
@@ -688,8 +684,7 @@ export class AddressesClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listStream(
@@ -747,12 +742,11 @@ export class AddressesClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.compute.v1.Address|Address}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/addresses.list.js</caption>
  * region_tag:compute_v1_generated_Addresses_List_async

--- a/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -304,8 +304,7 @@ export class RegionOperationsClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.compute.v1.Operation|Operation}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/region_operations.get.js</caption>
  * region_tag:compute_v1_generated_RegionOperations_Get_async
@@ -385,8 +384,7 @@ export class RegionOperationsClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.compute.v1.Operation|Operation}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/region_operations.wait.js</caption>
  * region_tag:compute_v1_generated_RegionOperations_Wait_async

--- a/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -299,8 +299,7 @@ export class DeprecatedServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/deprecated_service.fast_fibonacci.js</caption>
  * region_tag:localhost_v1_generated_DeprecatedService_FastFibonacci_async
@@ -365,8 +364,7 @@ export class DeprecatedServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/deprecated_service.slow_fibonacci.js</caption>
  * region_tag:localhost_v1_generated_DeprecatedService_SlowFibonacci_async

--- a/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -349,8 +349,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBody_async
@@ -430,8 +429,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_info.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyInfo_async
@@ -510,8 +508,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_query.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataQuery_async
@@ -591,8 +588,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_simple_path.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataSimplePath_async
@@ -679,8 +675,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_path_resource.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataPathResource_async
@@ -765,8 +760,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_path_trailing_resource.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataPathTrailingResource_async
@@ -850,8 +844,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_put.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyPut_async
@@ -929,8 +922,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_patch.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyPatch_async
@@ -1000,8 +992,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.get_enum.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_GetEnum_async
@@ -1073,8 +1064,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.verify_enum.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_VerifyEnum_async

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -397,8 +397,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.echo.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Echo_async
@@ -557,8 +556,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand_legacy.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpandLegacy_async
@@ -630,8 +628,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.block.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Block_async
@@ -700,8 +697,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Expand_async
@@ -727,8 +723,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
  * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.collect.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Collect_async
@@ -776,8 +771,7 @@ export class EchoClient {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
  *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.chat.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Chat_async
@@ -810,8 +804,7 @@ export class EchoClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -871,8 +864,7 @@ export class EchoClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -904,8 +896,7 @@ export class EchoClient {
  *   Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpand(
@@ -978,8 +969,7 @@ export class EchoClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpandStream(
@@ -1015,12 +1005,11 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpand_async

--- a/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -342,8 +342,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.create_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_CreateUser_async
@@ -408,8 +407,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.get_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_GetUser_async
@@ -482,8 +480,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.update_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_UpdateUser_async
@@ -553,8 +550,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.delete_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_DeleteUser_async
@@ -635,8 +631,7 @@ export class IdentityClient {
  *   Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUsers(
@@ -710,8 +705,7 @@ export class IdentityClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUsersStream(
@@ -748,12 +742,11 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.User|User}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.list_users.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_ListUsers_async

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -390,8 +390,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.create_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_CreateRoom_async
@@ -456,8 +455,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.get_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_GetRoom_async
@@ -530,8 +528,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.update_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_UpdateRoom_async
@@ -601,8 +598,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.delete_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_DeleteRoom_async
@@ -677,8 +673,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.create_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_CreateBlurb_async
@@ -748,8 +743,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.get_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_GetBlurb_async
@@ -822,8 +816,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.update_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_UpdateBlurb_async
@@ -893,8 +886,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.delete_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_DeleteBlurb_async
@@ -968,8 +960,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.stream_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_StreamBlurbs_async
@@ -999,8 +990,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
  * {@link protos.google.showcase.v1beta1.CreateBlurbRequest|CreateBlurbRequest}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.send_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SendBlurbs_async
@@ -1049,8 +1039,7 @@ export class MessagingClient {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.showcase.v1beta1.ConnectRequest|ConnectRequest} for write() method, and
  *   will emit objects representing {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.connect.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_Connect_async
@@ -1090,8 +1079,7 @@ export class MessagingClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.search_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
@@ -1156,8 +1144,7 @@ export class MessagingClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.search_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
@@ -1189,8 +1176,7 @@ export class MessagingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listRooms(
@@ -1264,8 +1250,7 @@ export class MessagingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listRoomsStream(
@@ -1302,12 +1287,11 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Room|Room}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.list_rooms.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_ListRooms_async
@@ -1354,8 +1338,7 @@ export class MessagingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBlurbs(
@@ -1437,8 +1420,7 @@ export class MessagingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBlurbsStream(
@@ -1483,12 +1465,11 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Blurb|Blurb}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.list_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_ListBlurbs_async

--- a/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -331,8 +331,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Sequence|Sequence}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.create_sequence.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_CreateSequence_async
@@ -396,8 +395,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.SequenceReport|SequenceReport}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.get_sequence_report.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_GetSequenceReport_async
@@ -466,8 +464,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.attempt_sequence.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_AttemptSequence_async

--- a/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -347,8 +347,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.create_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_CreateSession_async
@@ -413,8 +412,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.get_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_GetSession_async
@@ -484,8 +482,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.delete_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_DeleteSession_async
@@ -557,8 +554,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.ReportSessionResponse|ReportSessionResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.report_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ReportSession_async
@@ -633,8 +629,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.delete_test.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_DeleteTest_async
@@ -711,8 +706,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.VerifyTestResponse|VerifyTestResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.verify_test.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_VerifyTest_async
@@ -790,8 +784,7 @@ export class TestingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSessions(
@@ -862,8 +855,7 @@ export class TestingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSessionsStream(
@@ -897,12 +889,11 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Session|Session}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.list_sessions.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ListSessions_async
@@ -944,8 +935,7 @@ export class TestingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTests(
@@ -1023,8 +1013,7 @@ export class TestingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTestsStream(
@@ -1065,12 +1054,11 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Test|Test}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.list_tests.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ListTests_async

--- a/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -379,8 +379,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectContentResponse|InspectContentResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.inspect_content.js</caption>
  * region_tag:dlp_v2_generated_DlpService_InspectContent_async
@@ -470,8 +469,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.RedactImageResponse|RedactImageResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.redact_image.js</caption>
  * region_tag:dlp_v2_generated_DlpService_RedactImage_async
@@ -574,8 +572,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyContentResponse|DeidentifyContentResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.deidentify_content.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeidentifyContent_async
@@ -680,8 +677,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.ReidentifyContentResponse|ReidentifyContentResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.reidentify_content.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ReidentifyContent_async
@@ -762,8 +758,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.ListInfoTypesResponse|ListInfoTypesResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_info_types.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListInfoTypes_async
@@ -846,8 +841,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.create_inspect_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CreateInspectTemplate_async
@@ -925,8 +919,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.update_inspect_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_UpdateInspectTemplate_async
@@ -999,8 +992,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.get_inspect_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_GetInspectTemplate_async
@@ -1073,8 +1065,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.delete_inspect_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeleteInspectTemplate_async
@@ -1158,8 +1149,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.create_deidentify_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CreateDeidentifyTemplate_async
@@ -1238,8 +1228,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.update_deidentify_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_UpdateDeidentifyTemplate_async
@@ -1313,8 +1302,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.get_deidentify_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_GetDeidentifyTemplate_async
@@ -1388,8 +1376,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.delete_deidentify_template.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeleteDeidentifyTemplate_async
@@ -1471,8 +1458,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.create_job_trigger.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CreateJobTrigger_async
@@ -1549,8 +1535,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.update_job_trigger.js</caption>
  * region_tag:dlp_v2_generated_DlpService_UpdateJobTrigger_async
@@ -1622,8 +1607,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.get_job_trigger.js</caption>
  * region_tag:dlp_v2_generated_DlpService_GetJobTrigger_async
@@ -1695,8 +1679,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.delete_job_trigger.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeleteJobTrigger_async
@@ -1768,8 +1751,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.activate_job_trigger.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ActivateJobTrigger_async
@@ -1857,8 +1839,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.create_dlp_job.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CreateDlpJob_async
@@ -1931,8 +1912,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.get_dlp_job.js</caption>
  * region_tag:dlp_v2_generated_DlpService_GetDlpJob_async
@@ -2006,8 +1986,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.delete_dlp_job.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeleteDlpJob_async
@@ -2081,8 +2060,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.cancel_dlp_job.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CancelDlpJob_async
@@ -2165,8 +2143,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.create_stored_info_type.js</caption>
  * region_tag:dlp_v2_generated_DlpService_CreateStoredInfoType_async
@@ -2248,8 +2225,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.update_stored_info_type.js</caption>
  * region_tag:dlp_v2_generated_DlpService_UpdateStoredInfoType_async
@@ -2323,8 +2299,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.get_stored_info_type.js</caption>
  * region_tag:dlp_v2_generated_DlpService_GetStoredInfoType_async
@@ -2398,8 +2373,7 @@ export class DlpServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.delete_stored_info_type.js</caption>
  * region_tag:dlp_v2_generated_DlpService_DeleteStoredInfoType_async
@@ -2500,8 +2474,7 @@ export class DlpServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listInspectTemplatesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listInspectTemplates(
@@ -2600,8 +2573,7 @@ export class DlpServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listInspectTemplatesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listInspectTemplatesStream(
@@ -2663,12 +2635,11 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.privacy.dlp.v2.InspectTemplate|InspectTemplate}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_inspect_templates.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListInspectTemplates_async
@@ -2738,8 +2709,7 @@ export class DlpServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listDeidentifyTemplatesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listDeidentifyTemplates(
@@ -2838,8 +2808,7 @@ export class DlpServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listDeidentifyTemplatesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listDeidentifyTemplatesStream(
@@ -2901,12 +2870,11 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.privacy.dlp.v2.DeidentifyTemplate|DeidentifyTemplate}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_deidentify_templates.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListDeidentifyTemplates_async
@@ -3001,8 +2969,7 @@ export class DlpServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listJobTriggersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listJobTriggers(
@@ -3127,8 +3094,7 @@ export class DlpServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listJobTriggersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listJobTriggersStream(
@@ -3216,12 +3182,11 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.privacy.dlp.v2.JobTrigger|JobTrigger}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_job_triggers.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListJobTriggers_async
@@ -3319,8 +3284,7 @@ export class DlpServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listDlpJobsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listDlpJobs(
@@ -3447,8 +3411,7 @@ export class DlpServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listDlpJobsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listDlpJobsStream(
@@ -3538,12 +3501,11 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.privacy.dlp.v2.DlpJob|DlpJob}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_dlp_jobs.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListDlpJobs_async
@@ -3614,8 +3576,7 @@ export class DlpServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listStoredInfoTypesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listStoredInfoTypes(
@@ -3715,8 +3676,7 @@ export class DlpServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listStoredInfoTypesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listStoredInfoTypesStream(
@@ -3779,12 +3739,11 @@ export class DlpServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.privacy.dlp.v2.StoredInfoType|StoredInfoType}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/dlp_service.list_stored_info_types.js</caption>
  * region_tag:dlp_v2_generated_DlpService_ListStoredInfoTypes_async

--- a/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -324,8 +324,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.get_key_ring.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_GetKeyRing_async
@@ -396,8 +395,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.get_crypto_key.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_GetCryptoKey_async
@@ -467,8 +465,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.get_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_GetCryptoKeyVersion_async
@@ -542,8 +539,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.PublicKey|PublicKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.get_public_key.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_GetPublicKey_async
@@ -613,8 +609,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.get_import_job.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_GetImportJob_async
@@ -690,8 +685,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.create_key_ring.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_CreateKeyRing_async
@@ -777,8 +771,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.create_crypto_key.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_CreateCryptoKey_async
@@ -855,8 +848,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.create_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_CreateCryptoKeyVersion_async
@@ -958,8 +950,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.import_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_ImportCryptoKeyVersion_async
@@ -1037,8 +1028,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.create_import_job.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_CreateImportJob_async
@@ -1110,8 +1100,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.update_crypto_key.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_UpdateCryptoKey_async
@@ -1189,8 +1178,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.update_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_UpdateCryptoKeyVersion_async
@@ -1285,8 +1273,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.EncryptResponse|EncryptResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.encrypt.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_Encrypt_async
@@ -1364,8 +1351,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.DecryptResponse|DecryptResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.decrypt.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_Decrypt_async
@@ -1441,8 +1427,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.AsymmetricSignResponse|AsymmetricSignResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.asymmetric_sign.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_AsymmetricSign_async
@@ -1518,8 +1503,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.AsymmetricDecryptResponse|AsymmetricDecryptResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.asymmetric_decrypt.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_AsymmetricDecrypt_async
@@ -1593,8 +1577,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.update_crypto_key_primary_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_UpdateCryptoKeyPrimaryVersion_async
@@ -1675,8 +1658,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.destroy_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_DestroyCryptoKeyVersion_async
@@ -1752,8 +1734,7 @@ export class KeyManagementServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.restore_crypto_key_version.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_RestoreCryptoKeyVersion_async
@@ -1843,8 +1824,7 @@ export class KeyManagementServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listKeyRingsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listKeyRings(
@@ -1932,8 +1912,7 @@ export class KeyManagementServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listKeyRingsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listKeyRingsStream(
@@ -1984,12 +1963,11 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.kms.v1.KeyRing|KeyRing}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.list_key_rings.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_ListKeyRings_async
@@ -2048,8 +2026,7 @@ export class KeyManagementServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listCryptoKeysAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listCryptoKeys(
@@ -2139,8 +2116,7 @@ export class KeyManagementServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listCryptoKeysAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listCryptoKeysStream(
@@ -2193,12 +2169,11 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.kms.v1.CryptoKey|CryptoKey}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.list_crypto_keys.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_ListCryptoKeys_async
@@ -2258,8 +2233,7 @@ export class KeyManagementServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listCryptoKeyVersionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listCryptoKeyVersions(
@@ -2350,8 +2324,7 @@ export class KeyManagementServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listCryptoKeyVersionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listCryptoKeyVersionsStream(
@@ -2405,12 +2378,11 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.kms.v1.CryptoKeyVersion|CryptoKeyVersion}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.list_crypto_key_versions.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_ListCryptoKeyVersions_async
@@ -2467,8 +2439,7 @@ export class KeyManagementServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listImportJobsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listImportJobs(
@@ -2556,8 +2527,7 @@ export class KeyManagementServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listImportJobsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listImportJobsStream(
@@ -2608,12 +2578,11 @@ export class KeyManagementServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.kms.v1.ImportJob|ImportJob}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/key_management_service.list_import_jobs.js</caption>
  * region_tag:cloudkms_v1_generated_KeyManagementService_ListImportJobs_async
@@ -2700,8 +2669,7 @@ export class KeyManagementServiceClient {
  * @param {string[]} request.permissions
  *   The set of permissions to check for the `resource`. Permissions with
  *   wildcards (such as '*' or 'storage.*') are not allowed. For more
- *   information see
- *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ *   information see {@link https://cloud.google.com/iam/docs/overview#permissions | IAM Overview }.
  * @param {Object} [options]
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See {@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html | gax.CallOptions} for the details.
@@ -2748,8 +2716,7 @@ export class KeyManagementServiceClient {
  * @param {string[]} request.permissions
  *   The set of permissions to check for the `resource`. Permissions with
  *   wildcards (such as '*' or 'storage.*') are not allowed. For more
- *   information see
- *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ *   information see {@link https://cloud.google.com/iam/docs/overview#permissions | IAM Overview }.
  * @param {Object} [options]
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See {@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html | gax.CallOptions} for the details.

--- a/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -449,8 +449,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_bucket.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetBucket_async
@@ -535,8 +534,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.create_bucket.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CreateBucket_async
@@ -635,8 +633,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogBucket|LogBucket}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_bucket.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateBucket_async
@@ -719,8 +716,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.delete_bucket.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_DeleteBucket_async
@@ -800,8 +796,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.undelete_bucket.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UndeleteBucket_async
@@ -877,8 +872,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_view.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetView_async
@@ -959,8 +953,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.create_view.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CreateView_async
@@ -1051,8 +1044,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogView|LogView}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_view.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateView_async
@@ -1131,8 +1123,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.delete_view.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_DeleteView_async
@@ -1211,8 +1202,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_sink.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetSink_async
@@ -1310,8 +1300,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.create_sink.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CreateSink_async
@@ -1427,8 +1416,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogSink|LogSink}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_sink.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateSink_async
@@ -1509,8 +1497,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.delete_sink.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_DeleteSink_async
@@ -1589,8 +1576,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_exclusion.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetExclusion_async
@@ -1675,8 +1661,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.create_exclusion.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CreateExclusion_async
@@ -1767,8 +1752,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogExclusion|LogExclusion}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_exclusion.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateExclusion_async
@@ -1847,8 +1831,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.delete_exclusion.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_DeleteExclusion_async
@@ -1941,8 +1924,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.CmekSettings|CmekSettings}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_cmek_settings.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetCmekSettings_async
@@ -2053,8 +2035,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.CmekSettings|CmekSettings}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_cmek_settings.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async
@@ -2147,8 +2128,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.Settings|Settings}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.get_settings.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_GetSettings_async
@@ -2257,8 +2237,7 @@ export class ConfigServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.Settings|Settings}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.update_settings.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_UpdateSettings_async
@@ -2340,8 +2319,7 @@ export class ConfigServiceV2Client {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.copy_log_entries.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CopyLogEntries_async
@@ -2401,8 +2379,7 @@ export class ConfigServiceV2Client {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.copy_log_entries.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_CopyLogEntries_async
@@ -2447,8 +2424,7 @@ export class ConfigServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listBucketsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBuckets(
@@ -2540,8 +2516,7 @@ export class ConfigServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBucketsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBucketsStream(
@@ -2596,12 +2571,11 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogBucket|LogBucket}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.list_buckets.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_ListBuckets_async
@@ -2656,8 +2630,7 @@ export class ConfigServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listViewsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listViews(
@@ -2743,8 +2716,7 @@ export class ConfigServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listViewsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listViewsStream(
@@ -2793,12 +2765,11 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogView|LogView}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.list_views.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_ListViews_async
@@ -2855,8 +2826,7 @@ export class ConfigServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listSinksAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSinks(
@@ -2944,8 +2914,7 @@ export class ConfigServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSinksAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSinksStream(
@@ -2996,12 +2965,11 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogSink|LogSink}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.list_sinks.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_ListSinks_async
@@ -3058,8 +3026,7 @@ export class ConfigServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listExclusionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listExclusions(
@@ -3147,8 +3114,7 @@ export class ConfigServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listExclusionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listExclusionsStream(
@@ -3199,12 +3165,11 @@ export class ConfigServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogExclusion|LogExclusion}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/config_service_v2.list_exclusions.js</caption>
  * region_tag:logging_v2_generated_ConfigServiceV2_ListExclusions_async

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -455,8 +455,7 @@ export class LoggingServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.delete_log.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_DeleteLog_async
@@ -597,8 +596,7 @@ export class LoggingServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.WriteLogEntriesResponse|WriteLogEntriesResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.write_log_entries.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_WriteLogEntries_async
@@ -663,8 +661,7 @@ export class LoggingServiceV2Client {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.logging.v2.TailLogEntriesRequest|TailLogEntriesRequest} for write() method, and
  *   will emit objects representing {@link protos.google.logging.v2.TailLogEntriesResponse|TailLogEntriesResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.tail_log_entries.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_TailLogEntries_async
@@ -735,8 +732,7 @@ export class LoggingServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listLogEntriesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogEntries(
@@ -845,8 +841,7 @@ export class LoggingServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listLogEntriesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogEntriesStream(
@@ -918,12 +913,11 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogEntry|LogEntry}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.list_log_entries.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_ListLogEntries_async
@@ -968,8 +962,7 @@ export class LoggingServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMonitoredResourceDescriptors(
@@ -1045,8 +1038,7 @@ export class LoggingServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMonitoredResourceDescriptorsStream(
@@ -1085,12 +1077,11 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_ListMonitoredResourceDescriptors_async
@@ -1157,8 +1148,7 @@ export class LoggingServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listLogsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogs(
@@ -1260,8 +1250,7 @@ export class LoggingServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listLogsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogsStream(
@@ -1326,12 +1315,11 @@ export class LoggingServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   string. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/logging_service_v2.list_logs.js</caption>
  * region_tag:logging_v2_generated_LoggingServiceV2_ListLogs_async

--- a/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -407,8 +407,7 @@ export class MetricsServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/metrics_service_v2.get_log_metric.js</caption>
  * region_tag:logging_v2_generated_MetricsServiceV2_GetLogMetric_async
@@ -485,8 +484,7 @@ export class MetricsServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/metrics_service_v2.create_log_metric.js</caption>
  * region_tag:logging_v2_generated_MetricsServiceV2_CreateLogMetric_async
@@ -564,8 +562,7 @@ export class MetricsServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.logging.v2.LogMetric|LogMetric}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/metrics_service_v2.update_log_metric.js</caption>
  * region_tag:logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async
@@ -637,8 +634,7 @@ export class MetricsServiceV2Client {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/metrics_service_v2.delete_log_metric.js</caption>
  * region_tag:logging_v2_generated_MetricsServiceV2_DeleteLogMetric_async
@@ -725,8 +721,7 @@ export class MetricsServiceV2Client {
  *   Note that it can affect your quota.
  *   We recommend using `listLogMetricsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogMetrics(
@@ -811,8 +806,7 @@ export class MetricsServiceV2Client {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listLogMetricsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listLogMetricsStream(
@@ -860,12 +854,11 @@ export class MetricsServiceV2Client {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.logging.v2.LogMetric|LogMetric}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/metrics_service_v2.list_log_metrics.js</caption>
  * region_tag:logging_v2_generated_MetricsServiceV2_ListLogMetrics_async

--- a/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -395,8 +395,7 @@ export class AlertPolicyServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/alert_policy_service.get_alert_policy.js</caption>
  * region_tag:monitoring_v3_generated_AlertPolicyService_GetAlertPolicy_async
@@ -477,8 +476,7 @@ export class AlertPolicyServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/alert_policy_service.create_alert_policy.js</caption>
  * region_tag:monitoring_v3_generated_AlertPolicyService_CreateAlertPolicy_async
@@ -552,8 +550,7 @@ export class AlertPolicyServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/alert_policy_service.delete_alert_policy.js</caption>
  * region_tag:monitoring_v3_generated_AlertPolicyService_DeleteAlertPolicy_async
@@ -651,8 +648,7 @@ export class AlertPolicyServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/alert_policy_service.update_alert_policy.js</caption>
  * region_tag:monitoring_v3_generated_AlertPolicyService_UpdateAlertPolicy_async
@@ -755,8 +751,7 @@ export class AlertPolicyServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listAlertPoliciesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listAlertPolicies(
@@ -857,8 +852,7 @@ export class AlertPolicyServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listAlertPoliciesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listAlertPoliciesStream(
@@ -922,12 +916,11 @@ export class AlertPolicyServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.AlertPolicy|AlertPolicy}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/alert_policy_service.list_alert_policies.js</caption>
  * region_tag:monitoring_v3_generated_AlertPolicyService_ListAlertPolicies_async

--- a/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -399,8 +399,7 @@ export class GroupServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.get_group.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_GetGroup_async
@@ -476,8 +475,7 @@ export class GroupServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.create_group.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_CreateGroup_async
@@ -551,8 +549,7 @@ export class GroupServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Group|Group}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.update_group.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_UpdateGroup_async
@@ -627,8 +624,7 @@ export class GroupServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.delete_group.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_DeleteGroup_async
@@ -726,8 +722,7 @@ export class GroupServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listGroupsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGroups(
@@ -823,8 +818,7 @@ export class GroupServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGroupsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGroupsStream(
@@ -883,12 +877,11 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.Group|Group}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.list_groups.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_ListGroups_async
@@ -951,8 +944,7 @@ export class GroupServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listGroupMembersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGroupMembers(
@@ -1046,8 +1038,7 @@ export class GroupServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGroupMembersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGroupMembersStream(
@@ -1104,12 +1095,11 @@ export class GroupServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.api.MonitoredResource|MonitoredResource}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/group_service.list_group_members.js</caption>
  * region_tag:monitoring_v3_generated_GroupService_ListGroupMembers_async

--- a/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -412,8 +412,7 @@ export class MetricServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.get_monitored_resource_descriptor.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_GetMonitoredResourceDescriptor_async
@@ -486,8 +485,7 @@ export class MetricServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.get_metric_descriptor.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_GetMetricDescriptor_async
@@ -563,8 +561,7 @@ export class MetricServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.api.MetricDescriptor|MetricDescriptor}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.create_metric_descriptor.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_CreateMetricDescriptor_async
@@ -638,8 +635,7 @@ export class MetricServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.delete_metric_descriptor.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_DeleteMetricDescriptor_async
@@ -721,8 +717,7 @@ export class MetricServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.create_time_series.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_CreateTimeSeries_async
@@ -813,8 +808,7 @@ export class MetricServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMonitoredResourceDescriptors(
@@ -903,8 +897,7 @@ export class MetricServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMonitoredResourceDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMonitoredResourceDescriptorsStream(
@@ -956,12 +949,11 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.api.MonitoredResourceDescriptor|MonitoredResourceDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.list_monitored_resource_descriptors.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_ListMonitoredResourceDescriptors_async
@@ -1020,8 +1012,7 @@ export class MetricServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listMetricDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMetricDescriptors(
@@ -1111,8 +1102,7 @@ export class MetricServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listMetricDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listMetricDescriptorsStream(
@@ -1165,12 +1155,11 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.api.MetricDescriptor|MetricDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.list_metric_descriptors.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_ListMetricDescriptors_async
@@ -1247,8 +1236,7 @@ export class MetricServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listTimeSeriesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTimeSeries(
@@ -1356,8 +1344,7 @@ export class MetricServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTimeSeriesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTimeSeriesStream(
@@ -1428,12 +1415,11 @@ export class MetricServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.TimeSeries|TimeSeries}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/metric_service.list_time_series.js</caption>
  * region_tag:monitoring_v3_generated_MetricService_ListTimeSeries_async

--- a/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -390,8 +390,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_GetNotificationChannelDescriptor_async
@@ -466,8 +465,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.get_notification_channel.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_GetNotificationChannel_async
@@ -547,8 +545,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.create_notification_channel.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_CreateNotificationChannel_async
@@ -624,8 +621,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.update_notification_channel.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_UpdateNotificationChannel_async
@@ -701,8 +697,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.delete_notification_channel.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_DeleteNotificationChannel_async
@@ -773,8 +768,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_SendNotificationChannelVerificationCode_async
@@ -876,8 +870,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.GetNotificationChannelVerificationCodeResponse|GetNotificationChannelVerificationCodeResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_GetNotificationChannelVerificationCode_async
@@ -957,8 +950,7 @@ export class NotificationChannelServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.verify_notification_channel.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_VerifyNotificationChannel_async
@@ -1051,8 +1043,7 @@ export class NotificationChannelServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listNotificationChannelDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listNotificationChannelDescriptors(
@@ -1142,8 +1133,7 @@ export class NotificationChannelServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listNotificationChannelDescriptorsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listNotificationChannelDescriptorsStream(
@@ -1196,12 +1186,11 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.NotificationChannelDescriptor|NotificationChannelDescriptor}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_ListNotificationChannelDescriptors_async
@@ -1271,8 +1260,7 @@ export class NotificationChannelServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listNotificationChannelsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listNotificationChannels(
@@ -1373,8 +1361,7 @@ export class NotificationChannelServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listNotificationChannelsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listNotificationChannelsStream(
@@ -1438,12 +1425,11 @@ export class NotificationChannelServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.NotificationChannel|NotificationChannel}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/notification_channel_service.list_notification_channels.js</caption>
  * region_tag:monitoring_v3_generated_NotificationChannelService_ListNotificationChannels_async

--- a/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -396,8 +396,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.create_service.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_CreateService_async
@@ -468,8 +467,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.get_service.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_GetService_async
@@ -542,8 +540,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.Service|Service}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.update_service.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_UpdateService_async
@@ -614,8 +611,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.delete_service.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_DeleteService_async
@@ -694,8 +690,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.create_service_level_objective.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_CreateServiceLevelObjective_async
@@ -772,8 +767,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.get_service_level_objective.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_GetServiceLevelObjective_async
@@ -846,8 +840,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.update_service_level_objective.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_UpdateServiceLevelObjective_async
@@ -919,8 +912,7 @@ export class ServiceMonitoringServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.delete_service_level_objective.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_DeleteServiceLevelObjective_async
@@ -1020,8 +1012,7 @@ export class ServiceMonitoringServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listServicesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listServices(
@@ -1119,8 +1110,7 @@ export class ServiceMonitoringServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listServicesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listServicesStream(
@@ -1181,12 +1171,11 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.Service|Service}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.list_services.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_ListServices_async
@@ -1244,8 +1233,7 @@ export class ServiceMonitoringServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listServiceLevelObjectivesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listServiceLevelObjectives(
@@ -1334,8 +1322,7 @@ export class ServiceMonitoringServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listServiceLevelObjectivesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listServiceLevelObjectivesStream(
@@ -1387,12 +1374,11 @@ export class ServiceMonitoringServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.ServiceLevelObjective|ServiceLevelObjective}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/service_monitoring_service.list_service_level_objectives.js</caption>
  * region_tag:monitoring_v3_generated_ServiceMonitoringService_ListServiceLevelObjectives_async

--- a/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -395,8 +395,7 @@ export class UptimeCheckServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.get_uptime_check_config.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_GetUptimeCheckConfig_async
@@ -469,8 +468,7 @@ export class UptimeCheckServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.create_uptime_check_config.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_CreateUptimeCheckConfig_async
@@ -558,8 +556,7 @@ export class UptimeCheckServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.update_uptime_check_config.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_UpdateUptimeCheckConfig_async
@@ -632,8 +629,7 @@ export class UptimeCheckServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.delete_uptime_check_config.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_DeleteUptimeCheckConfig_async
@@ -720,8 +716,7 @@ export class UptimeCheckServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listUptimeCheckConfigsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUptimeCheckConfigs(
@@ -805,8 +800,7 @@ export class UptimeCheckServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUptimeCheckConfigsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUptimeCheckConfigsStream(
@@ -853,12 +847,11 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.UptimeCheckConfig|UptimeCheckConfig}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.list_uptime_check_configs.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_ListUptimeCheckConfigs_async
@@ -910,8 +903,7 @@ export class UptimeCheckServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listUptimeCheckIpsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUptimeCheckIps(
@@ -989,8 +981,7 @@ export class UptimeCheckServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUptimeCheckIpsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUptimeCheckIpsStream(
@@ -1031,12 +1022,11 @@ export class UptimeCheckServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.monitoring.v3.UptimeCheckIp|UptimeCheckIp}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3/uptime_check_service.list_uptime_check_ips.js</caption>
  * region_tag:monitoring_v3_generated_UptimeCheckService_ListUptimeCheckIps_async

--- a/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -339,8 +339,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.paginated_method_stream.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_PaginatedMethodStream_async
@@ -402,8 +401,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.paginated_method_async.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_PaginatedMethodAsync_async
@@ -465,8 +463,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.check_long_running_progress.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_CheckLongRunningProgress_async
@@ -529,8 +526,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.initialize.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_Initialize_async
@@ -592,8 +588,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.service_path.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_ServicePath_async
@@ -655,8 +650,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.api_endpoint.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_ApiEndpoint_async
@@ -718,8 +712,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.port.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_Port_async
@@ -781,8 +774,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.scopes.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_Scopes_async
@@ -844,8 +836,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.get_project_id.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_getProjectId_async
@@ -908,8 +899,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.naming.v1beta1.ReservedWord|ReservedWord}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.get_reserved_word.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_getReservedWord_async
@@ -971,8 +961,7 @@ export class NamingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_createABCDESomething_async
@@ -1038,8 +1027,7 @@ export class NamingClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.long_running.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_LongRunning_async
@@ -1099,8 +1087,7 @@ export class NamingClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.long_running.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_LongRunning_async
@@ -1129,8 +1116,7 @@ export class NamingClient {
  *   Note that it can affect your quota.
  *   We recommend using `paginatedMethodAsync1()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   paginatedMethod(
@@ -1200,8 +1186,7 @@ export class NamingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `paginatedMethodAsync1()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   paginatedMethodStream1(
@@ -1234,12 +1219,11 @@ export class NamingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.protobuf.Empty|Empty}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/naming.paginated_method.js</caption>
  * region_tag:localhost_v1beta1_generated_Naming_PaginatedMethod_async

--- a/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -400,8 +400,7 @@ export class CloudRedisClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.redis.v1beta1.Instance|Instance}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.get_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_GetInstance_async
@@ -498,8 +497,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.create_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_CreateInstance_async
@@ -564,8 +562,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.create_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_CreateInstance_async
@@ -603,8 +600,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.update_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_UpdateInstance_async
@@ -669,8 +665,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.update_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_UpdateInstance_async
@@ -705,8 +700,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.import_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_ImportInstance_async
@@ -771,8 +765,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.import_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_ImportInstance_async
@@ -805,8 +798,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.export_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_ExportInstance_async
@@ -871,8 +863,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.export_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_ExportInstance_async
@@ -902,8 +893,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.failover_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_FailoverInstance_async
@@ -968,8 +958,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.failover_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_FailoverInstance_async
@@ -996,8 +985,7 @@ export class CloudRedisClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.delete_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_DeleteInstance_async
@@ -1062,8 +1050,7 @@ export class CloudRedisClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.delete_instance.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_DeleteInstance_async
@@ -1110,8 +1097,7 @@ export class CloudRedisClient {
  *   Note that it can affect your quota.
  *   We recommend using `listInstancesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listInstances(
@@ -1198,8 +1184,7 @@ export class CloudRedisClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listInstancesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listInstancesStream(
@@ -1249,12 +1234,11 @@ export class CloudRedisClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.redis.v1beta1.Instance|Instance}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/cloud_redis.list_instances.js</caption>
  * region_tag:redis_v1beta1_generated_CloudRedis_ListInstances_async

--- a/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -302,8 +302,7 @@ export class TestServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/test_service.fast_fibonacci.js</caption>
  * region_tag:localhost_v1_generated_TestService_FastFibonacci_async
@@ -390,8 +389,7 @@ export class TestServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/test_service.random_fibonacci.js</caption>
  * region_tag:localhost_v1_generated_TestService_RandomFibonacci_async
@@ -488,8 +486,7 @@ export class TestServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/test_service.slow_fibonacci.js</caption>
  * region_tag:localhost_v1_generated_TestService_SlowFibonacci_async

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -335,8 +335,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.echo.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Echo_async
@@ -495,8 +494,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand_legacy.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpandLegacy_async
@@ -568,8 +566,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.block.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Block_async
@@ -638,8 +635,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Expand_async
@@ -665,8 +661,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
  * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.collect.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Collect_async
@@ -714,8 +709,7 @@ export class EchoClient {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
  *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.chat.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Chat_async
@@ -748,8 +742,7 @@ export class EchoClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -809,8 +802,7 @@ export class EchoClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -842,8 +834,7 @@ export class EchoClient {
  *   Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpand(
@@ -916,8 +907,7 @@ export class EchoClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpandStream(
@@ -953,12 +943,11 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpand_async

--- a/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -352,8 +352,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBody_async
@@ -433,8 +432,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_info.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyInfo_async
@@ -513,8 +511,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_query.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataQuery_async
@@ -594,8 +591,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_simple_path.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataSimplePath_async
@@ -682,8 +678,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_path_resource.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataPathResource_async
@@ -768,8 +763,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_path_trailing_resource.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataPathTrailingResource_async
@@ -853,8 +847,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_put.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyPut_async
@@ -932,8 +925,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.RepeatResponse|RepeatResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.repeat_data_body_patch.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_RepeatDataBodyPatch_async
@@ -1003,8 +995,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.get_enum.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_GetEnum_async
@@ -1076,8 +1067,7 @@ export class ComplianceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EnumResponse|EnumResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/compliance.verify_enum.js</caption>
  * region_tag:localhost_v1beta1_generated_Compliance_VerifyEnum_async

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -403,8 +403,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.echo.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Echo_async
@@ -563,8 +562,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.PagedExpandResponse|PagedExpandResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand_legacy.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpandLegacy_async
@@ -636,8 +634,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.BlockResponse|BlockResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.block.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Block_async
@@ -706,8 +703,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Expand_async
@@ -733,8 +729,7 @@ export class EchoClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
  * {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.collect.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Collect_async
@@ -782,8 +777,7 @@ export class EchoClient {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.showcase.v1beta1.EchoRequest|EchoRequest} for write() method, and
  *   will emit objects representing {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.chat.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Chat_async
@@ -816,8 +810,7 @@ export class EchoClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -877,8 +870,7 @@ export class EchoClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.wait.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_Wait_async
@@ -910,8 +902,7 @@ export class EchoClient {
  *   Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpand(
@@ -984,8 +975,7 @@ export class EchoClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `pagedExpandAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   pagedExpandStream(
@@ -1021,12 +1011,11 @@ export class EchoClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.EchoResponse|EchoResponse}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/echo.paged_expand.js</caption>
  * region_tag:localhost_v1beta1_generated_Echo_PagedExpand_async

--- a/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -345,8 +345,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.create_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_CreateUser_async
@@ -411,8 +410,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.get_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_GetUser_async
@@ -485,8 +483,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.User|User}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.update_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_UpdateUser_async
@@ -556,8 +553,7 @@ export class IdentityClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.delete_user.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_DeleteUser_async
@@ -638,8 +634,7 @@ export class IdentityClient {
  *   Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUsers(
@@ -713,8 +708,7 @@ export class IdentityClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listUsersAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listUsersStream(
@@ -751,12 +745,11 @@ export class IdentityClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.User|User}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/identity.list_users.js</caption>
  * region_tag:localhost_v1beta1_generated_Identity_ListUsers_async

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -396,8 +396,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.create_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_CreateRoom_async
@@ -462,8 +461,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.get_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_GetRoom_async
@@ -536,8 +534,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Room|Room}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.update_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_UpdateRoom_async
@@ -607,8 +604,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.delete_room.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_DeleteRoom_async
@@ -683,8 +679,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.create_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_CreateBlurb_async
@@ -754,8 +749,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.get_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_GetBlurb_async
@@ -828,8 +822,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Blurb|Blurb}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.update_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_UpdateBlurb_async
@@ -899,8 +892,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.delete_blurb.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_DeleteBlurb_async
@@ -974,8 +966,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream}
  *   An object stream which emits {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.stream_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_StreamBlurbs_async
@@ -1005,8 +996,7 @@ export class MessagingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Stream} - A writable stream which accepts objects representing
  * {@link protos.google.showcase.v1beta1.CreateBlurbRequest|CreateBlurbRequest}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.send_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SendBlurbs_async
@@ -1055,8 +1045,7 @@ export class MessagingClient {
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {@link protos.google.showcase.v1beta1.ConnectRequest|ConnectRequest} for write() method, and
  *   will emit objects representing {@link protos.google.showcase.v1beta1.StreamBlurbsResponse|StreamBlurbsResponse} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.connect.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_Connect_async
@@ -1096,8 +1085,7 @@ export class MessagingClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.search_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
@@ -1162,8 +1150,7 @@ export class MessagingClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.search_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_SearchBlurbs_async
@@ -1195,8 +1182,7 @@ export class MessagingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listRooms(
@@ -1270,8 +1256,7 @@ export class MessagingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listRoomsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listRoomsStream(
@@ -1308,12 +1293,11 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Room|Room}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.list_rooms.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_ListRooms_async
@@ -1360,8 +1344,7 @@ export class MessagingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBlurbs(
@@ -1443,8 +1426,7 @@ export class MessagingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listBlurbsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listBlurbsStream(
@@ -1489,12 +1471,11 @@ export class MessagingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Blurb|Blurb}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/messaging.list_blurbs.js</caption>
  * region_tag:localhost_v1beta1_generated_Messaging_ListBlurbs_async

--- a/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -334,8 +334,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Sequence|Sequence}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.create_sequence.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_CreateSequence_async
@@ -399,8 +398,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.SequenceReport|SequenceReport}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.get_sequence_report.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_GetSequenceReport_async
@@ -469,8 +467,7 @@ export class SequenceServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/sequence_service.attempt_sequence.js</caption>
  * region_tag:localhost_v1beta1_generated_SequenceService_AttemptSequence_async

--- a/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -350,8 +350,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.create_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_CreateSession_async
@@ -416,8 +415,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.Session|Session}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.get_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_GetSession_async
@@ -487,8 +485,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.delete_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_DeleteSession_async
@@ -560,8 +557,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.ReportSessionResponse|ReportSessionResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.report_session.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ReportSession_async
@@ -636,8 +632,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.delete_test.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_DeleteTest_async
@@ -714,8 +709,7 @@ export class TestingClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.showcase.v1beta1.VerifyTestResponse|VerifyTestResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.verify_test.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_VerifyTest_async
@@ -793,8 +787,7 @@ export class TestingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSessions(
@@ -865,8 +858,7 @@ export class TestingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listSessionsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listSessionsStream(
@@ -900,12 +892,11 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Session|Session}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.list_sessions.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ListSessions_async
@@ -947,8 +938,7 @@ export class TestingClient {
  *   Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTests(
@@ -1026,8 +1016,7 @@ export class TestingClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTestsAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTestsStream(
@@ -1068,12 +1057,11 @@ export class TestingClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.showcase.v1beta1.Test|Test}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1beta1/testing.list_tests.js</caption>
  * region_tag:localhost_v1beta1_generated_Testing_ListTests_async

--- a/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -321,8 +321,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.get_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_GetQueue_async
@@ -412,8 +411,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.create_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_CreateQueue_async
@@ -507,8 +505,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.update_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_UpdateQueue_async
@@ -591,8 +588,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.delete_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_DeleteQueue_async
@@ -668,8 +664,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.purge_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_PurgeQueue_async
@@ -746,8 +741,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.pause_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_PauseQueue_async
@@ -830,8 +824,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Queue|Queue}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.resume_queue.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_ResumeQueue_async
@@ -913,8 +906,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.iam.v1.Policy|Policy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.get_iam_policy.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_GetIamPolicy_async
@@ -1000,8 +992,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.iam.v1.Policy|Policy}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.set_iam_policy.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_SetIamPolicy_async
@@ -1083,8 +1074,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.iam.v1.TestIamPermissionsResponse|TestIamPermissionsResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.test_iam_permissions.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_TestIamPermissions_async
@@ -1168,8 +1158,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.get_task.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_GetTask_async
@@ -1293,8 +1282,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.create_task.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_CreateTask_async
@@ -1369,8 +1357,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.protobuf.Empty|Empty}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.delete_task.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_DeleteTask_async
@@ -1477,8 +1464,7 @@ export class CloudTasksClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.tasks.v2.Task|Task}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.run_task.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_RunTask_async
@@ -1586,8 +1572,7 @@ export class CloudTasksClient {
  *   Note that it can affect your quota.
  *   We recommend using `listQueuesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listQueues(
@@ -1691,8 +1676,7 @@ export class CloudTasksClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listQueuesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listQueuesStream(
@@ -1759,12 +1743,11 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.tasks.v2.Queue|Queue}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.list_queues.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_ListQueues_async
@@ -1848,8 +1831,7 @@ export class CloudTasksClient {
  *   Note that it can affect your quota.
  *   We recommend using `listTasksAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTasks(
@@ -1956,8 +1938,7 @@ export class CloudTasksClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listTasksAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listTasksStream(
@@ -2027,12 +2008,11 @@ export class CloudTasksClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.tasks.v2.Task|Task}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v2/cloud_tasks.list_tasks.js</caption>
  * region_tag:cloudtasks_v2_generated_CloudTasks_ListTasks_async

--- a/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -302,8 +302,7 @@ export class TextToSpeechClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.texttospeech.v1.ListVoicesResponse|ListVoicesResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/text_to_speech.list_voices.js</caption>
  * region_tag:texttospeech_v1_generated_TextToSpeech_ListVoices_async
@@ -373,8 +372,7 @@ export class TextToSpeechClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.texttospeech.v1.SynthesizeSpeechResponse|SynthesizeSpeechResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/text_to_speech.synthesize_speech.js</caption>
  * region_tag:texttospeech_v1_generated_TextToSpeech_SynthesizeSpeech_async

--- a/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -421,8 +421,7 @@ export class TranslationServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.TranslateTextResponse|TranslateTextResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.translate_text.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_TranslateText_async
@@ -526,8 +525,7 @@ export class TranslationServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.DetectLanguageResponse|DetectLanguageResponse}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.detect_language.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_DetectLanguage_async
@@ -628,8 +626,7 @@ export class TranslationServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.SupportedLanguages|SupportedLanguages}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.get_supported_languages.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_GetSupportedLanguages_async
@@ -700,8 +697,7 @@ export class TranslationServiceClient {
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.get_glossary.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_GetGlossary_async
@@ -830,8 +826,7 @@ export class TranslationServiceClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.batch_translate_text.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_BatchTranslateText_async
@@ -896,8 +891,7 @@ export class TranslationServiceClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.batch_translate_text.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_BatchTranslateText_async
@@ -924,8 +918,7 @@ export class TranslationServiceClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.create_glossary.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_CreateGlossary_async
@@ -990,8 +983,7 @@ export class TranslationServiceClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.create_glossary.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_CreateGlossary_async
@@ -1017,8 +1009,7 @@ export class TranslationServiceClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.delete_glossary.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_DeleteGlossary_async
@@ -1083,8 +1074,7 @@ export class TranslationServiceClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.delete_glossary.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_DeleteGlossary_async
@@ -1124,8 +1114,7 @@ export class TranslationServiceClient {
  *   Note that it can affect your quota.
  *   We recommend using `listGlossariesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGlossaries(
@@ -1211,8 +1200,7 @@ export class TranslationServiceClient {
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `listGlossariesAsync()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  */
   listGlossariesStream(
@@ -1261,12 +1249,11 @@ export class TranslationServiceClient {
  * @param {object} [options]
  *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  *   {@link protos.google.cloud.translation.v3beta1.Glossary|Glossary}. The API will be called under the hood as needed, once per the page,
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v3beta1/translation_service.list_glossaries.js</caption>
  * region_tag:translate_v3beta1_generated_TranslationService_ListGlossaries_async

--- a/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -356,8 +356,7 @@ export class VideoIntelligenceServiceClient {
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/video_intelligence_service.annotate_video.js</caption>
  * region_tag:videointelligence_v1_generated_VideoIntelligenceService_AnnotateVideo_async
@@ -417,8 +416,7 @@ export class VideoIntelligenceServiceClient {
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  * @example <caption>include:samples/generated/v1/video_intelligence_service.annotate_video.js</caption>
  * region_tag:videointelligence_v1_generated_VideoIntelligenceService_AnnotateVideo_async

--- a/templates/typescript_gapic/_iam.njk
+++ b/templates/typescript_gapic/_iam.njk
@@ -65,8 +65,7 @@
  * @param {string[]} request.permissions
  *   The set of permissions to check for the `resource`. Permissions with
  *   wildcards (such as '*' or 'storage.*') are not allowed. For more
- *   information see
- *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ *   information see {@link https://cloud.google.com/iam/docs/overview#permissions | IAM Overview }.
  * @param {Object} [options]
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See {@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html | gax.CallOptions} for the details.
@@ -113,8 +112,7 @@
  * @param {string[]} request.permissions
  *   The set of permissions to check for the `resource`. Permissions with
  *   wildcards (such as '*' or 'storage.*') are not allowed. For more
- *   information see
- *   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ *   information see {@link https://cloud.google.com/iam/docs/overview#permissions | IAM Overview }.
  * @param {Object} [options]
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See {@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html | gax.CallOptions} for the details.

--- a/templates/typescript_gapic/_locations.njk
+++ b/templates/typescript_gapic/_locations.njk
@@ -17,8 +17,7 @@
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html | CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing {@link google.cloud.location.Location | Location}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
    *   for more details and examples.
    * @example
    * ```
@@ -64,12 +63,11 @@
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
    *   When you iterate the returned iterable, each element will be an object representing
    *   {@link google.cloud.location.Location | Location}. The API will be called under the hood as needed, once per the page,
    *   so you can stop the iteration when you don't need more results.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
    *   for more details and examples.
    * @example
    * ```

--- a/templates/typescript_gapic/_util.njk
+++ b/templates/typescript_gapic/_util.njk
@@ -32,8 +32,7 @@ limitations under the License.
  *   The operation name that will be passed.
  * @returns {Promise} - The promise which resolves to an object.
  *   The decoded operation object has result and metadata field to get information from.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
 {%- endmacro %}
 
@@ -143,8 +142,7 @@ limitations under the License.
  *   The first element of the array is an object representing
  *   a long running operation. Its `promise()` method returns a promise
  *   you can `await` for.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
@@ -153,8 +151,7 @@ limitations under the License.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing
  *   a long running operation.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations | documentation }
  *   for more details and examples.
  *   This method is considered to be in beta. This means while
  *   stable it is still a work-in-progress and under active development,
@@ -163,8 +160,7 @@ limitations under the License.
 {%- else %}
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is an object representing {{ typeLink(method.outputType) }}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods | documentation }
  *   for more details and examples.
 {%- endif %}
 {%- endmacro -%}
@@ -177,24 +173,21 @@ limitations under the License.
  *   Note that it can affect your quota.
  *   We recommend using `{{ generatedAsyncName }}()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
 {%- macro printReturnServerStreamingMethod(method) %}
  * @returns {Stream}
  *   An object stream which emits {{ typeLink(method.outputType) }} on 'data' event.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
 {%- macro printReturnClientStreamingMethod(method) %}
  * @returns {Stream} - A writable stream which accepts objects representing
  * {{ typeLink(method.inputType) }}.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#client-streaming | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
@@ -203,8 +196,7 @@ limitations under the License.
  *   An object stream which is both readable and writable. It accepts objects
  *   representing {{ typeLink(method.inputType) }} for write() method, and
  *   will emit objects representing {{ typeLink(method.outputType) }} on 'data' event asynchronously.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#bi-directional-streaming | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
@@ -215,14 +207,13 @@ limitations under the License.
  *   times as needed. Note that it can affect your quota.
  *   We recommend using `{{ generatedAsyncName }}()`
  *   method described below for async iteration which you can stop as needed.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 
 {%- macro printReturnPageAsync(method, generatedName) %}
  * @returns {Object}
- *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+ *   An iterable Object that allows {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols | async iteration }.
  *   When you iterate the returned iterable, each element will be an object representing
  {%- if method.pagingMapResponseType %}
  *   as tuple [string, {{ typeLink(method.pagingMapResponseType) }}]. The API will be called under the hood as needed, once per the page,
@@ -230,8 +221,7 @@ limitations under the License.
  *   {{ typeLink(method.pagingResponseType) }}. The API will be called under the hood as needed, once per the page,
  {%- endif %}
  *   so you can stop the iteration when you don't need more results.
- *   Please see the
- *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+ *   Please see the {@link https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination | documentation }
  *   for more details and examples.
 {%- endmacro -%}
 


### PR DESCRIPTION
This should fix broken links across all libraries that use the template.