### PR TITLE
fix: add explicit Bazel dependency on protos.json

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,7 +23,10 @@ filegroup(
 
 filegroup(
     name = "protos",
-    srcs = ["//:protos/index.js"],
+    srcs = [
+      "//:protos/index.js",
+      "//:protos/protos.json",
+    ],
 )
 
 npm_runtime_dependencies = [


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#558.