### PR TITLE
chore: do not require up to date branch

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -25,7 +25,7 @@ branchProtectionRules:
   # Defaults to `false`
   requiresCodeOwnerReviews: true
   # Require up to date branches
-  requiresStrictStatusChecks: true
+  requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - "cla/google"


### PR DESCRIPTION
Let's do it here as well, since Renovate PRs come too often.