### PR TITLE
fix: Fix protos import in index files

### DIFF
--- a/baselines/asset-esm/esm/src/index.ts.baseline
+++ b/baselines/asset-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type AssetServiceClient = v1.AssetServiceClient;
 export {v1, AssetServiceClient};
 export default {v1, AssetServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type BigQueryStorageClient = v1beta1.BigQueryStorageClient;
 export {v1beta1, BigQueryStorageClient};
 export default {v1beta1, BigQueryStorageClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/compute-esm/esm/src/index.ts.baseline
+++ b/baselines/compute-esm/esm/src/index.ts.baseline
@@ -24,5 +24,5 @@ type RegionOperationsClient = v1.RegionOperationsClient;
 export {v1, AddressesClient, RegionOperationsClient};
 export default {v1, AddressesClient, RegionOperationsClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
+++ b/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type DeprecatedServiceClient = v1.DeprecatedServiceClient;
 export {v1, DeprecatedServiceClient};
 export default {v1, DeprecatedServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
@@ -32,5 +32,5 @@ type TestingClient = v1beta1.TestingClient;
 export {v1beta1, ComplianceClient, EchoClient, IdentityClient, MessagingClient, SequenceServiceClient, TestingClient};
 export default {v1beta1, ComplianceClient, EchoClient, IdentityClient, MessagingClient, SequenceServiceClient, TestingClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/dlp-esm/esm/src/index.ts.baseline
+++ b/baselines/dlp-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type DlpServiceClient = v2.DlpServiceClient;
 export {v2, DlpServiceClient};
 export default {v2, DlpServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/kms-esm/esm/src/index.ts.baseline
+++ b/baselines/kms-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type KeyManagementServiceClient = v1.KeyManagementServiceClient;
 export {v1, KeyManagementServiceClient};
 export default {v1, KeyManagementServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/logging-esm/esm/src/index.ts.baseline
+++ b/baselines/logging-esm/esm/src/index.ts.baseline
@@ -26,5 +26,5 @@ type MetricsServiceV2Client = v2.MetricsServiceV2Client;
 export {v2, ConfigServiceV2Client, LoggingServiceV2Client, MetricsServiceV2Client};
 export default {v2, ConfigServiceV2Client, LoggingServiceV2Client, MetricsServiceV2Client};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/monitoring-esm/esm/src/index.ts.baseline
+++ b/baselines/monitoring-esm/esm/src/index.ts.baseline
@@ -32,5 +32,5 @@ type UptimeCheckServiceClient = v3.UptimeCheckServiceClient;
 export {v3, AlertPolicyServiceClient, GroupServiceClient, MetricServiceClient, NotificationChannelServiceClient, ServiceMonitoringServiceClient, UptimeCheckServiceClient};
 export default {v3, AlertPolicyServiceClient, GroupServiceClient, MetricServiceClient, NotificationChannelServiceClient, ServiceMonitoringServiceClient, UptimeCheckServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/naming-esm/esm/src/index.ts.baseline
+++ b/baselines/naming-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type NamingClient = v1beta1.NamingClient;
 export {v1beta1, NamingClient};
 export default {v1beta1, NamingClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/redis-esm/esm/src/index.ts.baseline
+++ b/baselines/redis-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type CloudRedisClient = v1beta1.CloudRedisClient;
 export {v1beta1, CloudRedisClient};
 export default {v1beta1, CloudRedisClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/routingtest-esm/esm/src/index.ts.baseline
+++ b/baselines/routingtest-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type TestServiceClient = v1.TestServiceClient;
 export {v1, TestServiceClient};
 export default {v1, TestServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/showcase-esm/esm/src/index.ts.baseline
+++ b/baselines/showcase-esm/esm/src/index.ts.baseline
@@ -32,5 +32,5 @@ type TestingClient = v1beta1.TestingClient;
 export {v1beta1, ComplianceClient, EchoClient, IdentityClient, MessagingClient, SequenceServiceClient, TestingClient};
 export default {v1beta1, ComplianceClient, EchoClient, IdentityClient, MessagingClient, SequenceServiceClient, TestingClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type EchoClient = v1beta1.EchoClient;
 export {v1beta1, EchoClient};
 export default {v1beta1, EchoClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/tasks-esm/esm/src/index.ts.baseline
+++ b/baselines/tasks-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type CloudTasksClient = v2.CloudTasksClient;
 export {v2, CloudTasksClient};
 export default {v2, CloudTasksClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/texttospeech-esm/esm/src/index.ts.baseline
+++ b/baselines/texttospeech-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type TextToSpeechClient = v1.TextToSpeechClient;
 export {v1, TextToSpeechClient};
 export default {v1, TextToSpeechClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/translate-esm/esm/src/index.ts.baseline
+++ b/baselines/translate-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type TranslationServiceClient = v3beta1.TranslationServiceClient;
 export {v3beta1, TranslationServiceClient};
 export default {v3beta1, TranslationServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/baselines/videointelligence-esm/esm/src/index.ts.baseline
+++ b/baselines/videointelligence-esm/esm/src/index.ts.baseline
@@ -22,5 +22,5 @@ type VideoIntelligenceServiceClient = v1.VideoIntelligenceServiceClient;
 export {v1, VideoIntelligenceServiceClient};
 export default {v1, VideoIntelligenceServiceClient};
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}

--- a/templates/esm/typescript_gapic/esm/src/index.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/index.ts.njk
@@ -33,5 +33,5 @@ export default { {{- api.naming.version }}
 {%- endfor -%}
 };
 // @ts-ignore
-import type * as protos from '../../protos/protos.js';
+import * as protos from '../../protos/protos.js';
 export {protos}


### PR DESCRIPTION
When `import type` is used, it is not possible to use the classes and values in the protos namespace.

Fixes googleapis/google-cloud-node-core#556