### PR TITLE
fix: disable retry-request for stream closed test

### DIFF
--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -716,7 +716,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.readRows(request);
+            const stream = client.readRows(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -673,7 +673,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request);
+            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1321,7 +1321,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request);
+            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -660,7 +660,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request);
+            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -673,7 +673,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request);
+            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1321,7 +1321,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request);
+            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -573,7 +573,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method, skipExpectedVariable='true') }}
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.{{ method.name.toCamelCase() }}(request);
+            const stream = client.{{ method.name.toCamelCase() }}(request, {retryRequestOptions: {noResponseRetries: 0}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
                     resolve(response);


### PR DESCRIPTION
Some streaming unit tests that check error handling took 6+ seconds to run because `retry-request` was retrying the test with exponential backoff before giving up. Fixing that, it should speed up generated unit tests.