### PR TITLE
fix: remove log message when methodConfig is undefined

### DIFF
--- a/typescript/src/schema/proto.ts
+++ b/typescript/src/schema/proto.ts
@@ -413,7 +413,7 @@ function getMethodConfig(
         }
       }
     }
-  } else {
+  } else if (grpcServiceConfig.methodConfig) {
     console.warn(
       'Warning: cannot parse gRPC service config: methodConfig is not an array.'
     );


### PR DESCRIPTION
Warning: cannot parse gRPC service config: methodConfig is not an array.