### PR TITLE
fix: use new gax streaming retries

### DIFF
--- a/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -192,7 +192,7 @@ export class BigQueryStorageClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      readRows: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest')
+      readRows: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     // Put together the default options sent with requests.

--- a/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -725,7 +725,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.readRows(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.readRows(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse) => {
                     resolve(response);

--- a/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -175,7 +175,7 @@ export class BigQueryStorageClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      readRows: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback)
+      readRows: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     // Put together the default options sent with requests.

--- a/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -716,7 +716,7 @@ describe('v1beta1.BigQueryStorageClient', () => {
             request.readPosition.stream.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.readRows(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.readRows(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.cloud.bigquery.storage.v1beta1.ReadRowsResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -232,9 +232,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos as gax.protobuf.INamespace);

--- a/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -231,9 +231,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos as gax.protobuf.INamespace);

--- a/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -682,7 +682,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1330,7 +1330,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.streamBlurbs(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -215,9 +215,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);

--- a/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -214,9 +214,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
-      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);

--- a/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -673,7 +673,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1321,7 +1321,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.streamBlurbs(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -286,7 +286,7 @@ export class LoggingServiceV2Client {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      tailLogEntries: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      tailLogEntries: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos as gax.protobuf.INamespace);

--- a/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -269,7 +269,7 @@ export class LoggingServiceV2Client {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      tailLogEntries: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      tailLogEntries: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);

--- a/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -235,9 +235,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos as gax.protobuf.INamespace);

--- a/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -234,9 +234,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos as gax.protobuf.INamespace);

--- a/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -682,7 +682,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1330,7 +1330,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.streamBlurbs(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -172,9 +172,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, opts.fallback === 'rest'),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, opts.fallback === 'rest'),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, opts.fallback === 'rest')
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();

--- a/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -661,7 +661,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -157,9 +157,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();

--- a/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -660,7 +660,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -218,9 +218,9 @@ export class EchoClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback),
-      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
-      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      expand: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      collect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      chat: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);

--- a/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -217,9 +217,9 @@ export class MessagingClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this.descriptors.stream = {
-      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback),
-      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback),
-      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback)
+      streamBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.SERVER_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      sendBlurbs: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.CLIENT_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true),
+      connect: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.BIDI_STREAMING, !!opts.fallback, /* gaxStreamingRetries: */ true)
     };
 
     const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);

--- a/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -673,7 +673,7 @@ describe('v1beta1.EchoClient', () => {
             );
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.expand(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.expand(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.EchoResponse) => {
                     resolve(response);

--- a/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1321,7 +1321,7 @@ describe('v1beta1.MessagingClient', () => {
             request.name = defaultValue1;
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.streamBlurbs(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.streamBlurbs(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos.google.showcase.v1beta1.StreamBlurbsResponse) => {
                     resolve(response);

--- a/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -281,7 +281,7 @@ export class {{ service.name }}Client {
 {%- set streamingJoiner = joiner() %}
 {%- for method in service.streaming %}
       {{- streamingJoiner() }}
-      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback)
+      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback, /* gaxStreamingRetries: */ true)
 {%- endfor %}
     };
 {%- endif %}

--- a/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
+++ b/templates/cjs/typescript_gapic/test/gapic_$service_$version.ts.njk
@@ -573,7 +573,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method, skipExpectedVariable='true') }}
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.{{ method.name.toCamelCase() }}(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.{{ method.name.toCamelCase() }}(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
                     resolve(response);

--- a/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -296,7 +296,7 @@ export class {{ service.name }}Client {
 {%- set streamingJoiner = joiner() %}
 {%- for method in service.streaming %}
       {{- streamingJoiner() }}
-      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, opts.fallback === 'rest')
+      {{ method.name.toCamelCase() }}: new this._gaxModule.StreamDescriptor(this._gaxModule.StreamType.{{ method.streaming }}, !!opts.fallback, /* gaxStreamingRetries: */ true)
 {%- endfor %}
     };
 {%- endif %}

--- a/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
+++ b/templates/esm/typescript_gapic/esm/test/gapic_$service_$version.ts.njk
@@ -581,7 +581,7 @@ describe('{{ api.naming.version }}.{{ service.name }}Client', () => {
             {{ util.initRequestWithHeaderParam(method, skipExpectedVariable='true') }}
             const expectedError = new Error('The client has already been closed.');
             client.close();
-            const stream = client.{{ method.name.toCamelCase() }}(request, {retryRequestOptions: {noResponseRetries: 0}});
+            const stream = client.{{ method.name.toCamelCase() }}(request, {retry: {shouldRetryFn: () => { return false; }}});
             const promise = new Promise((resolve, reject) => {
                 stream.on('data', (response: protos{{ method.outputInterface }}) => {
                     resolve(response);


### PR DESCRIPTION
This change enables new [GAX streaming retries](https://github.com/googleapis/gax-nodejs/pull/1496). It's needed to silence deprecation warning in tests, but apparently, the best thing we can do now is to enable new streaming retry code for all libraries (which will anyway happen sooner or later).

This is not going to be a real breaking change for libraries, but it can change behavior in some rare cases (streaming retries is not a widely used feature anyway). I suggest we'll let it in as a semver minor, but we'll need to track users' issues and be ready to fix stuff that got broken.